### PR TITLE
chore: open-source readiness — purge internal refs, relax dep pins

### DIFF
--- a/blockauth/__init__.py
+++ b/blockauth/__init__.py
@@ -25,8 +25,6 @@ Static utilities (no storage needed):
     backup_codes = TOTPService.generate_backup_codes()
 """
 
-default_app_config = "blockauth.apps.BlockAuthConfig"
-
 # =============================================================================
 # Direct imports (Django-independent, no AppRegistryNotReady errors)
 # =============================================================================

--- a/blockauth/apps.py
+++ b/blockauth/apps.py
@@ -3,7 +3,7 @@ from django.apps import AppConfig
 
 class BlockAuthConfig(AppConfig):
     name = "blockauth"
-    verbose_name = "Internal Authentication Module"
+    verbose_name = "BlockAuth"
     default_auto_field = "django.db.models.BigAutoField"
 
     def ready(self):

--- a/blockauth/serializers/user_account_serializers.py
+++ b/blockauth/serializers/user_account_serializers.py
@@ -8,13 +8,13 @@ from rest_framework.exceptions import ValidationError
 from blockauth.serializers.otp_serializers import OTPRequestSerializer, OTPVerifySerializer
 from blockauth.utils.config import get_block_auth_user_model, get_config
 from blockauth.utils.generics import get_password_help_text
-from blockauth.utils.validators import FabricBlocPasswordValidator, is_valid_phone_number
+from blockauth.utils.validators import BlockAuthPasswordValidator, is_valid_phone_number
 
 _User = get_block_auth_user_model()
 logger = logging.getLogger(__name__)
 
 # Single instance of password validator to avoid duplicate error messages
-_password_validator = FabricBlocPasswordValidator()
+_password_validator = BlockAuthPasswordValidator()
 
 """account basic auth related serializers"""
 

--- a/blockauth/stepup/receipt.py
+++ b/blockauth/stepup/receipt.py
@@ -66,7 +66,7 @@ class ReceiptIssuer:
         secret: HS256 signing key (shared with consuming service).
                 Must be >= 32 bytes. Use ``secrets.token_hex(32)`` to generate.
         issuer: Optional ``iss`` claim (e.g., "fabric-auth").
-        default_audience: Default ``aud`` claim (e.g., "fabric-wallet").
+        default_audience: Default ``aud`` claim (e.g., "my-wallet-service").
         default_scope: Default ``scope`` claim (e.g., "mpc").
         default_ttl_seconds: Default receipt lifetime. 120s recommended.
     """
@@ -76,7 +76,7 @@ class ReceiptIssuer:
         secret: str,
         *,
         issuer: Optional[str] = None,
-        default_audience: str = "fabric-wallet",
+        default_audience: str = "default",
         default_scope: str = "mpc",
         default_ttl_seconds: int = 120,
     ):
@@ -138,7 +138,7 @@ class ReceiptValidator:
 
     Args:
         secret: HS256 signing key (shared with issuing service).
-        expected_audience: Required ``aud`` value (e.g., "fabric-wallet").
+        expected_audience: Required ``aud`` value (e.g., "my-wallet-service").
         expected_scope: Required ``scope`` value (e.g., "mpc").
     """
 
@@ -146,7 +146,7 @@ class ReceiptValidator:
         self,
         secret: str,
         *,
-        expected_audience: str = "fabric-wallet",
+        expected_audience: str = "default",
         expected_scope: str = "mpc",
     ):
         if not secret or len(secret) < 32:

--- a/blockauth/utils/tests/test_validators.py
+++ b/blockauth/utils/tests/test_validators.py
@@ -1,5 +1,5 @@
 """
-Tests for FabricBloc validators.
+Tests for BlockAuth validators.
 
 Tests the password validation functions and Django validator class.
 """
@@ -11,7 +11,7 @@ from blockauth.utils.validators import (
     PASSWORD_MAX_LENGTH,
     PASSWORD_MIN_LENGTH,
     PASSWORD_VALIDATION_ERROR,
-    FabricBlocPasswordValidator,
+    BlockAuthPasswordValidator,
     is_valid_password,
     is_valid_phone_number,
     validate_password,
@@ -167,12 +167,12 @@ class TestIsValidPassword:
         assert is_valid_password("password1!") is False  # missing uppercase
 
 
-class TestFabricBlocPasswordValidator:
+class TestBlockAuthPasswordValidator:
     """Test the Django password validator class."""
 
     def setup_method(self):
         """Set up test fixtures."""
-        self.validator = FabricBlocPasswordValidator()
+        self.validator = BlockAuthPasswordValidator()
 
     def test_valid_password_does_not_raise(self):
         """Valid passwords should not raise ValidationError."""

--- a/blockauth/utils/validators.py
+++ b/blockauth/utils/validators.py
@@ -1,11 +1,11 @@
 """
-FabricBloc Validators
-=====================
-Common validation utilities for the FabricBloc platform.
+BlockAuth Validators
+====================
+Common validation utilities for BlockAuth.
 
 This module contains validators for:
 - Phone numbers
-- Passwords (FabricBloc standard)
+- Passwords
 
 Password Requirements:
 - 8-128 characters
@@ -29,7 +29,7 @@ Usage:
 Django Integration:
     # settings.py
     AUTH_PASSWORD_VALIDATORS = [
-        {'NAME': 'blockauth.utils.validators.FabricBlocPasswordValidator'},
+        {'NAME': 'blockauth.utils.validators.BlockAuthPasswordValidator'},
     ]
 """
 
@@ -61,7 +61,7 @@ PASSWORD_VALIDATION_ERROR = (
 
 def validate_password(password: str) -> List[str]:
     """
-    Validate password against FabricBloc requirements.
+    Validate password against BlockAuth requirements.
 
     Args:
         password: The password string to validate.
@@ -93,7 +93,7 @@ def validate_password(password: str) -> List[str]:
 
 def is_valid_password(password: str) -> bool:
     """
-    Quick check if password meets FabricBloc requirements.
+    Quick check if password meets BlockAuth requirements.
 
     Args:
         password: The password string to validate.
@@ -115,12 +115,12 @@ def is_valid_password(password: str) -> bool:
 # =============================================================================
 
 
-class FabricBlocPasswordValidator:
+class BlockAuthPasswordValidator:
     """
-    Django password validator implementing FabricBloc requirements.
+    Django password validator implementing BlockAuth requirements.
 
     Add to AUTH_PASSWORD_VALIDATORS in settings.py:
-        {'NAME': 'blockauth.utils.validators.FabricBlocPasswordValidator'}
+        {'NAME': 'blockauth.utils.validators.BlockAuthPasswordValidator'}
 
     Requirements:
         - 8-128 characters

--- a/poetry.lock
+++ b/poetry.lock
@@ -3160,4 +3160,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "b71d533e90e067adc0a776e2ce3a4be6bbb21298b5f11417d4d79c1344c7c25f"
+content-hash = "fb734bdfe18bdab712edc48d5c7a121c17b07dc05e4969949a7e46673e94b0bc"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,19 +1,19 @@
 [tool.poetry]
 name = "blockauth"
 version = "0.2.0"
-description = "Auth package for internal usage"
-authors = ["darkprinx <rctushar07@gmail.com>"]
-license = "All Rights Reserved"
+description = "Comprehensive Python authentication package bridging Web2 and Web3"
+authors = ["BloclabsHQ <eng@bloclabs.com>"]
+license = "MIT"
 readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.12"
-django = "5.1.4"
-pyjwt = "2.12.1"
-requests = "2.33.0"
-djangorestframework = "3.15.2"
-django-ratelimit = "^4.1.0"
-drf-spectacular = "0.28.0"
+django = ">=5.0,<6.0"
+pyjwt = ">=2.8,<3.0"
+requests = ">=2.31,<3.0"
+djangorestframework = ">=3.14,<4.0"
+django-ratelimit = ">=4.1,<5.0"
+drf-spectacular = ">=0.27,<1.0"
 web3 = "^6.20.1"
 eth-account = "^0.11.0"
 cryptography = "^46.0.5"


### PR DESCRIPTION
## Summary

PR 2 of 4 for #38 (master audit). Removes all FabricBloc-specific references and prepares the package for open-source release:

- **L1-L3**: Updated pyproject.toml — description, author (`BloclabsHQ`), license (`MIT`)
- **L3**: Renamed `verbose_name` from "Internal Authentication Module" to "BlockAuth"
- **L4-L5**: Renamed `FabricBlocPasswordValidator` → `BlockAuthPasswordValidator` (class + all references)
- **L6**: Replaced hardcoded `fabric-wallet` default audience with `default` in stepup receipts
- **F05**: Relaxed 6 exact-pinned deps to range pins (`django >=5.0,<6.0`, etc.)
- **F23**: Removed deprecated `default_app_config` from `__init__.py`

### Breaking Changes

1. `FabricBlocPasswordValidator` renamed to `BlockAuthPasswordValidator` — update `AUTH_PASSWORD_VALIDATORS` in Django settings
2. Step-up receipt default audience changed from `fabric-wallet` to `default` — fabric-auth/fabric-wallet must pass `audience` explicitly

## Test plan

- [ ] Verify `BlockAuthPasswordValidator` works in Django settings
- [ ] Verify stepup receipts still issue/validate with explicit audience
- [ ] Verify `poetry install` resolves correctly with relaxed pins
- [ ] Grep for remaining `FabricBloc` / `fabric-` references in Python files