### PR TITLE
fix: architecture cleanup — layer violations, deprecated patterns

### DIFF
--- a/blockauth/authentication.py
+++ b/blockauth/authentication.py
@@ -1,5 +1,6 @@
 import logging
 
+import jwt as pyjwt
 from rest_framework.authentication import BaseAuthentication
 from rest_framework.exceptions import AuthenticationFailed
 
@@ -67,8 +68,9 @@ class JWTAuthentication(BaseAuthentication):
         if self.jwt_manager:
             try:
                 payload = self.jwt_manager.decode_token(validated_token)
-            except Exception as e:
-                # Fall back to original token class if enhanced system fails
+            except (pyjwt.InvalidTokenError, AuthenticationFailed):
+                raise
+            except Exception:
                 payload = self._TOKEN_CLASS().decode_token(validated_token)
         else:
             payload = self._TOKEN_CLASS().decode_token(validated_token)

--- a/blockauth/enums.py
+++ b/blockauth/enums.py
@@ -49,7 +49,6 @@ class AuthenticationType(str, Enum):
         return labels.get(self.value, self.value)
 
     @classmethod
-    @property
     def choices(cls) -> list:
         """Django-compatible choices tuple list."""
         return [(e.value, e.label) for e in cls]

--- a/blockauth/models/otp.py
+++ b/blockauth/models/otp.py
@@ -3,7 +3,7 @@ import string
 
 from django.db import models
 from django.utils import timezone
-from rest_framework.serializers import ValidationError
+from rest_framework.exceptions import ValidationError
 
 from blockauth.utils.config import get_config
 

--- a/blockauth/totp/storage/base.py
+++ b/blockauth/totp/storage/base.py
@@ -42,9 +42,7 @@ class TOTP2FAData:
         """Check if account is locked."""
         if self.locked_until is None:
             return False
-        from django.utils import timezone
-
-        return timezone.now() < self.locked_until
+        return datetime.now(tz=self.locked_until.tzinfo) < self.locked_until
 
 
 class ITOTP2FAStore(ABC):

--- a/blockauth/utils/generics.py
+++ b/blockauth/utils/generics.py
@@ -109,7 +109,7 @@ def get_available_authentication_types() -> List[Dict[str, str]]:
     Returns:
         List of dictionaries with 'code' and 'label' keys
     """
-    return [{"code": choice[0], "label": choice[1]} for choice in AuthenticationType.choices]
+    return [{"code": choice[0], "label": choice[1]} for choice in AuthenticationType.choices()]
 
 
 def get_password_help_text():


### PR DESCRIPTION
## Summary

PR 4 of 4 for #38 (master audit). Fixes architecture violations and deprecated patterns.

- **F06**: Fix `ValidationError` import in `models/otp.py` — was importing from `rest_framework.serializers` instead of `rest_framework.exceptions`
- **F15**: Remove `django.utils.timezone` import from `totp/storage/base.py` DTO — use stdlib `datetime` for framework-agnostic data transfer object
- **F21**: Narrow broad `except Exception` in `authentication.py` — re-raise `InvalidTokenError` and `AuthenticationFailed` instead of silently falling back to alternate decoder
- **F24**: Remove deprecated `@classmethod @property` stack in `enums.py` — deprecated in Python 3.13+, replaced with plain `@classmethod` and updated caller to use `choices()` with parens

### Breaking Change

`AuthenticationType.choices` is now a classmethod call (`AuthenticationType.choices()`) instead of a property. Any code accessing it without parens must be updated.

## Test plan

- [ ] Verify OTP validation still raises correct errors
- [ ] Verify TOTP `is_locked()` works with timezone-aware datetimes
- [ ] Verify JWT authentication re-raises invalid token errors properly
- [ ] Verify `AuthenticationType.choices()` returns correct list