### PR TITLE
fix: rename refresh request field to refresh_token (RFC 6749)

### DIFF
--- a/blockauth/docs/auth_docs.py
+++ b/blockauth/docs/auth_docs.py
@@ -756,7 +756,7 @@ refresh_token_docs = {
     "examples": [
         OpenApiExample(
             "Token Refresh",
-            value={"refresh": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."},
+            value={"refresh_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."},
             request_only=True,
             description="Refresh access token with refresh token",
         )

--- a/blockauth/schemas/examples/common.py
+++ b/blockauth/schemas/examples/common.py
@@ -60,7 +60,7 @@ token_invalid_signature = OpenApiExample(
 )
 
 empty_refresh_token = OpenApiExample(
-    name="empty_refresh_token", summary="Empty refresh token", value={"refresh": ["This field is required."]}
+    name="empty_refresh_token", summary="Empty refresh token", value={"refresh_token": ["This field is required."]}
 )
 
 empty_authorization_header = OpenApiExample(

--- a/blockauth/serializers/user_account_serializers.py
+++ b/blockauth/serializers/user_account_serializers.py
@@ -255,4 +255,4 @@ class EmailChangeConfirmationSerializer(serializers.Serializer):
 
 
 class RefreshTokenSerializer(serializers.Serializer):
-    refresh = serializers.CharField(help_text="Refresh token to get new access token", required=True)
+    refresh_token = serializers.CharField(help_text="Refresh token to get new access token", required=True)

--- a/blockauth/views/basic_auth_views.py
+++ b/blockauth/views/basic_auth_views.py
@@ -431,7 +431,7 @@ class AuthRefreshTokenView(APIView):
                 "Refresh token validation failed", sanitize_log_context(request.data, {"errors": serializer.errors})
             )
             raise ValidationErrorWithCode(detail=serializer.errors)
-        refresh_token = serializer.validated_data.get("refresh")
+        refresh_token = serializer.validated_data.get("refresh_token")
         token = AUTH_TOKEN_CLASS()
         payload = token.decode_token(refresh_token)
         try:


### PR DESCRIPTION
## Summary

Rename the request body field on the token refresh endpoint from `refresh` to `refresh_token` to align with OAuth 2.0 (RFC 6749).

| Before | After |
|--------|-------|
| `POST /token/refresh/ { "refresh": "..." }` | `POST /token/refresh/ { "refresh_token": "..." }` |

fabric-auth's logout endpoint already uses `refresh_token` — this eliminates the inconsistency.

## Changes

- `RefreshTokenSerializer` — field renamed `refresh` → `refresh_token`
- `AuthRefreshTokenView` — reads `refresh_token` from validated data
- `auth_docs.py` — request example updated
- `schemas/examples/common.py` — error example updated

Response fields (`"access"`, `"refresh"` in login/signup/refresh responses) are **unchanged** — that's a separate coordinated change with SDKs.

Closes #35

## Impact

After merging, these need updates:
- fabric-auth: `SecureTokenRefreshView` reads `refresh` from blockauth — needs to read `refresh_token`
- TS SDK: refresh call sends `{ "refresh": "..." }` — needs `{ "refresh_token": "..." }`
- Swift SDK: same

## Test plan

- [ ] `POST /token/refresh/` with `{ "refresh_token": "..." }` returns new tokens
- [ ] `POST /token/refresh/` with `{ "refresh": "..." }` returns 400 (field required)