### PR TITLE
fix: resolve 6 ghost references from audit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,7 +173,7 @@ All endpoints are feature-flag controlled via `BLOCK_AUTH_SETTINGS['FEATURES']`.
 
 ```bash
 # Install from GitHub Releases
-pip install https://github.com/BloclabsHQ/auth-pack/releases/download/v0.2.0/blockauth-0.2.0-py3-none-any.whl
+pip install https://github.com/BloclabsHQ/auth-pack/releases/download/v0.3.0/blockauth-0.3.0-py3-none-any.whl
 
 # Or from git
 pip install git+https://github.com/BloclabsHQ/auth-pack.git@dev
@@ -295,8 +295,8 @@ To release:
 # 1. Bump version in both files
 # 2. Commit and push to dev
 # 3. Tag and push
-git tag v0.2.0
-git push origin v0.2.0
+git tag v0.3.0
+git push origin v0.3.0
 ```
 
 The `publish.yml` workflow validates the tag matches `pyproject.toml`, builds the package, and creates a GitHub Release with sdist + wheel artifacts.

--- a/LICENSE
+++ b/LICENSE
@@ -1,1 +1,21 @@
-All Rights Reserved
+MIT License
+
+Copyright (c) 2024-2026 BloclabsHQ
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Makefile
+++ b/Makefile
@@ -6,22 +6,22 @@
 
 # Install dependencies
 install:
-	@poetry install
+	@uv sync
 
 # Format code (black + isort)
 format:
 	@echo "Formatting with black..."
-	@poetry run black blockauth/
+	@uv run black blockauth/
 	@echo "Sorting imports with isort..."
-	@poetry run isort blockauth/
+	@uv run isort blockauth/
 	@echo "Removing unused imports with autoflake..."
-	@poetry run autoflake --in-place --remove-all-unused-imports --recursive blockauth/
+	@uv run autoflake --in-place --remove-all-unused-imports --recursive blockauth/
 	@echo "Done."
 
 # Lint code (flake8)
 lint:
 	@echo "Linting with flake8..."
-	@poetry run flake8 blockauth/
+	@uv run flake8 blockauth/
 	@echo "Done."
 
 # Run both format and lint

--- a/README.md
+++ b/README.md
@@ -1363,7 +1363,7 @@ blockauth/
 ```
 
 ## License
-All rights reserved. 
+MIT License. See [LICENSE](LICENSE) for details.
 
 ## Acknowledgments
 - [Django](https://www.djangoproject.com/)

--- a/blockauth/kdf/IMPLEMENTATION_SUMMARY.md
+++ b/blockauth/kdf/IMPLEMENTATION_SUMMARY.md
@@ -144,7 +144,7 @@ business_wallet = create_wallet(email, password, "business")  # Salt C
 ## 🚀 **Next Steps**
 
 1. **Test the system** with the provided examples
-2. **Integrate into fabric-auth** for smart contract functionality
+2. **Integrate into your service** for smart contract functionality
 3. **Deploy to production** with proper security measures
 4. **Monitor and maintain** the system
 

--- a/docs/JWT_EXTENSION_GUIDE.md
+++ b/docs/JWT_EXTENSION_GUIDE.md
@@ -52,9 +52,9 @@ The `JWTTokenManager` class provides:
 - Token validation with custom claims verification
 - Backward compatibility with existing token system
 
-### 3. Example Claims Provider (fabric-auth)
+### 3. Example Claims Provider (consuming service)
 
-**File**: `fabric_auth/blockchain/jwt_claims.py`
+**File**: `myapp/jwt_claims.py` (example — implement in your own service)
 
 ```python
 class SmartAccountClaimsProvider(CustomClaimsProvider):


### PR DESCRIPTION
## Summary

Ghost audit cleanup — fixes all 6 stale references found by `/audit-ghosts`.

| # | File | Ghost | Fix |
|---|------|-------|-----|
| 1 | LICENSE | "All Rights Reserved" | Replaced with MIT license text |
| 2 | Makefile | 5x `poetry install/run` | Replaced with `uv sync/run` |
| 3 | CLAUDE.md | v0.2.0 download URL | Updated to v0.3.0 |
| 4 | CLAUDE.md | v0.2.0 tag example | Updated to v0.3.0 |
| 5 | JWT_EXTENSION_GUIDE.md | `fabric_auth/blockchain/jwt_claims.py` | Changed to generic `myapp/jwt_claims.py` |
| 6 | kdf/IMPLEMENTATION_SUMMARY.md | "Integrate into fabric-auth" | Changed to "your service" |

Also fixed README.md license section ("All rights reserved" → MIT).

## Audit result after fixes
- 0 poetry references remaining in non-historical docs
- 0 "All Rights Reserved" remaining
- 0 internal service names in code examples