### PR TITLE
feat: add GitHub Package publishing workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,47 @@
+name: Publish to GitHub Packages
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          version: "1.8.5"
+
+      - name: Validate tag matches pyproject.toml version
+        run: |
+          TAG_VERSION="${GITHUB_REF#refs/tags/v}"
+          PYPROJECT_VERSION=$(poetry version -s)
+          if [ "$TAG_VERSION" != "$PYPROJECT_VERSION" ]; then
+            echo "::error::Tag version ($TAG_VERSION) does not match pyproject.toml ($PYPROJECT_VERSION)"
+            exit 1
+          fi
+
+      - name: Build package
+        run: poetry build
+
+      - name: Create GitHub Release with package artifacts
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            dist/*.tar.gz
+            dist/*.whl
+          generate_release_notes: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,6 @@ on:
 
 permissions:
   contents: write
-  packages: write
 
 jobs:
   publish:
@@ -26,12 +25,17 @@ jobs:
         with:
           version: "1.8.5"
 
-      - name: Validate tag matches pyproject.toml version
+      - name: Validate tag matches pyproject.toml and __version__
         run: |
           TAG_VERSION="${GITHUB_REF#refs/tags/v}"
           PYPROJECT_VERSION=$(poetry version -s)
+          INIT_VERSION=$(python -c "import re; print(re.search(r'__version__\s*=\s*\"(.+?)\"', open('blockauth/__init__.py').read()).group(1))")
           if [ "$TAG_VERSION" != "$PYPROJECT_VERSION" ]; then
-            echo "::error::Tag version ($TAG_VERSION) does not match pyproject.toml ($PYPROJECT_VERSION)"
+            echo "::error::Tag ($TAG_VERSION) != pyproject.toml ($PYPROJECT_VERSION)"
+            exit 1
+          fi
+          if [ "$TAG_VERSION" != "$INIT_VERSION" ]; then
+            echo "::error::Tag ($TAG_VERSION) != __init__.py ($INIT_VERSION)"
             exit 1
           fi
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,6 +171,14 @@ All endpoints are feature-flag controlled via `BLOCK_AUTH_SETTINGS['FEATURES']`.
 
 ## Installation & Setup
 
+```bash
+# Install from GitHub Releases
+pip install https://github.com/BloclabsHQ/auth-pack/releases/download/v0.2.0/blockauth-0.2.0-py3-none-any.whl
+
+# Or from git
+pip install git+https://github.com/BloclabsHQ/auth-pack.git@dev
+```
+
 ```python
 # Django settings
 INSTALLED_APPS = [
@@ -275,6 +283,23 @@ Key rules:
 - Rate limiting on all auth endpoints
 - No sensitive data in logs (passwords, tokens, keys)
 - No `traceback.print_exc()` in production code
+
+## Releasing
+
+Version is tracked in two places (keep in sync):
+- `pyproject.toml` → `version = "X.Y.Z"`
+- `blockauth/__init__.py` → `__version__ = "X.Y.Z"`
+
+To release:
+```bash
+# 1. Bump version in both files
+# 2. Commit and push to dev
+# 3. Tag and push
+git tag v0.2.0
+git push origin v0.2.0
+```
+
+The `publish.yml` workflow validates the tag matches `pyproject.toml`, builds the package, and creates a GitHub Release with sdist + wheel artifacts.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,6 @@
-# Blockauth
+# BlockAuth
 
-[//]: # ([![PyPI version]&#40;https://badge.fury.io/py/block-inter-auth.svg&#41;]&#40;https://badge.fury.io/py/block-inter-auth&#41;)
-[//]: # ([![PyPI - Python Version]&#40;https://img.shields.io/pypi/pyversions/block-inter-auth&#41;]&#40;https://pypi.org/project/block-inter-auth/&#41;)
-
-Blockauth is an authentication package for Python REST APIs, designed for internal use. It provides JWT-based authentication mechanisms, including login and token refresh functionalities. It also supports Social login using OAuth2.
-
-_Disclaimer: This package is currently at initiative state so you can expect frequent changes based on the teams requirements._
+Comprehensive Python authentication package bridging Web2 and Web3. Provides JWT authentication, OAuth integration, passwordless login, Web3 wallet authentication, TOTP/2FA, WebAuthn passkeys, and a KDF system that enables blockchain access without crypto knowledge.
 
 ## Table of Contents
 - [Features](#features)
@@ -259,33 +254,32 @@ BLOCK_AUTH_SETTINGS = {
 
 ## Installation
 
-#### Direct Installation
-To install the package, we prefer poetry. It's recommended to install the package in a virtual environment. Also make sure to add ssh to your github account.
-With Poetry add dependency like below in `pyproject.toml` file:
-```
+#### From GitHub Releases (recommended)
+
+Add to your `pyproject.toml`:
+```toml
 [tool.poetry.dependencies]
-...
-blockauth = { git = "git@github.com:BloclabsHQ/auth-pack.git", branch = "dev" }  # <---- give your prefered branch
-...
+blockauth = { url = "https://github.com/BloclabsHQ/auth-pack/releases/download/v0.2.0/blockauth-0.2.0-py3-none-any.whl" }
 ```
-Then run the command
-`poetry update`
 
+Or install directly:
+```bash
+pip install https://github.com/BloclabsHQ/auth-pack/releases/download/v0.2.0/blockauth-0.2.0-py3-none-any.whl
+```
 
-#### Editable Mode
-To install the package in **editable mode**, you can clone the repository and install it in the virtual environment.
-After activating python virtual environment, go to the folder where the current repository should be  
-located and then follow the below commands:
+#### From Git (development)
+
+```toml
+[tool.poetry.dependencies]
+blockauth = { git = "https://github.com/BloclabsHQ/auth-pack.git", branch = "dev" }
+```
+
+#### Editable Mode (local development)
 
 ```sh
-git clone <repo-url>
-pip install -e <path-to-repo>
+git clone https://github.com/BloclabsHQ/auth-pack.git
+pip install -e ./auth-pack
 ```
-
-`pip install -e` is used to install a Python package in "editable" or "development"
-mode. This is helpful when you are actively developing a package and want the 
-changes made to the source code to be reflected immediately without needing to 
-reinstall the package each time.
 
 
 ## Configuration Setup

--- a/README.md
+++ b/README.md
@@ -892,10 +892,10 @@ Then calls the `POST_SIGNUP_TRIGGER` class with **provider name, user data from 
 
 ## Utility Classes
 ### Communication Class
-This class is used to send message to the user. The default class is `blockauth.utils.communication.DummyNotification`. 
-Which is a dummy class and prints the message to the console. 
+This class is used to send messages to the user. The default class is `blockauth.notification.DummyNotification`, 
+which is a dummy class that prints the message to the console. 
 
-Developers have to implement their own class by inheriting the `blockauth.utils.communication.BaseCommunicationClass` and set the path in the settings.
+Developers should implement their own class by inheriting `blockauth.notification.BaseNotification` and set the path in settings via `DEFAULT_NOTIFICATION_CLASS`.
 Otherwise, the default class will be used.
 
 Currently, the communication class is integrated in the following APIs:
@@ -913,15 +913,16 @@ Currently, the communication class is integrated in the following APIs:
 from blockauth.notification import BaseNotification
 
 
-class CustomCommunication(BaseNotification):
-    def communicate(self, purpose: str, context: dict) -> None:
+class CustomNotification(BaseNotification):
+    def notify(self, method: str, event: str, context: dict) -> None:
         """
-       :param purpose: should be used to identify the purpose of the communication.
-       :param context: should contain the necessary information to send the message by developers own logic.
+       :param method: delivery method ('email', 'sms')
+       :param event: notification event (see NotificationEvent constants)
+       :param context: contains identifier and any extra data
        """
-        if purpose == 'otp_request':
+        if event == 'otp_request':
             self.send_otp(context)
-        elif purpose == 'password_change':
+        elif event == 'password_change':
             self.send_password_change_email(context)
 
     def send_otp(self, context: dict) -> None:
@@ -934,18 +935,22 @@ class CustomCommunication(BaseNotification):
         print(f"Sending password change notification to email {email}")
 ```
 
-Currently, the following **purposes** are available for communication in the package. In the future, more purposes might be added:
+The following notification events are available (see `blockauth.notification.NotificationEvent`):
 ```python
-class CommunicationPurpose:
+class NotificationEvent:
     OTP_REQUEST = "otp_request"
-    PASSWORD_CHANGE = "password_change"
+    SUCCESS_PASSWORD_RESET = "success_password_reset"
+    SUCCESS_PASSWORD_CHANGE = "success_password_change"
+    SUCCESS_EMAIL_CHANGE = "success_email_change"
 ```
 
 ### Trigger Classes
 These classes are used to perform some actions before and after the signup and login process.
-- `PreSignupTrigger`: This class is called before the signup process. The default class is `blockauth.utils.triggers.DefaultPreSignupTrigger` which is a dummy class.
-- `PostSignupTrigger`: This class is called after the signup process. The default class is `blockauth.utils.triggers.DefaultPostSignupTrigger` which is a dummy class.
-- `PostLoginTrigger`: This class is called after the login process. The default class is `blockauth.utils.triggers.DefaultPostLoginTrigger` which is a dummy class.
+- `PRE_SIGNUP_TRIGGER`: Called before signup. Default: `blockauth.triggers.DummyPreSignupTrigger`
+- `POST_SIGNUP_TRIGGER`: Called after signup. Default: `blockauth.triggers.DummyPostSignupTrigger`
+- `POST_LOGIN_TRIGGER`: Called after login. Default: `blockauth.triggers.DummyPostLoginTrigger`
+- `POST_PASSWORD_CHANGE_TRIGGER`: Called after password change. Default: `blockauth.triggers.DummyPostPasswordChangeTrigger`
+- `POST_PASSWORD_RESET_TRIGGER`: Called after password reset. Default: `blockauth.triggers.DummyPostPasswordResetTrigger`
 
 Developers have to implement their own classes by inheriting the respective base classes and set the path in the settings.
 
@@ -1123,19 +1128,17 @@ for wallet in wallets:
 
 ### Password Change Integration
 
+Password change triggers fire automatically from the `PasswordChangeView`. To handle password changes in your app, implement a custom trigger:
+
 ```python
-from blockauth.triggers import PostPasswordChangeTrigger
+from blockauth.triggers import BaseTrigger
 
-# Trigger automatically re-encrypts KDF wallets
-trigger = PostPasswordChangeTrigger()
-context = {
-    'user': user,
-    'old_password': 'OldPassword123',
-    'new_password': 'NewPassword456'
-}
-
-trigger.execute(context)
-# KDF wallets are automatically re-encrypted with new password
+class MyPasswordChangeTrigger(BaseTrigger):
+    def trigger(self, context: dict) -> None:
+        # context contains: user_id, username, email, trigger_type, timestamp
+        # NOTE: plaintext passwords are never included in the context
+        user_id = context['user_id']
+        # Perform post-password-change actions (e.g., invalidate sessions)
 ```
 
 ### KDF Configuration

--- a/blockauth/__init__.py
+++ b/blockauth/__init__.py
@@ -1,6 +1,9 @@
 """
 BlockAuth - Reusable Authentication Components.
 
+:copyright: (c) BloclabsHQ
+:license: MIT
+
 Quick usage for B2B2C (custom storage):
     from blockauth import TOTPService, ITOTP2FAStore, TOTP2FAData, ISecretEncryption
 
@@ -24,6 +27,8 @@ Static utilities (no storage needed):
     is_valid, counter = TOTPService.verify_totp(secret, user_code)
     backup_codes = TOTPService.generate_backup_codes()
 """
+
+__version__ = "0.2.0"
 
 # =============================================================================
 # Direct imports (Django-independent, no AppRegistryNotReady errors)

--- a/docs/CUSTOM_JWT_CLAIMS.md
+++ b/docs/CUSTOM_JWT_CLAIMS.md
@@ -29,28 +29,30 @@ User Login → JWT Manager → Claims Provider 1 → Claims Provider 2 → ... �
 
 ### Step 1: Define Your Claims Provider Class
 
-Create a class with a `get_custom_claims` method that accepts a user object and returns a dictionary of claims:
+Create a class that inherits from `CustomClaimsProvider` and implements both `get_custom_claims` and `validate_custom_claims`:
 
 ```python
 # myapp/jwt_claims.py
 import logging
 from typing import Dict, Any
 
+from blockauth.jwt.interfaces import CustomClaimsProvider
+
 logger = logging.getLogger(__name__)
 
 
-class MyCustomClaimsProvider:
+class MyCustomClaimsProvider(CustomClaimsProvider):
     """
-    Custom JWT claims provider for MyApp
-    """
+    Custom JWT claims provider for MyApp.
 
-    def __init__(self):
-        self.name = "myapp"  # Provider name for identification
-        self.description = "Custom claims for MyApp"
+    Must implement:
+    - get_custom_claims(user) -> Dict[str, Any]
+    - validate_custom_claims(claims) -> bool
+    """
 
     def get_custom_claims(self, user) -> Dict[str, Any]:
         """
-        Generate custom claims for a user
+        Generate custom claims for a user.
 
         Args:
             user: User object (Django User model instance)
@@ -95,6 +97,16 @@ class MyCustomClaimsProvider:
         if hasattr(user, 'subscription'):
             return user.subscription.tier
         return "free"
+
+    def validate_custom_claims(self, claims: Dict[str, Any]) -> bool:
+        """
+        Validate custom claims during token verification.
+
+        Called by JWTTokenManager.decode_token() for each provider.
+        Return False to reject the token.
+        """
+        # Example: ensure role claim is present
+        return "role" in claims
 ```
 
 ### Step 2: Create a Registration Function

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,21 @@ description = "Comprehensive Python authentication package bridging Web2 and Web
 authors = ["BloclabsHQ <eng@bloclabs.com>"]
 license = "MIT"
 readme = "README.md"
+homepage = "https://github.com/BloclabsHQ/auth-pack"
+repository = "https://github.com/BloclabsHQ/auth-pack"
+packages = [{include = "blockauth"}]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Framework :: Django",
+    "Framework :: Django :: 5.0",
+    "Framework :: Django :: 5.1",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Security",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+]
 
 [tool.poetry.dependencies]
 python = "^3.12"


### PR DESCRIPTION
## Summary

Closes #31. Sets up blockauth for distribution as a versioned package via GitHub Releases.

### Changes
- **pyproject.toml**: Added `homepage`, `repository`, `packages`, and `classifiers` metadata
- **blockauth/__init__.py**: Added `__version__ = "0.2.0"` for runtime version access
- **.github/workflows/publish.yml**: New workflow triggered on `v*` tags that:
  1. Validates tag matches `pyproject.toml` version (prevents mismatches)
  2. Builds sdist + wheel via `poetry build`
  3. Creates a GitHub Release with artifacts attached

### How to release
```bash
# Bump version in pyproject.toml + __init__.py, then:
git tag v0.2.0
git push origin v0.2.0
```

### How consumers install
```toml
# pyproject.toml (Poetry)
blockauth = { url = "https://github.com/BloclabsHQ/auth-pack/releases/download/v0.2.0/blockauth-0.2.0-py3-none-any.whl" }
```

## Test plan

- [ ] Verify `poetry build` produces valid sdist + wheel
- [ ] Verify version tag validation logic (mismatched tag should fail)
- [ ] After merge, tag `v0.2.0` and verify release is created with artifacts