### PR TITLE
feat: Implement Step-Up Authentication Receipt Module

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,7 @@ Before writing ANY code, review the security standards. NO EXCEPTIONS.
 - **Passwordless**: OTP-based authentication
 - **Rate Limiting**: DDoS protection, configurable throttling
 - **MFA Support**: TOTP, SMS, email verification
+- **Step-Up Authentication**: RFC 9470 receipt-based step-up auth (`blockauth.stepup`). Django-independent.
 
 ## Package Architecture
 
@@ -48,6 +49,9 @@ blockauth/
 │   └── claims.py      # Claims provider base
 ├── middleware/         # Django middleware
 ├── permissions/        # Permission classes
+├── stepup/            # Step-up authentication receipts (RFC 9470)
+│   ├── __init__.py   # Exports: ReceiptIssuer, ReceiptValidator, ReceiptClaims, ReceiptValidationError
+│   └── receipt.py    # Django-independent HS256 JWT receipt issue/validate
 └── tests/             # Comprehensive test suite
 ```
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ _Disclaimer: This package is currently at initiative state so you can expect fre
   - [Example: Custom Logger Class](#example-custom-logger-class)
   - [Django Settings Configuration](#django-settings-configuration)
 - [Rate Limiting](#rate-limiting)
+- [Step-Up Authentication (TOTP Receipt)](#step-up-authentication-totp-receipt)
 - [License](#license)
 - [Acknowledgments](#acknowledgments)
 
@@ -59,6 +60,125 @@ _Disclaimer: This package is currently at initiative state so you can expect fre
 - **📱 Passwordless Authentication** - Email-only blockchain wallet generation
 - **🔄 Password Management Triggers** - Automatic wallet re-encryption
 - **🎯 Custom JWT Claims** - Extensible claims provider system for adding custom data to tokens
+- **🛡️ Step-Up Authentication** - RFC 9470 receipt-based step-up auth for sensitive operations
+
+---
+
+## Step-Up Authentication (TOTP Receipt)
+
+### Overview
+
+The **Step-Up Authentication** module (`blockauth.stepup`) implements the industry-standard step-up authentication pattern (RFC 9470, PSD2/SCA, Auth0 Step-Up, Fireblocks TAP, AWS IAM MFA session tokens).
+
+After a user completes an additional authentication factor (e.g., TOTP verification), the issuing service creates a short-lived signed **receipt** (HS256 JWT). The consuming service validates this receipt before allowing sensitive operations. This moves enforcement from the client (SDK) to the backend.
+
+### Key Properties
+
+- **Short-lived**: 120-second TTL by default (configurable)
+- **Scoped**: `aud` claim prevents cross-service replay, `scope` restricts to operation classes
+- **Anti-IDOR**: `sub` must match the authenticated user
+- **Django-independent**: Pure Python + PyJWT, usable in any service
+- **Generic**: Not tied to TOTP specifically -- works with any step-up factor
+
+### Quick Start
+
+#### Issuing Service (e.g., auth service)
+
+```python
+from blockauth.stepup import ReceiptIssuer
+
+issuer = ReceiptIssuer(
+    secret="your-shared-secret-min-32-chars",
+    issuer="fabric-auth",
+    default_audience="fabric-wallet",
+    default_scope="mpc",
+    default_ttl_seconds=120,
+)
+
+# After user passes TOTP verification:
+receipt_token = issuer.issue(subject=str(user.id))
+# Return receipt_token in the API response
+```
+
+#### Consuming Service (e.g., wallet service)
+
+```python
+from blockauth.stepup import ReceiptValidator, ReceiptValidationError
+
+validator = ReceiptValidator(
+    secret="your-shared-secret-min-32-chars",
+    expected_audience="fabric-wallet",
+    expected_scope="mpc",
+)
+
+try:
+    claims = validator.validate(
+        token=receipt_from_header,
+        expected_subject=authenticated_user_id,  # anti-IDOR check
+    )
+    # claims.subject, claims.scope, claims.jti, etc.
+except ReceiptValidationError as e:
+    # e.reason — human-readable message
+    # e.code — machine-readable code (e.g., "receipt_expired", "receipt_subject_mismatch")
+    return 403, {"error": e.reason}
+```
+
+### Receipt JWT Claims
+
+```json
+{
+  "sub": "user-uuid",
+  "type": "stepup_receipt",
+  "aud": "fabric-wallet",
+  "scope": "mpc",
+  "iat": 1740000000,
+  "exp": 1740000120,
+  "jti": "random-hex-16-bytes",
+  "iss": "fabric-auth"
+}
+```
+
+### Middleware Pattern (Header-Based)
+
+The receipt is typically passed as an HTTP header (`X-TOTP-Receipt`). The consuming service applies middleware to protected endpoints:
+
+- **Header present**: Must be valid or request is rejected (403)
+- **Header absent**: Pass through (users who didn't do TOTP, e.g., passkey/EOA users)
+- **Enforce mode**: Reject ALL requests without a valid receipt (opt-in, for strict environments)
+
+### Validation Checks
+
+| Check | Error Code |
+|---|---|
+| HS256 signature valid | `receipt_signature_invalid` |
+| Not expired (`exp > now`) | `receipt_expired` |
+| `type == "stepup_receipt"` | `receipt_wrong_type` |
+| `aud` matches expected | `receipt_audience_mismatch` |
+| `scope` matches expected | `receipt_scope_mismatch` |
+| `sub` matches authenticated user | `receipt_subject_mismatch` |
+
+### API Reference
+
+#### `ReceiptIssuer(secret, *, issuer, default_audience, default_scope, default_ttl_seconds)`
+
+Create an issuer. `secret` must be >= 32 characters.
+
+- `issue(subject, *, audience=None, scope=None, ttl_seconds=None)` -> `str` (JWT)
+
+#### `ReceiptValidator(secret, *, expected_audience, expected_scope)`
+
+Create a validator.
+
+- `validate(token, *, expected_subject=None)` -> `ReceiptClaims`
+
+#### `ReceiptClaims` (frozen dataclass)
+
+- `subject`, `audience`, `scope`, `issued_at`, `expires_at`, `jti`, `issuer`
+
+#### `ReceiptValidationError`
+
+- `reason` (str) — human-readable
+- `code` (str) — machine-readable
 
 ---
 

--- a/blockauth/__init__.py
+++ b/blockauth/__init__.py
@@ -56,6 +56,12 @@ __all__ = [
     'PasskeyRegistrationResult',
     'PasskeyAuthenticationResult',
     'ChallengeService',
+
+    # Step-Up Authentication (RFC 9470)
+    'ReceiptIssuer',
+    'ReceiptValidator',
+    'ReceiptClaims',
+    'ReceiptValidationError',
 ]
 
 
@@ -104,5 +110,19 @@ def __getattr__(name):
     if name == 'ChallengeService':
         from .passkey.services.challenge_service import ChallengeService
         return ChallengeService
+
+    # Step-Up Authentication components (Django-independent — no lazy loading needed)
+    if name == 'ReceiptIssuer':
+        from .stepup.receipt import ReceiptIssuer
+        return ReceiptIssuer
+    if name == 'ReceiptValidator':
+        from .stepup.receipt import ReceiptValidator
+        return ReceiptValidator
+    if name == 'ReceiptClaims':
+        from .stepup.receipt import ReceiptClaims
+        return ReceiptClaims
+    if name == 'ReceiptValidationError':
+        from .stepup.receipt import ReceiptValidationError
+        return ReceiptValidationError
 
     raise AttributeError(f"module 'blockauth' has no attribute '{name}'")

--- a/blockauth/passkey/views.py
+++ b/blockauth/passkey/views.py
@@ -94,9 +94,26 @@ class PasskeyRegistrationOptionsView(APIView):
             service = get_passkey_service()
             display_name = request.data.get('display_name')
 
+            # Build human-readable username (user.name in WebAuthn spec)
+            # Priority: email > wallet address (truncated) > user ID prefix
+            user = request.user
+            username = (
+                user.email
+                or (f"{user.wallet_address[:10]}..." if getattr(user, 'wallet_address', None) else None)
+                or f"User {str(user.id)[:8]}"
+            )
+
+            # Auto-resolve display_name from profile if client didn't provide one
+            if not display_name:
+                full_name = ' '.join(filter(None, [
+                    getattr(user, 'first_name', None),
+                    getattr(user, 'last_name', None),
+                ]))
+                display_name = full_name or None
+
             options = service.generate_registration_options(
-                user_id=request.user.id,
-                username=request.user.email or request.user.username,
+                user_id=user.id,
+                username=username,
                 display_name=display_name,
             )
 

--- a/blockauth/stepup/__init__.py
+++ b/blockauth/stepup/__init__.py
@@ -1,0 +1,48 @@
+"""
+Step-Up Authentication Receipt Module.
+
+Implements short-lived signed JWT receipts for step-up authentication (RFC 9470).
+After a user completes an additional authentication factor (e.g., TOTP, biometric),
+the issuing service creates a receipt. The consuming service validates the receipt
+before allowing sensitive operations.
+
+Industry references:
+- RFC 9470 (Step-Up Authentication Challenge Protocol)
+- PSD2/SCA (EU Strong Customer Authentication)
+- Auth0 Step-Up Authentication
+- Fireblocks Transaction Authorization Policy (TAP)
+- AWS IAM MFA Session Tokens
+
+Usage (issuer side — e.g., auth service):
+    from blockauth.stepup import ReceiptIssuer
+
+    issuer = ReceiptIssuer(
+        secret="shared-secret-with-consumer",
+        issuer="my-auth-service",
+        default_audience="my-wallet-service",
+        default_scope="mpc",
+    )
+    token = issuer.issue(subject="user-uuid")
+
+Usage (consumer side — e.g., wallet service, any language):
+    # Python:
+    from blockauth.stepup import ReceiptValidator
+
+    validator = ReceiptValidator(
+        secret="shared-secret-with-issuer",
+        expected_audience="my-wallet-service",
+        expected_scope="mpc",
+    )
+    claims = validator.validate(token, expected_subject="user-uuid")
+
+    # Go / other languages: standard HS256 JWT validation with claims check.
+"""
+
+from .receipt import ReceiptIssuer, ReceiptValidator, ReceiptClaims, ReceiptValidationError
+
+__all__ = [
+    "ReceiptIssuer",
+    "ReceiptValidator",
+    "ReceiptClaims",
+    "ReceiptValidationError",
+]

--- a/blockauth/stepup/receipt.py
+++ b/blockauth/stepup/receipt.py
@@ -32,6 +32,9 @@ logger = logging.getLogger(__name__)
 # Receipt type constant — prevents confusion with access/refresh JWTs
 RECEIPT_TYPE = "stepup_receipt"
 
+# JTI entropy: 16 bytes → 32-char hex → 128 bits of uniqueness per receipt
+JTI_BYTES = 16
+
 
 class ReceiptValidationError(Exception):
     """Raised when a step-up receipt fails validation."""
@@ -107,7 +110,7 @@ class ReceiptIssuer:
         """
         now = int(time.time())
         ttl = ttl_seconds if ttl_seconds is not None else self._default_ttl
-        jti = secrets.token_hex(16)
+        jti = secrets.token_hex(JTI_BYTES)
 
         claims = {
             "sub": str(subject),

--- a/blockauth/stepup/receipt.py
+++ b/blockauth/stepup/receipt.py
@@ -146,8 +146,8 @@ class ReceiptValidator:
         expected_audience: str = "fabric-wallet",
         expected_scope: str = "mpc",
     ):
-        if not secret:
-            raise ValueError("Receipt secret is required")
+        if not secret or len(secret) < 32:
+            raise ValueError("Receipt secret must be at least 32 characters")
         self._secret = secret
         self._expected_audience = expected_audience
         self._expected_scope = expected_scope

--- a/blockauth/stepup/receipt.py
+++ b/blockauth/stepup/receipt.py
@@ -1,0 +1,236 @@
+"""
+Step-Up Authentication Receipt — Issue and Validate.
+
+A receipt is a short-lived HS256 JWT that proves a user completed an additional
+authentication factor. The issuing service (e.g., auth) creates the receipt after
+factor verification. The consuming service (e.g., wallet) validates it before
+allowing sensitive operations.
+
+Security properties:
+- HS256 signature binds receipt to shared secret (not forgeable without key)
+- ``type`` claim prevents confusion with session/access JWTs
+- ``aud`` claim prevents cross-service replay
+- ``scope`` claim restricts to specific operation classes
+- ``sub`` must match the authenticated user (anti-IDOR)
+- ``exp`` enforces short TTL (default 120s)
+- ``jti`` provides unique identifier for audit logging
+
+This module depends only on PyJWT (already a blockauth dependency) and the
+Python stdlib. No Django dependency — usable in any Python service.
+"""
+
+import logging
+import secrets
+import time
+from dataclasses import dataclass
+from typing import Optional
+
+import jwt
+
+logger = logging.getLogger(__name__)
+
+# Receipt type constant — prevents confusion with access/refresh JWTs
+RECEIPT_TYPE = "stepup_receipt"
+
+
+class ReceiptValidationError(Exception):
+    """Raised when a step-up receipt fails validation."""
+
+    def __init__(self, reason: str, *, code: str = "invalid_receipt"):
+        self.reason = reason
+        self.code = code
+        super().__init__(reason)
+
+
+@dataclass(frozen=True)
+class ReceiptClaims:
+    """Decoded and validated receipt claims."""
+
+    subject: str       # sub — user/consumer ID
+    audience: str      # aud — intended consuming service
+    scope: str         # scope — operation class (e.g., "mpc")
+    issued_at: int     # iat — Unix timestamp
+    expires_at: int    # exp — Unix timestamp
+    jti: str           # jti — unique receipt ID
+    issuer: Optional[str] = None  # iss — issuing service (optional)
+
+
+class ReceiptIssuer:
+    """
+    Issues short-lived signed receipts after step-up authentication.
+
+    Args:
+        secret: HS256 signing key (shared with consuming service).
+                Must be >= 32 bytes. Use ``secrets.token_hex(32)`` to generate.
+        issuer: Optional ``iss`` claim (e.g., "fabric-auth").
+        default_audience: Default ``aud`` claim (e.g., "fabric-wallet").
+        default_scope: Default ``scope`` claim (e.g., "mpc").
+        default_ttl_seconds: Default receipt lifetime. 120s recommended.
+    """
+
+    def __init__(
+        self,
+        secret: str,
+        *,
+        issuer: Optional[str] = None,
+        default_audience: str = "fabric-wallet",
+        default_scope: str = "mpc",
+        default_ttl_seconds: int = 120,
+    ):
+        if not secret or len(secret) < 32:
+            raise ValueError("Receipt secret must be at least 32 characters")
+        self._secret = secret
+        self._issuer = issuer
+        self._default_audience = default_audience
+        self._default_scope = default_scope
+        self._default_ttl = default_ttl_seconds
+
+    def issue(
+        self,
+        subject: str,
+        *,
+        audience: Optional[str] = None,
+        scope: Optional[str] = None,
+        ttl_seconds: Optional[int] = None,
+    ) -> str:
+        """
+        Issue a step-up receipt for the given subject.
+
+        Args:
+            subject: User or consumer ID (stored as ``sub``).
+            audience: Override default audience.
+            scope: Override default scope.
+            ttl_seconds: Override default TTL.
+
+        Returns:
+            Signed JWT string.
+        """
+        now = int(time.time())
+        ttl = ttl_seconds if ttl_seconds is not None else self._default_ttl
+        jti = secrets.token_hex(16)
+
+        claims = {
+            "sub": str(subject),
+            "type": RECEIPT_TYPE,
+            "aud": audience or self._default_audience,
+            "scope": scope or self._default_scope,
+            "iat": now,
+            "exp": now + ttl,
+            "jti": jti,
+        }
+        if self._issuer:
+            claims["iss"] = self._issuer
+
+        token = jwt.encode(claims, self._secret, algorithm="HS256")
+        logger.info(
+            "Step-up receipt issued",
+            extra={"sub": subject, "aud": claims["aud"], "scope": claims["scope"], "jti": jti},
+        )
+        return token
+
+
+class ReceiptValidator:
+    """
+    Validates step-up receipts on the consuming service side.
+
+    Args:
+        secret: HS256 signing key (shared with issuing service).
+        expected_audience: Required ``aud`` value (e.g., "fabric-wallet").
+        expected_scope: Required ``scope`` value (e.g., "mpc").
+    """
+
+    def __init__(
+        self,
+        secret: str,
+        *,
+        expected_audience: str = "fabric-wallet",
+        expected_scope: str = "mpc",
+    ):
+        if not secret:
+            raise ValueError("Receipt secret is required")
+        self._secret = secret
+        self._expected_audience = expected_audience
+        self._expected_scope = expected_scope
+
+    def validate(
+        self,
+        token: str,
+        *,
+        expected_subject: Optional[str] = None,
+    ) -> ReceiptClaims:
+        """
+        Validate a step-up receipt token.
+
+        Args:
+            token: The JWT string from the ``X-TOTP-Receipt`` header.
+            expected_subject: If provided, ``sub`` must match (anti-IDOR).
+
+        Returns:
+            ReceiptClaims on success.
+
+        Raises:
+            ReceiptValidationError on any validation failure.
+        """
+        # Decode and verify signature + expiry
+        try:
+            payload = jwt.decode(
+                token,
+                self._secret,
+                algorithms=["HS256"],
+                audience=self._expected_audience,
+            )
+        except jwt.ExpiredSignatureError:
+            raise ReceiptValidationError("Receipt has expired", code="receipt_expired")
+        except jwt.InvalidAudienceError:
+            raise ReceiptValidationError(
+                f"Receipt audience mismatch (expected {self._expected_audience})",
+                code="receipt_audience_mismatch",
+            )
+        except jwt.InvalidSignatureError:
+            raise ReceiptValidationError("Receipt signature invalid", code="receipt_signature_invalid")
+        except jwt.DecodeError:
+            raise ReceiptValidationError("Receipt is malformed", code="receipt_malformed")
+        except jwt.InvalidTokenError as e:
+            raise ReceiptValidationError(f"Receipt invalid: {e}", code="receipt_invalid")
+
+        # Validate type claim
+        receipt_type = payload.get("type")
+        if receipt_type != RECEIPT_TYPE:
+            raise ReceiptValidationError(
+                f"Wrong receipt type: {receipt_type}",
+                code="receipt_wrong_type",
+            )
+
+        # Validate scope claim
+        receipt_scope = payload.get("scope")
+        if receipt_scope != self._expected_scope:
+            raise ReceiptValidationError(
+                f"Receipt scope mismatch (expected {self._expected_scope}, got {receipt_scope})",
+                code="receipt_scope_mismatch",
+            )
+
+        # Validate subject (anti-IDOR)
+        receipt_sub = payload.get("sub")
+        if not receipt_sub:
+            raise ReceiptValidationError("Receipt missing subject", code="receipt_no_subject")
+        if expected_subject and receipt_sub != str(expected_subject):
+            raise ReceiptValidationError(
+                "Receipt subject mismatch",
+                code="receipt_subject_mismatch",
+            )
+
+        claims = ReceiptClaims(
+            subject=receipt_sub,
+            audience=payload.get("aud", ""),
+            scope=receipt_scope,
+            issued_at=payload.get("iat", 0),
+            expires_at=payload.get("exp", 0),
+            jti=payload.get("jti", ""),
+            issuer=payload.get("iss"),
+        )
+
+        logger.info(
+            "Step-up receipt validated",
+            extra={"sub": claims.subject, "jti": claims.jti, "scope": claims.scope},
+        )
+        return claims

--- a/blockauth/stepup/receipt.py
+++ b/blockauth/stepup/receipt.py
@@ -180,44 +180,47 @@ class ReceiptValidator:
                 audience=self._expected_audience,
             )
         except jwt.ExpiredSignatureError:
-            raise ReceiptValidationError("Receipt has expired", code="receipt_expired")
+            logger.debug("Receipt expired", extra={"aud": self._expected_audience})
+            raise ReceiptValidationError("Receipt validation failed", code="receipt_expired")
         except jwt.InvalidAudienceError:
-            raise ReceiptValidationError(
-                f"Receipt audience mismatch (expected {self._expected_audience})",
-                code="receipt_audience_mismatch",
+            logger.warning(
+                "Receipt audience mismatch",
+                extra={"expected_aud": self._expected_audience},
             )
+            raise ReceiptValidationError("Receipt validation failed", code="receipt_audience_mismatch")
         except jwt.InvalidSignatureError:
-            raise ReceiptValidationError("Receipt signature invalid", code="receipt_signature_invalid")
+            logger.warning("Receipt signature invalid")
+            raise ReceiptValidationError("Receipt validation failed", code="receipt_signature_invalid")
         except jwt.DecodeError:
-            raise ReceiptValidationError("Receipt is malformed", code="receipt_malformed")
-        except jwt.InvalidTokenError as e:
-            raise ReceiptValidationError(f"Receipt invalid: {e}", code="receipt_invalid")
+            logger.warning("Receipt malformed — could not decode JWT")
+            raise ReceiptValidationError("Receipt validation failed", code="receipt_malformed")
+        except jwt.InvalidTokenError:
+            logger.warning("Receipt invalid — generic JWT error")
+            raise ReceiptValidationError("Receipt validation failed", code="receipt_invalid")
 
         # Validate type claim
         receipt_type = payload.get("type")
         if receipt_type != RECEIPT_TYPE:
-            raise ReceiptValidationError(
-                f"Wrong receipt type: {receipt_type}",
-                code="receipt_wrong_type",
-            )
+            logger.warning("Wrong receipt type", extra={"got": receipt_type, "expected": RECEIPT_TYPE})
+            raise ReceiptValidationError("Receipt validation failed", code="receipt_wrong_type")
 
         # Validate scope claim
         receipt_scope = payload.get("scope")
         if receipt_scope != self._expected_scope:
-            raise ReceiptValidationError(
-                f"Receipt scope mismatch (expected {self._expected_scope}, got {receipt_scope})",
-                code="receipt_scope_mismatch",
+            logger.warning(
+                "Receipt scope mismatch",
+                extra={"expected": self._expected_scope, "got": receipt_scope},
             )
+            raise ReceiptValidationError("Receipt validation failed", code="receipt_scope_mismatch")
 
         # Validate subject (anti-IDOR)
         receipt_sub = payload.get("sub")
         if not receipt_sub:
-            raise ReceiptValidationError("Receipt missing subject", code="receipt_no_subject")
+            logger.warning("Receipt missing subject claim")
+            raise ReceiptValidationError("Receipt validation failed", code="receipt_no_subject")
         if expected_subject and receipt_sub != str(expected_subject):
-            raise ReceiptValidationError(
-                "Receipt subject mismatch",
-                code="receipt_subject_mismatch",
-            )
+            logger.warning("Receipt subject mismatch (possible IDOR attempt)")
+            raise ReceiptValidationError("Receipt validation failed", code="receipt_subject_mismatch")
 
         claims = ReceiptClaims(
             subject=receipt_sub,


### PR DESCRIPTION
- Added a new module for Step-Up Authentication, including ReceiptIssuer and ReceiptValidator classes for issuing and validating JWT receipts.
- Enhanced PasskeyRegistrationOptionsView to build a human-readable username and auto-resolve display names.
- Updated the blockauth module to include new receipt-related components in the __init__.py file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Step-Up Authentication receipts: issue and validate short-lived JWT receipts for enhanced step-up flows with configurable TTL and scope.
  * Passkey registration: improved username resolution (email → truncated wallet → fallback ID) for deterministic WebAuthn options.
  * Passkey registration: automatic display name inference from user profile when not provided.

* **Documentation**
  * Added guidance and examples for the Step-Up Authentication receipt workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->