### PR TITLE
feat: add RS256/ES256 asymmetric JWT support alongside HS256

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,7 +341,9 @@ BLOCK_AUTH_SETTINGS = {
     "JWT_SECRET_KEY": "your-jwt-secret-key-here",  # For HS256: shared secret (optional, falls back to Django SECRET_KEY)
     # "JWT_PRIVATE_KEY": "-----BEGIN RSA PRIVATE KEY-----\n...",  # For RS256/ES256: PEM private key (signing)
     # "JWT_PUBLIC_KEY": "-----BEGIN PUBLIC KEY-----\n...",        # For RS256/ES256: PEM public key (verification)
-    
+    # NOTE: For RS256/ES256, never expose private keys in logs, version control, or client-side code.
+    # Use environment variables or a secrets manager (1Password, AWS Secrets Manager) in production.
+
     "OTP_VALIDITY": timedelta(minutes=3),
     "OTP_LENGTH": 6,
     "REQUEST_LIMIT": (3, 30),  # (number of request, duration in second) rate limits based on per (identifier, subject, and IP address)

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ _Disclaimer: This package is currently at initiative state so you can expect fre
 
 ## Features
 
-- JWT Authentication
+- JWT Authentication (HS256, RS256, ES256 — symmetric and asymmetric)
 - Token refresh functionality
 - SignUp with email and password
 - Login with email and password (Basic Auth)
@@ -332,13 +332,15 @@ own class and add the class path in the settings. Details disccussed in the [Uti
 BLOCK_AUTH_SETTINGS = {
     "BLOCK_AUTH_USER_MODEL": "{{app_name.model_class_name}}",  # replace it with your custom user model class name for Blockauth users
     "CLIENT_APP_URL": "http://localhost:3000", # this is the URL of the client app which will communicate with the backend API
-    
+
     "ACCESS_TOKEN_LIFETIME": timedelta(seconds=3600),
     "REFRESH_TOKEN_LIFETIME": timedelta(days=1),
-    "ALGORITHM": "HS256",
+    "ALGORITHM": "HS256",           # Supports: HS256, HS384, HS512, RS256, RS384, RS512, ES256, ES384, ES512
     "AUTH_HEADER_NAME": "HTTP_AUTHORIZATION",
     "USER_ID_FIELD": "id",   # Field name in the user model which will be used as user id in the JWT token
-    "JWT_SECRET_KEY": "your-jwt-secret-key-here",  # Separate secret key for JWT tokens (optional, falls back to Django SECRET_KEY)
+    "JWT_SECRET_KEY": "your-jwt-secret-key-here",  # For HS256: shared secret (optional, falls back to Django SECRET_KEY)
+    # "JWT_PRIVATE_KEY": "-----BEGIN RSA PRIVATE KEY-----\n...",  # For RS256/ES256: PEM private key (signing)
+    # "JWT_PUBLIC_KEY": "-----BEGIN PUBLIC KEY-----\n...",        # For RS256/ES256: PEM public key (verification)
     
     "OTP_VALIDITY": timedelta(minutes=3),
     "OTP_LENGTH": 6,

--- a/blockauth/conf.py
+++ b/blockauth/conf.py
@@ -14,6 +14,9 @@ DEFAULTS = {
     "AUTH_HEADER_NAME": "HTTP_AUTHORIZATION",
     "USER_ID_FIELD": "id",
     "SECRET_KEY": settings.SECRET_KEY,
+    # Asymmetric JWT (RS256/ES256): set these instead of JWT_SECRET_KEY
+    "JWT_PRIVATE_KEY": None,  # PEM-encoded private key for signing
+    "JWT_PUBLIC_KEY": None,   # PEM-encoded public key for verification
 
     "OTP_VALIDITY": timedelta(minutes=1),
     "OTP_LENGTH": 6,

--- a/blockauth/jwt/token_manager.py
+++ b/blockauth/jwt/token_manager.py
@@ -20,17 +20,19 @@ logger = logging.getLogger(__name__)
 
 
 class JWTTokenManager:
-    """Enhanced JWT manager with custom claims support"""
+    """Enhanced JWT manager with custom claims support.
+
+    Supports both symmetric (HS256) and asymmetric (RS256/ES256) algorithms.
+    Key resolution is automatic based on the configured ALGORITHM.
+    """
 
     def __init__(self):
-        # Use JWT_SECRET_KEY if provided, otherwise fall back to SECRET_KEY
-        try:
-            self.secret_key = get_config('JWT_SECRET_KEY')
-        except AttributeError:
-            # Fall back to SECRET_KEY if JWT_SECRET_KEY is not configured
-            self.secret_key = get_config('SECRET_KEY')
-        
+        from blockauth.utils.token import _resolve_keys
+
         self.algorithm = get_config('ALGORITHM')
+        self.signing_key, self.verification_key = _resolve_keys(self.algorithm)
+        # Backward compatibility
+        self.secret_key = self.signing_key
         self.expiry_hours = get_config('ACCESS_TOKEN_LIFETIME')
         self._claims_providers: List[CustomClaimsProvider] = []
 
@@ -103,14 +105,14 @@ class JWTTokenManager:
         logger.info(f"✅ Final claims for token: {list(all_claims.keys())}")
 
         # Generate token
-        token = jwt.encode(all_claims, self.secret_key, algorithm=self.algorithm)
+        token = jwt.encode(all_claims, self.signing_key, algorithm=self.algorithm)
         logger.info(f"✅ Generated JWT token with {len(all_claims)} claims")
         return token
 
     def decode_token(self, token: str) -> Dict[str, Any]:
         """Decode and validate JWT token"""
         try:
-            claims = jwt.decode(token, self.secret_key, algorithms=[self.algorithm])
+            claims = jwt.decode(token, self.verification_key, algorithms=[self.algorithm])
 
             # Validate custom claims with providers
             for provider in self._claims_providers:

--- a/blockauth/utils/tests/test_token_algorithms.py
+++ b/blockauth/utils/tests/test_token_algorithms.py
@@ -1,0 +1,209 @@
+"""
+Tests for JWT token algorithm support (HS256 + RS256/ES256).
+
+Validates:
+- HS256 backward compatibility (no config change needed)
+- RS256 sign with private key, verify with public key
+- RS256 missing keys raises clear error
+- Cross-algorithm rejection (HS256 token can't be verified with RS256)
+- Token payload integrity across algorithms
+"""
+
+import os
+from datetime import timedelta
+from unittest.mock import patch
+
+import jwt
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+from blockauth.utils.token import Token, _resolve_keys, _ASYMMETRIC_ALGORITHMS
+
+TEST_HS256_SECRET = os.environ.get("TEST_JWT_SECRET", "test-hs256-secret-key-for-unit-tests")
+
+
+def _generate_rsa_keypair():
+    """Generate a fresh RSA key pair for testing."""
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    private_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode()
+    public_pem = private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode()
+    return private_pem, public_pem
+
+
+class TestResolveKeys:
+    """Test _resolve_keys helper."""
+
+    def test_explicit_secret_key_overrides_everything(self):
+        signing, verification = _resolve_keys("RS256", explicit_secret_key="override")
+        assert signing == "override"
+        assert verification == "override"
+
+    @patch("blockauth.utils.token.get_config")
+    def test_hs256_uses_jwt_secret_key(self, mock_config):
+        mock_config.return_value = TEST_HS256_SECRET
+        signing, verification = _resolve_keys("HS256")
+        assert signing == TEST_HS256_SECRET
+        assert verification == TEST_HS256_SECRET
+
+    @patch("blockauth.utils.token.get_config")
+    def test_rs256_uses_private_and_public_keys(self, mock_config):
+        private_pem, public_pem = _generate_rsa_keypair()
+
+        def side_effect(key):
+            return {"JWT_PRIVATE_KEY": private_pem, "JWT_PUBLIC_KEY": public_pem}[key]
+
+        mock_config.side_effect = side_effect
+        signing, verification = _resolve_keys("RS256")
+        assert signing == private_pem
+        assert verification == public_pem
+
+    @patch("blockauth.utils.token.get_config")
+    def test_rs256_missing_keys_raises_error(self, mock_config):
+        mock_config.return_value = None
+        with pytest.raises(ValueError, match="requires JWT_PRIVATE_KEY and JWT_PUBLIC_KEY"):
+            _resolve_keys("RS256")
+
+    def test_asymmetric_algorithms_set(self):
+        assert "RS256" in _ASYMMETRIC_ALGORITHMS
+        assert "ES256" in _ASYMMETRIC_ALGORITHMS
+        assert "HS256" not in _ASYMMETRIC_ALGORITHMS
+
+
+class TestTokenHS256:
+    """Test Token with HS256 (backward compatibility)."""
+
+    def test_generate_and_decode(self):
+        token = Token(secret_key=TEST_HS256_SECRET, algorithm="HS256")
+        encoded = token.generate_token(
+            user_id="user-123",
+            token_type="access",
+            token_lifetime=timedelta(minutes=15),
+        )
+        payload = token.decode_token(encoded)
+        assert payload["user_id"] == "user-123"
+        assert payload["type"] == "access"
+
+    def test_signing_key_equals_verification_key(self):
+        token = Token(secret_key=TEST_HS256_SECRET, algorithm="HS256")
+        assert token.signing_key == token.verification_key
+
+    def test_backward_compat_secret_key_attribute(self):
+        token = Token(secret_key=TEST_HS256_SECRET, algorithm="HS256")
+        assert token.secret_key == TEST_HS256_SECRET
+
+    def test_user_data_in_payload(self):
+        token = Token(secret_key=TEST_HS256_SECRET, algorithm="HS256")
+        encoded = token.generate_token(
+            user_id="user-456",
+            token_type="access",
+            token_lifetime=timedelta(minutes=15),
+            user_data={"role": "admin", "tier": "pro"},
+        )
+        payload = token.decode_token(encoded)
+        assert payload["role"] == "admin"
+        assert payload["tier"] == "pro"
+
+
+class TestTokenRS256:
+    """Test Token with RS256 (asymmetric)."""
+
+    @pytest.fixture
+    def rsa_keys(self):
+        return _generate_rsa_keypair()
+
+    @patch("blockauth.utils.token.get_config")
+    def test_generate_and_decode(self, mock_config, rsa_keys):
+        private_pem, public_pem = rsa_keys
+
+        def side_effect(key):
+            return {
+                "ALGORITHM": "RS256",
+                "JWT_PRIVATE_KEY": private_pem,
+                "JWT_PUBLIC_KEY": public_pem,
+            }.get(key)
+
+        mock_config.side_effect = side_effect
+        token = Token(algorithm="RS256")
+
+        encoded = token.generate_token(
+            user_id="user-rs256",
+            token_type="access",
+            token_lifetime=timedelta(minutes=15),
+        )
+        payload = token.decode_token(encoded)
+        assert payload["user_id"] == "user-rs256"
+        assert payload["type"] == "access"
+
+    @patch("blockauth.utils.token.get_config")
+    def test_signing_key_differs_from_verification_key(self, mock_config, rsa_keys):
+        private_pem, public_pem = rsa_keys
+
+        def side_effect(key):
+            return {
+                "ALGORITHM": "RS256",
+                "JWT_PRIVATE_KEY": private_pem,
+                "JWT_PUBLIC_KEY": public_pem,
+            }.get(key)
+
+        mock_config.side_effect = side_effect
+        token = Token(algorithm="RS256")
+        assert token.signing_key != token.verification_key
+
+    def test_hs256_token_rejected_by_rs256(self, rsa_keys):
+        private_pem, public_pem = rsa_keys
+
+        # Sign with HS256
+        hs_token = Token(secret_key=TEST_HS256_SECRET, algorithm="HS256")
+        encoded = hs_token.generate_token(
+            user_id="user-cross",
+            token_type="access",
+            token_lifetime=timedelta(minutes=15),
+        )
+
+        # Try to decode with RS256 public key — should fail
+        with pytest.raises(Exception):
+            jwt.decode(encoded, public_pem, algorithms=["RS256"])
+
+    @patch("blockauth.utils.token.get_config")
+    def test_public_key_cannot_sign(self, mock_config, rsa_keys):
+        _, public_pem = rsa_keys
+
+        # Try to sign with public key — PyJWT should reject
+        with pytest.raises(Exception):
+            jwt.encode(
+                {"user_id": "attacker", "type": "access"},
+                public_pem,
+                algorithm="RS256",
+            )
+
+    @patch("blockauth.utils.token.get_config")
+    def test_user_data_preserved(self, mock_config, rsa_keys):
+        private_pem, public_pem = rsa_keys
+
+        def side_effect(key):
+            return {
+                "ALGORITHM": "RS256",
+                "JWT_PRIVATE_KEY": private_pem,
+                "JWT_PUBLIC_KEY": public_pem,
+            }.get(key)
+
+        mock_config.side_effect = side_effect
+        token = Token(algorithm="RS256")
+
+        encoded = token.generate_token(
+            user_id="user-data",
+            token_type="access",
+            token_lifetime=timedelta(minutes=15),
+            user_data={"email": "test@example.com", "tier": "enterprise"},
+        )
+        payload = token.decode_token(encoded)
+        assert payload["email"] == "test@example.com"
+        assert payload["tier"] == "enterprise"

--- a/blockauth/utils/tests/test_token_algorithms.py
+++ b/blockauth/utils/tests/test_token_algorithms.py
@@ -68,7 +68,7 @@ class TestResolveKeys:
     @patch("blockauth.utils.token.get_config")
     def test_rs256_missing_keys_raises_error(self, mock_config):
         mock_config.return_value = None
-        with pytest.raises(ValueError, match="requires JWT_PRIVATE_KEY and JWT_PUBLIC_KEY"):
+        with pytest.raises(ValueError, match="requires both JWT_PRIVATE_KEY and JWT_PUBLIC_KEY"):
             _resolve_keys("RS256")
 
     def test_asymmetric_algorithms_set(self):

--- a/blockauth/utils/token.py
+++ b/blockauth/utils/token.py
@@ -11,22 +11,24 @@ Key Features:
 - Token validation with proper error handling
 - Support for both access and refresh tokens
 - Configurable token lifetimes
+- Supports both symmetric (HS256) and asymmetric (RS256/ES256) algorithms
 
 Configuration:
-- JWT_SECRET_KEY: Secret key for token signing (optional, falls back to Django SECRET_KEY)
-- ALGORITHM: JWT signing algorithm (defaults to 'HS256')
+- ALGORITHM: JWT signing algorithm ('HS256', 'RS256', 'ES256', etc.)
+- Symmetric (HS256): set JWT_SECRET_KEY (or falls back to SECRET_KEY)
+- Asymmetric (RS256/ES256): set JWT_PRIVATE_KEY (signing) and JWT_PUBLIC_KEY (verification)
 - ACCESS_TOKEN_LIFETIME: Lifetime for access tokens (defaults to 1 hour)
 - REFRESH_TOKEN_LIFETIME: Lifetime for refresh tokens (defaults to 1 day)
 
 Usage:
     from blockauth.utils.token import generate_auth_token, AUTH_TOKEN_CLASS
-    
+
     # Generate tokens for a user
     access_token, refresh_token = generate_auth_token(
-        token_class=AUTH_TOKEN_CLASS(), 
+        token_class=AUTH_TOKEN_CLASS(),
         user_id=str(user.id)
     )
-    
+
     # Decode a token
     token_instance = AUTH_TOKEN_CLASS()
     payload = token_instance.decode_token(token_string)
@@ -43,6 +45,41 @@ from rest_framework.exceptions import AuthenticationFailed
 from blockauth.utils.config import get_config
 
 logger = logging.getLogger(__name__)
+
+# Algorithms that use asymmetric keys (private key for signing, public key for verification)
+_ASYMMETRIC_ALGORITHMS = {"RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "PS256", "PS384", "PS512"}
+
+
+def _resolve_keys(algorithm: str, explicit_secret_key=None):
+    """
+    Resolve signing and verification keys based on algorithm type.
+
+    Symmetric (HS256): signing_key = verification_key = JWT_SECRET_KEY
+    Asymmetric (RS256/ES256): signing_key = JWT_PRIVATE_KEY, verification_key = JWT_PUBLIC_KEY
+
+    Returns:
+        tuple: (signing_key, verification_key)
+    """
+    if explicit_secret_key:
+        return explicit_secret_key, explicit_secret_key
+
+    if algorithm in _ASYMMETRIC_ALGORITHMS:
+        private_key = get_config("JWT_PRIVATE_KEY")
+        public_key = get_config("JWT_PUBLIC_KEY")
+        if not private_key or not public_key:
+            raise ValueError(
+                f"Algorithm {algorithm} requires JWT_PRIVATE_KEY and JWT_PUBLIC_KEY "
+                f"in BLOCK_AUTH_SETTINGS. Got private_key={'set' if private_key else 'None'}, "
+                f"public_key={'set' if public_key else 'None'}."
+            )
+        return private_key, public_key
+
+    # Symmetric algorithm — same key for both
+    try:
+        secret = get_config("JWT_SECRET_KEY")
+    except AttributeError:
+        secret = get_config("SECRET_KEY")
+    return secret, secret
 
 
 class AbstractToken:
@@ -93,126 +130,91 @@ class AbstractToken:
 class Token(AbstractToken):
     """
     JWT Token implementation for authentication.
-    
-    This class provides JWT token generation and validation functionality using
-    the PyJWT library. It supports configurable secret keys and algorithms,
-    and includes proper error handling for various token validation scenarios.
-    
+
+    Supports both symmetric (HS256) and asymmetric (RS256/ES256) algorithms.
+    Key resolution is automatic based on the configured algorithm:
+    - HS256: uses JWT_SECRET_KEY for both signing and verification
+    - RS256/ES256: uses JWT_PRIVATE_KEY for signing, JWT_PUBLIC_KEY for verification
+
     Attributes:
-        secret_key (str): The secret key used for token signing
-        algorithm (str): The JWT algorithm used for signing (e.g., 'HS256')
-    
-    Configuration:
-        JWT_SECRET_KEY: Secret key for token signing (from Django settings)
-        ALGORITHM: JWT signing algorithm (defaults to 'HS256')
+        signing_key: Key used for token signing
+        verification_key: Key used for token verification
+        algorithm (str): The JWT algorithm (e.g., 'HS256', 'RS256')
+
+    Backward compatible: existing HS256 configurations work without changes.
     """
-    
+
     def __init__(self, secret_key: str = None, algorithm: str = None):
         """
-        Initialize the Token instance with secret key and algorithm.
-        
+        Initialize the Token instance.
+
         Args:
-            secret_key (str, optional): Secret key for token signing. 
-                Defaults to JWT_SECRET_KEY from configuration, falls back to SECRET_KEY.
-            algorithm (str, optional): JWT signing algorithm. 
+            secret_key (str, optional): Explicit key for both signing and verification
+                (symmetric override). If provided, used directly regardless of algorithm.
+            algorithm (str, optional): JWT signing algorithm.
                 Defaults to ALGORITHM from configuration.
         """
-        # Use JWT_SECRET_KEY if provided, otherwise fall back to SECRET_KEY
-        if secret_key:
-            self.secret_key = secret_key
-        else:
-            try:
-                self.secret_key = get_config('JWT_SECRET_KEY')
-            except AttributeError:
-                # Fall back to SECRET_KEY if JWT_SECRET_KEY is not configured
-                self.secret_key = get_config('SECRET_KEY')
-        self.algorithm = algorithm or get_config('ALGORITHM')
+        self.algorithm = algorithm or get_config("ALGORITHM")
+        self.signing_key, self.verification_key = _resolve_keys(
+            self.algorithm, explicit_secret_key=secret_key
+        )
+        # Backward compatibility — existing code may read self.secret_key
+        self.secret_key = self.signing_key
 
     def generate_token(self, user_id: str, token_type: str, token_lifetime: timedelta, user_data: Dict[str, Any] = None) -> str:
         """
-        Generate a new JWT token with the specified parameters.
-        
-        Creates a JWT token containing user information, expiration time,
-        issued time, and token type. The token is signed using the configured
-        secret key and algorithm.
-        
+        Generate a new JWT token.
+
         Args:
-            user_id (str): The unique identifier of the user (typically user.id)
+            user_id (str): The unique identifier of the user
             token_type (str): Type of token ('access' or 'refresh')
             token_lifetime (timedelta): How long the token should be valid
             user_data (Dict[str, Any], optional): Additional user data to include in token
-            
+
         Returns:
             str: The generated JWT token string
-            
-        Example:
-            token = Token()
-            access_token = token.generate_token(
-                user_id="user123",
-                token_type="access",
-                token_lifetime=timedelta(hours=1)
-            )
         """
-        # Create the token payload with standard JWT claims
         payload = {
-            "user_id": user_id,                    # Custom claim: user identifier
-            "exp": timezone.now() + token_lifetime, # Standard claim: expiration time
-            "iat": timezone.now(),                 # Standard claim: issued at time
-            "type": token_type                     # Custom claim: token type
+            "user_id": user_id,
+            "exp": timezone.now() + token_lifetime,
+            "iat": timezone.now(),
+            "type": token_type,
         }
-        
-        # Add additional user data if provided
         if user_data:
             payload.update(user_data)
-        
-        # Encode the payload into a JWT token
-        return jwt.encode(payload, self.secret_key, algorithm=self.algorithm)
+
+        return jwt.encode(payload, self.signing_key, algorithm=self.algorithm)
 
     def decode_token(self, token: str) -> Dict[str, Any]:
         """
         Decode and validate a JWT token.
-        
-        Decodes the JWT token and validates its signature, expiration, and format.
-        Handles various error conditions with appropriate logging and exceptions.
-        
+
+        Uses the verification key (public key for RS256, shared secret for HS256).
+
         Args:
             token (str): The JWT token string to decode
-            
+
         Returns:
-            Dict[str, Any]: The decoded token payload containing user_id, exp, iat, type, and any additional user data
-            
+            Dict[str, Any]: The decoded token payload
+
         Raises:
             AuthenticationFailed: If the token is invalid, expired, or has an invalid signature
-            
-        Example:
-            token = Token()
-            try:
-                payload = token.decode_token("eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9...")
-                user_id = payload['user_id']
-                token_type = payload['type']
-            except AuthenticationFailed as e:
-                # Handle authentication error
-                pass
         """
         try:
-            # Decode and verify the token signature
-            payload = jwt.decode(token, self.secret_key, algorithms=[self.algorithm])
+            payload = jwt.decode(token, self.verification_key, algorithms=[self.algorithm])
             return payload
-            
+
         except jwt.ExpiredSignatureError:
-            # Token has passed its expiration time
             logger.error("Token has expired.")
             raise AuthenticationFailed("Token has expired.")
-            
-        except jwt.InvalidTokenError:
-            # Token is malformed or invalid
-            logger.error("Invalid token.")
-            raise AuthenticationFailed("Invalid token.")
-            
+
         except jwt.InvalidSignatureError:
-            # Token signature verification failed
             logger.error("Invalid signature.")
             raise AuthenticationFailed("Invalid signature.")
+
+        except jwt.InvalidTokenError:
+            logger.error("Invalid token.")
+            raise AuthenticationFailed("Invalid token.")
 
 
 def generate_auth_token(token_class: AbstractToken, user_id: str, user_data: Dict[str, Any] = None) -> Tuple[str, str]:

--- a/blockauth/utils/token.py
+++ b/blockauth/utils/token.py
@@ -68,9 +68,8 @@ def _resolve_keys(algorithm: str, explicit_secret_key=None):
         public_key = get_config("JWT_PUBLIC_KEY")
         if not private_key or not public_key:
             raise ValueError(
-                f"Algorithm {algorithm} requires JWT_PRIVATE_KEY and JWT_PUBLIC_KEY "
-                f"in BLOCK_AUTH_SETTINGS. Got private_key={'set' if private_key else 'None'}, "
-                f"public_key={'set' if public_key else 'None'}."
+                f"Algorithm {algorithm} requires both JWT_PRIVATE_KEY and JWT_PUBLIC_KEY "
+                f"in BLOCK_AUTH_SETTINGS."
             )
         return private_key, public_key
 


### PR DESCRIPTION
## Summary
Add asymmetric JWT algorithm support (RS256/ES256) alongside existing HS256. The deployer picks the algorithm via config — the library handles key routing automatically.

## How it works

| Algorithm | Signing key | Verification key | Config needed |
|-----------|------------|-----------------|---------------|
| HS256 (default) | `JWT_SECRET_KEY` | `JWT_SECRET_KEY` | No change (backward compatible) |
| RS256/ES256 | `JWT_PRIVATE_KEY` | `JWT_PUBLIC_KEY` | Add both PEM keys to `BLOCK_AUTH_SETTINGS` |

## Changes

| File | What |
|------|------|
| `blockauth/conf.py` | Added `JWT_PRIVATE_KEY` and `JWT_PUBLIC_KEY` defaults (None) |
| `blockauth/utils/token.py` | Added `_resolve_keys()` helper. `Token` uses `signing_key`/`verification_key` instead of single `secret_key` |
| `blockauth/jwt/token_manager.py` | `JWTTokenManager` uses same signing/verification key pattern |
| `blockauth/utils/tests/test_token_algorithms.py` | 13 unit tests covering both algorithms |
| `README.md` | Updated config docs + features list |

## No new dependencies
PyJWT 2.9.0 + cryptography 43.0.0 already in `pyproject.toml`. RS256 support is built into PyJWT when cryptography is installed.

## Backward compatible
Existing HS256 configurations work without any changes. `self.secret_key` attribute preserved for code that reads it directly.

## Test results (9 validations)
- HS256 generate + decode
- HS256 symmetric keys (signing == verification)
- RS256 generate + decode via config
- RS256 asymmetric keys (signing != verification)
- Public key cannot sign (security)
- Cross-algorithm rejection (HS256 token rejected by RS256)
- RS256 user data preserved in payload
- Algorithm classification correct
- Backward compat `secret_key` attribute

Closes #27


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for asymmetric JWT algorithms (RS*/ES*) while keeping HS* support; tokens now use proper signing and verification keys.
  * Added config options to supply PEM private/public keys for asymmetric signing.

* **Documentation**
  * Expanded README JWT section with supported algorithms, key semantics, configuration examples, and security notes.

* **Tests**
  * Added end-to-end tests covering HS* and RS* token creation, verification, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->