### PR TITLE
chore: add CODEOWNERS, CONTRIBUTING.md, SECURITY.md for public release

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,17 @@
+# BlockAuth Code Owners
+# These owners will be automatically requested for review on PRs.
+
+# Default — all changes require review from the core team
+* @BloclabsHQ/engineering
+
+# Security-sensitive areas — require security team review
+blockauth/kdf/ @BloclabsHQ/engineering
+blockauth/stepup/ @BloclabsHQ/engineering
+blockauth/utils/token.py @BloclabsHQ/engineering
+blockauth/jwt/ @BloclabsHQ/engineering
+blockauth/authentication.py @BloclabsHQ/engineering
+blockauth/utils/web3/ @BloclabsHQ/engineering
+
+# CI/CD and release
+.github/ @BloclabsHQ/engineering
+pyproject.toml @BloclabsHQ/engineering

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,75 @@
+# Contributing to BlockAuth
+
+Thanks for your interest in contributing to BlockAuth.
+
+## Getting Started
+
+```bash
+# Clone the repo
+git clone https://github.com/BloclabsHQ/auth-pack.git
+cd auth-pack
+
+# Install uv (if not installed)
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# Install dependencies
+uv sync
+
+# Run tests
+uv run pytest
+
+# Format & lint
+make check
+```
+
+## Development Workflow
+
+1. Fork the repo and create a branch from `dev`
+2. Make your changes
+3. Run `make check` (format + lint)
+4. Run `uv run pytest` to verify tests pass
+5. Open a PR against `dev`
+
+## Branch Strategy
+
+- `main` — stable releases only
+- `dev` — active development, PRs target this branch
+
+## Code Standards
+
+- **Format**: black (120 char line length) + isort
+- **Lint**: flake8
+- **Security**: See [SECURITY_STANDARDS.md](.claude/SECURITY_STANDARDS.md)
+
+Key rules:
+- No hardcoded secrets or credentials
+- No sensitive data in logs (passwords, tokens, keys)
+- Use `hmac.compare_digest()` for cryptographic comparisons
+- Use `secrets` module for random generation
+- Pin JWT algorithms on decode
+
+## Commit Messages
+
+Follow conventional commits:
+```
+feat: add new authentication method
+fix: resolve timing attack in KDF verification
+docs: update API endpoint documentation
+chore: bump dependency versions
+```
+
+## Security
+
+If you discover a security vulnerability, please do NOT open a public issue. Email security@bloclabs.com instead.
+
+## Versioning
+
+We use [Semantic Versioning](https://semver.org/). Version is tracked in:
+- `pyproject.toml` → `version`
+- `blockauth/__init__.py` → `__version__`
+
+Both must be updated together.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the MIT License.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,33 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in BlockAuth, please report it responsibly.
+
+**Do NOT open a public GitHub issue for security vulnerabilities.**
+
+Instead, email **security@bloclabs.com** with:
+- Description of the vulnerability
+- Steps to reproduce
+- Potential impact
+- Suggested fix (if any)
+
+We will acknowledge receipt within 48 hours and aim to release a fix within 7 days for critical issues.
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| 0.3.x   | Yes       |
+| < 0.3   | No        |
+
+## Security Practices
+
+BlockAuth follows these security practices:
+
+- All cryptographic comparisons use constant-time functions (`hmac.compare_digest`)
+- JWT algorithms are pinned on decode (no algorithm confusion attacks)
+- OTP generation uses `secrets.choice()` (cryptographically secure)
+- No sensitive data (passwords, tokens, keys) in logs
+- Rate limiting on all authentication endpoints
+- Dependencies are regularly audited for vulnerabilities


### PR DESCRIPTION
## Summary

Adds governance files required before making the repo public.

- **CODEOWNERS** — engineering team required as reviewer on all PRs; extra coverage on security-sensitive paths (KDF, JWT, stepup, web3)
- **CONTRIBUTING.md** — dev setup with uv, workflow guide, code standards, commit conventions, security reporting
- **SECURITY.md** — vulnerability reporting policy (email, not public issues), supported versions, security practices summary

## After merge

1. Squash-merge `dev` → `main` for clean public history
2. Set branch protection rules on `main` and `dev`
3. Change repo visibility to public