### PR TITLE
fix: remove all internal service references

### DIFF
--- a/.claude/SECURITY_STANDARDS.md
+++ b/.claude/SECURITY_STANDARDS.md
@@ -1,6 +1,6 @@
-# 🔐 MANDATORY SECURITY STANDARDS - FabricBloc Authentication
+# MANDATORY SECURITY STANDARDS - BlockAuth
 
-## ⚠️ CRITICAL: These Standards Are NON-NEGOTIABLE
+## CRITICAL: These Standards Are NON-NEGOTIABLE
 
 **EVERY line of code MUST comply with these security standards. NO EXCEPTIONS.**
 

--- a/blockauth/passkey/services/cleanup_service.py
+++ b/blockauth/passkey/services/cleanup_service.py
@@ -2,7 +2,7 @@
 Passkey Cleanup Service
 
 Service layer for cleaning up expired passkey data.
-Can be imported and used by consuming applications (e.g., fabric-auth management commands).
+Can be imported and used by consuming applications (e.g., Django management commands).
 
 Usage:
     from blockauth.passkey.services import cleanup_expired_challenges, cleanup_all

--- a/blockauth/stepup/receipt.py
+++ b/blockauth/stepup/receipt.py
@@ -65,7 +65,7 @@ class ReceiptIssuer:
     Args:
         secret: HS256 signing key (shared with consuming service).
                 Must be >= 32 bytes. Use ``secrets.token_hex(32)`` to generate.
-        issuer: Optional ``iss`` claim (e.g., "fabric-auth").
+        issuer: Optional ``iss`` claim (e.g., "my-auth-service").
         default_audience: Default ``aud`` claim (e.g., "my-wallet-service").
         default_scope: Default ``scope`` claim (e.g., "mpc").
         default_ttl_seconds: Default receipt lifetime. 120s recommended.

--- a/blockauth/views/basic_auth_views.py
+++ b/blockauth/views/basic_auth_views.py
@@ -223,7 +223,7 @@ class SignUpConfirmView(APIView):
 
                 user_data = model_to_json(user, remove_fields=("password",))
 
-                # Call POST_SIGNUP_TRIGGER with user data - let fabric-auth handle the complexity
+                # Call POST_SIGNUP_TRIGGER with user data
                 post_signup_trigger = get_config("POST_SIGNUP_TRIGGER")()
                 post_signup_trigger.trigger(context={"user": user, "provider_data": data})
                 blockauth_logger.success("User signup confirmed", sanitize_log_context(request.data, {"user": user.id}))

--- a/docs/JWT_EXTENSION_GUIDE.md
+++ b/docs/JWT_EXTENSION_GUIDE.md
@@ -14,7 +14,7 @@ This guide explains the JWT extension implementation that allows any service to 
 │  │         JWT Token Manager                       │     │
 │  │                                                 │     │
 │  │  1. Base Claims (user_id, email)              │     │
-│  │  2. Custom Claims Provider Interface ←─────────┼─────┼── Fabric-Auth injects
+│  │  2. Custom Claims Provider Interface ←─────────┼─────┼── Your app injects
 │  │  3. Generate Token with merged claims          │     │    custom claims
 │  └────────────────────────────────────────────────┘     │
 └─────────────────────────────────────────────────────────┘
@@ -68,7 +68,7 @@ class SmartAccountClaimsProvider(CustomClaimsProvider):
         }
 ```
 
-**Note**: This is just an example implementation in fabric-auth. The blockauth library itself is completely generic and doesn't know about smart accounts or any specific data types.
+**Note**: This is just an example implementation. The blockauth library itself is completely generic and doesn't know about smart accounts or any specific data types.
 
 ## Usage Examples
 
@@ -126,7 +126,7 @@ deployed_chains = claims.get('deployed_chains', [])
   "iat": 1704063600,
   "type": "access",
 
-  // Custom claims from any provider (example from fabric-auth)
+  // Custom claims from your provider
   "smart_account": "0xABC123...",
   "smart_account_status": "ACTIVE",
   "deployed_chains": ["ethereum_sepolia", "base_sepolia"],

--- a/docs/WEBAUTHN_PASSKEY_DPIA.md
+++ b/docs/WEBAUTHN_PASSKEY_DPIA.md
@@ -61,7 +61,7 @@ This DPIA assesses the privacy impact of implementing WebAuthn/FIDO2 passkey aut
                     ════════════╪════════════  NETWORK BOUNDARY
                                 │
 ┌───────────────────────────────▼─────────────────────────────────────────┐
-│                        FABRICBLOC SERVERS                                │
+│                        BLOCKAUTH SERVERS                                │
 │                                                                          │
 │  ┌─────────────────────────────────────────────────────────────────┐   │
 │  │                    STORED DATA                                   │   │
@@ -104,7 +104,7 @@ This DPIA assesses the privacy impact of implementing WebAuthn/FIDO2 passkey aut
 | Is biometric data stored? | **NO** - never reaches servers |
 | Does Article 9 apply? | **NO** |
 
-**Conclusion**: Article 9 special category protections do **NOT** apply because FabricBloc servers never receive, process, or store biometric data.
+**Conclusion**: Article 9 special category protections do **NOT** apply because BlockAuth servers never receive, process, or store biometric data.
 
 ---
 


### PR DESCRIPTION
Removes all remaining FabricBloc/fabric-auth/fabric-wallet references from the codebase. Zero internal service names remaining.

6 files updated — docstrings, code comments, and documentation diagrams.