### PR TITLE
fix: tier 2 security gaps — replay protection, token rotation, progressive lockout

### DIFF
--- a/blockauth/conf.py
+++ b/blockauth/conf.py
@@ -57,6 +57,10 @@ DEFAULTS = {
     # other util classes
     "DEFAULT_NOTIFICATION_CLASS": "blockauth.notification.DummyNotification",
     "BLOCK_AUTH_LOGGER_CLASS": "blockauth.utils.logger.DummyLogger",
+    # Wallet replay protection
+    "WALLET_MESSAGE_TTL": 300,  # Signed wallet messages expire after 5 minutes
+    # Refresh token rotation
+    "ROTATE_REFRESH_TOKENS": True,  # Blacklist old refresh token on rotation
 }
 
 

--- a/blockauth/serializers/wallet_serializers.py
+++ b/blockauth/serializers/wallet_serializers.py
@@ -43,13 +43,18 @@ class WalletLoginSerializer(serializers.Serializer):
         message = data.get("message")
         signature = data.get("signature")
 
-        # Verify the signature
+        # Verify the signature (includes replay protection via nonce + timestamp)
         try:
             authenticator = WalletAuthenticator()
             if not authenticator.verify_signature(wallet_address, message, signature):
                 raise ValidationError(
                     detail={"signature": "Invalid signature. Signature verification failed."}, code=4009
                 )
+        except ValueError as e:
+            # Structured validation errors from replay/timestamp/nonce checks
+            raise ValidationError(detail={"message": str(e)}, code=4009)
+        except ValidationError:
+            raise
         except Exception as e:
             logger.error(f"Signature verification error: {str(e)}")
             raise ValidationError(detail={"signature": "Signature verification failed."}, code=4009)

--- a/blockauth/utils/tests/test_enhanced_throttle.py
+++ b/blockauth/utils/tests/test_enhanced_throttle.py
@@ -1,0 +1,135 @@
+"""
+Tests for EnhancedThrottle progressive lockout.
+
+Covers:
+- record_failure() triggers cooldown after max_failures
+- record_success() resets failure counter and cooldown
+- Cooldown blocks requests
+- Rate limiting (per-minute)
+- Daily limits
+"""
+
+import pytest
+from django.core.cache import cache
+
+from blockauth.utils.rate_limiter import EnhancedThrottle
+
+
+@pytest.fixture(autouse=True)
+def clear_cache():
+    cache.clear()
+    yield
+    cache.clear()
+
+
+class FakeRequest:
+    """Minimal request mock for throttle testing."""
+
+    def __init__(self, identifier="test@example.com", ip="192.168.1.1"):
+        self.data = {"identifier": identifier}
+        self.META = {"REMOTE_ADDR": ip, "HTTP_X_FORWARDED_FOR": ""}
+        self.user = type("User", (), {"is_authenticated": False, "id": None})()
+
+
+class TestEnhancedThrottleFailureTracking:
+    def test_cooldown_after_max_failures(self):
+        throttle = EnhancedThrottle(rate=(100, 60), max_failures=3, cooldown_minutes=15)
+        request = FakeRequest()
+        subject = "test_login"
+
+        # Record 3 failures (max_failures=3)
+        for _ in range(3):
+            throttle.record_failure(request, subject)
+
+        # Now request should be blocked (cooldown)
+        assert throttle.allow_request(request, subject) is False
+        assert throttle.get_block_reason() == "cooldown"
+
+    def test_under_max_failures_still_allowed(self):
+        throttle = EnhancedThrottle(rate=(100, 60), max_failures=5, cooldown_minutes=15)
+        request = FakeRequest()
+        subject = "test_login"
+
+        # Record 4 failures (under max_failures=5)
+        for _ in range(4):
+            throttle.record_failure(request, subject)
+
+        # Should still be allowed
+        assert throttle.allow_request(request, subject) is True
+
+    def test_record_success_resets_failures(self):
+        throttle = EnhancedThrottle(rate=(100, 60), max_failures=3, cooldown_minutes=15)
+        request = FakeRequest()
+        subject = "test_login"
+
+        # Record 2 failures then a success
+        throttle.record_failure(request, subject)
+        throttle.record_failure(request, subject)
+        throttle.record_success(request, subject)
+
+        # Record 2 more failures — should NOT trigger cooldown (counter was reset)
+        throttle.record_failure(request, subject)
+        throttle.record_failure(request, subject)
+
+        assert throttle.allow_request(request, subject) is True
+
+    def test_success_clears_cooldown(self):
+        throttle = EnhancedThrottle(rate=(100, 60), max_failures=2, cooldown_minutes=15)
+        request = FakeRequest()
+        subject = "test_login"
+
+        # Trigger cooldown
+        throttle.record_failure(request, subject)
+        throttle.record_failure(request, subject)
+        assert throttle.allow_request(request, subject) is False
+
+        # Simulate successful auth (e.g., admin unlock)
+        throttle.record_success(request, subject)
+        assert throttle.allow_request(request, subject) is True
+
+
+class TestEnhancedThrottleRateLimiting:
+    def test_rate_limit_exceeded(self):
+        throttle = EnhancedThrottle(rate=(2, 60), max_failures=100)
+        request = FakeRequest()
+        subject = "test_rate"
+
+        # First 2 requests succeed
+        assert throttle.allow_request(request, subject) is True
+        assert throttle.allow_request(request, subject) is True
+
+        # Third request blocked by rate limit
+        assert throttle.allow_request(request, subject) is False
+        assert throttle.get_block_reason() == "rate"
+
+
+class TestEnhancedThrottleDailyLimit:
+    def test_daily_limit_exceeded(self):
+        throttle = EnhancedThrottle(rate=(100, 60), daily_limit=3, max_failures=100)
+        request = FakeRequest()
+        subject = "test_daily"
+
+        # First 3 succeed
+        for _ in range(3):
+            assert throttle.allow_request(request, subject) is True
+
+        # Fourth blocked
+        assert throttle.allow_request(request, subject) is False
+        assert throttle.get_block_reason() == "daily"
+
+
+class TestDifferentIdentifiersIsolated:
+    def test_failures_isolated_per_identifier(self):
+        throttle = EnhancedThrottle(rate=(100, 60), max_failures=2, cooldown_minutes=15)
+        req_a = FakeRequest(identifier="user_a@test.com")
+        req_b = FakeRequest(identifier="user_b@test.com")
+        subject = "test_login"
+
+        # Trigger cooldown for user_a
+        throttle.record_failure(req_a, subject)
+        throttle.record_failure(req_a, subject)
+
+        # user_a blocked
+        assert throttle.allow_request(req_a, subject) is False
+        # user_b still free
+        assert throttle.allow_request(req_b, subject) is True

--- a/blockauth/utils/tests/test_token_blacklist.py
+++ b/blockauth/utils/tests/test_token_blacklist.py
@@ -1,0 +1,65 @@
+"""
+Tests for refresh token blacklist.
+
+Covers:
+- Blacklisting a token's jti
+- Detecting blacklisted tokens
+- Fresh tokens are not blacklisted
+- Empty/None jti handling
+- TTL expiry behavior
+"""
+
+import pytest
+from django.core.cache import cache
+
+from blockauth.utils.token_blacklist import blacklist_token, is_blacklisted
+
+
+@pytest.fixture(autouse=True)
+def clear_cache():
+    cache.clear()
+    yield
+    cache.clear()
+
+
+class TestBlacklistToken:
+    def test_blacklisted_token_is_detected(self):
+        blacklist_token("test-jti-001", remaining_ttl_seconds=3600)
+        assert is_blacklisted("test-jti-001") is True
+
+    def test_fresh_token_not_blacklisted(self):
+        assert is_blacklisted("never-seen-jti") is False
+
+    def test_different_jti_not_affected(self):
+        blacklist_token("jti-A", remaining_ttl_seconds=3600)
+        assert is_blacklisted("jti-B") is False
+
+    def test_empty_jti_blacklist_is_noop(self):
+        blacklist_token("", remaining_ttl_seconds=3600)
+        assert is_blacklisted("") is False
+
+    def test_none_jti_blacklist_is_noop(self):
+        blacklist_token(None, remaining_ttl_seconds=3600)
+        assert is_blacklisted(None) is False
+
+    def test_zero_remaining_ttl_still_blacklists(self):
+        """Even with 0 remaining TTL, we keep a 60s buffer."""
+        blacklist_token("jti-zero-ttl", remaining_ttl_seconds=0)
+        assert is_blacklisted("jti-zero-ttl") is True
+
+    def test_custom_cache_backend(self):
+        """Verify the cache override parameter works."""
+        custom_cache = {}
+
+        class FakeCache:
+            def set(self, key, value, ttl):
+                custom_cache[key] = value
+
+            def get(self, key):
+                return custom_cache.get(key)
+
+        fake = FakeCache()
+        blacklist_token("jti-custom", remaining_ttl_seconds=100, cache=fake)
+        assert is_blacklisted("jti-custom", cache=fake) is True
+        # Should NOT appear in default Django cache
+        assert is_blacklisted("jti-custom") is False

--- a/blockauth/utils/tests/test_wallet_replay_protection.py
+++ b/blockauth/utils/tests/test_wallet_replay_protection.py
@@ -1,0 +1,169 @@
+"""
+Tests for wallet signature replay protection.
+
+Covers:
+- Structured message parsing (nonce, timestamp)
+- Timestamp expiry rejection
+- Nonce reuse rejection
+- Valid signature flow with replay protection
+- Edge cases: future timestamps, missing fields, short nonces
+"""
+
+import json
+import time
+from unittest.mock import MagicMock
+
+import pytest
+from django.core.cache import cache
+
+from blockauth.utils.web3.wallet import WalletAuthenticator
+
+
+@pytest.fixture(autouse=True)
+def clear_cache():
+    cache.clear()
+    yield
+    cache.clear()
+
+
+@pytest.fixture
+def authenticator():
+    return WalletAuthenticator()
+
+
+def _make_message(nonce="test-nonce-0000-1111", timestamp=None, body="Sign in to TestApp"):
+    if timestamp is None:
+        timestamp = int(time.time())
+    return json.dumps({"nonce": nonce, "timestamp": timestamp, "body": body})
+
+
+class TestParseMessage:
+    def test_valid_json_message(self, authenticator):
+        msg = _make_message()
+        nonce, ts = authenticator._parse_message(msg)
+        assert len(nonce) >= 16
+        assert isinstance(ts, int)
+
+    def test_plain_text_rejected(self, authenticator):
+        with pytest.raises(ValueError, match="JSON"):
+            authenticator._parse_message("Sign in to MyApp")
+
+    def test_missing_nonce_rejected(self, authenticator):
+        msg = json.dumps({"timestamp": int(time.time()), "body": "hello"})
+        with pytest.raises(ValueError, match="nonce"):
+            authenticator._parse_message(msg)
+
+    def test_short_nonce_rejected(self, authenticator):
+        msg = json.dumps({"nonce": "short", "timestamp": int(time.time())})
+        with pytest.raises(ValueError, match="nonce"):
+            authenticator._parse_message(msg)
+
+    def test_missing_timestamp_rejected(self, authenticator):
+        msg = json.dumps({"nonce": "a" * 32, "body": "hello"})
+        with pytest.raises(ValueError, match="timestamp"):
+            authenticator._parse_message(msg)
+
+    def test_non_numeric_timestamp_rejected(self, authenticator):
+        msg = json.dumps({"nonce": "a" * 32, "timestamp": "not-a-number"})
+        with pytest.raises(ValueError, match="numeric"):
+            authenticator._parse_message(msg)
+
+
+class TestTimestampValidation:
+    def test_valid_timestamp(self, authenticator):
+        # Should not raise
+        authenticator._validate_timestamp(int(time.time()))
+
+    def test_expired_message_rejected(self, authenticator):
+        old_ts = int(time.time()) - 600  # 10 minutes ago, default TTL is 5 min
+        with pytest.raises(ValueError, match="expired"):
+            authenticator._validate_timestamp(old_ts)
+
+    def test_future_timestamp_rejected(self, authenticator):
+        future_ts = int(time.time()) + 120
+        with pytest.raises(ValueError, match="future"):
+            authenticator._validate_timestamp(future_ts)
+
+
+class TestNonceReuse:
+    def test_fresh_nonce_allowed(self, authenticator):
+        # Should not raise
+        authenticator._validate_nonce("unique-nonce-12345678", "0xabc")
+
+    def test_consumed_nonce_rejected(self, authenticator):
+        nonce = "unique-nonce-12345678"
+        address = "0xabc"
+        authenticator._consume_nonce(nonce, address)
+        with pytest.raises(ValueError, match="already been used"):
+            authenticator._validate_nonce(nonce, address)
+
+    def test_same_nonce_different_address_allowed(self, authenticator):
+        nonce = "unique-nonce-12345678"
+        authenticator._consume_nonce(nonce, "0xabc")
+        # Different address should still work
+        authenticator._validate_nonce(nonce, "0xdef")
+
+
+class TestVerifySignatureIntegration:
+    """Integration tests using mocked web3 signature recovery."""
+
+    ADDRESS = "0x" + "aB" * 20  # fake test address
+
+    def _mock_recovery(self, authenticator, recovered_address):
+        authenticator.w3.eth.account.recover_message = MagicMock(return_value=recovered_address)
+
+    def test_valid_signature_succeeds(self, authenticator):
+        msg = _make_message()
+        sig = "0x" + "ab" * 65  # noqa: S105 fake test signature
+        self._mock_recovery(authenticator, self.ADDRESS)
+
+        result = authenticator.verify_signature(self.ADDRESS, msg, sig)
+        assert result is True
+
+    def test_replay_same_nonce_fails(self, authenticator):
+        nonce = "fixed-nonce-for-replay-test1"
+        msg = _make_message(nonce=nonce)
+        sig = "0x" + "ab" * 65  # noqa: S105
+        self._mock_recovery(authenticator, self.ADDRESS)
+
+        # First call succeeds
+        assert authenticator.verify_signature(self.ADDRESS, msg, sig) is True
+
+        # Replay with same nonce fails
+        with pytest.raises(ValueError, match="already been used"):
+            authenticator.verify_signature(self.ADDRESS, msg, sig)
+
+    def test_wrong_address_returns_false(self, authenticator):
+        msg = _make_message()
+        sig = "0x" + "ab" * 65  # noqa: S105
+        self._mock_recovery(authenticator, "0xDEADBEEF" + "0" * 32)
+
+        result = authenticator.verify_signature(self.ADDRESS, msg, sig)
+        assert result is False
+
+    def test_expired_message_rejected_before_sig_check(self, authenticator):
+        msg = _make_message(timestamp=int(time.time()) - 600)
+        sig = "0x" + "ab" * 65  # noqa: S105
+
+        with pytest.raises(ValueError, match="expired"):
+            authenticator.verify_signature(self.ADDRESS, msg, sig)
+
+    def test_nonce_not_consumed_on_bad_signature(self, authenticator):
+        """If signature check fails, nonce should NOT be consumed."""
+        nonce = "test-nonce-bad-sig-01"
+        msg = _make_message(nonce=nonce)
+        sig = "0x" + "ab" * 65  # noqa: S105
+        self._mock_recovery(authenticator, "0xWRONG" + "0" * 34)
+
+        result = authenticator.verify_signature(self.ADDRESS, msg, sig)
+        assert result is False
+
+        # Nonce should still be valid (not consumed) since sig was wrong
+        authenticator._validate_nonce(nonce, self.ADDRESS)  # should not raise
+
+    def test_invalid_signature_length(self, authenticator):
+        msg = _make_message()
+        sig = "0x" + "ab" * 30  # too short
+
+        with pytest.raises(ValueError, match="length"):
+            authenticator.verify_signature(self.ADDRESS, msg, sig)

--- a/blockauth/utils/token_blacklist.py
+++ b/blockauth/utils/token_blacklist.py
@@ -1,0 +1,48 @@
+"""
+Refresh Token Blacklist
+
+Cache-backed blacklist that prevents reuse of rotated refresh tokens.
+When ``ROTATE_REFRESH_TOKENS`` is enabled (default), each refresh token
+can only be exchanged for a new pair once — the old token's ``jti`` is
+blacklisted for the remainder of its natural lifetime.
+
+Design decisions:
+- Uses Django's cache framework (no extra DB table required).
+- Blacklist entries auto-expire when the original token would have expired,
+  so the cache doesn't grow unboundedly.
+- ``is_blacklisted()`` is intentionally a simple cache lookup (O(1)).
+"""
+
+from django.core.cache import cache as default_cache
+
+_BLACKLIST_PREFIX = "jwt_blacklist_"
+
+
+def blacklist_token(jti: str, remaining_ttl_seconds: int, cache=None) -> None:
+    """
+    Add a token's ``jti`` to the blacklist.
+
+    Args:
+        jti: The JWT ID (``jti`` claim) of the token to blacklist.
+        remaining_ttl_seconds: Seconds until the token naturally expires.
+            The blacklist entry is kept for this long (plus a small buffer).
+        cache: Optional Django cache backend override (useful for testing).
+    """
+    if not jti:
+        return
+    _cache = cache or default_cache
+    # Keep entry a little longer than the token's remaining life to handle clock skew
+    ttl = max(int(remaining_ttl_seconds) + 60, 60)
+    _cache.set(f"{_BLACKLIST_PREFIX}{jti}", True, ttl)
+
+
+def is_blacklisted(jti: str, cache=None) -> bool:
+    """
+    Check whether a token's ``jti`` has been blacklisted.
+
+    Returns True if the token should be rejected.
+    """
+    if not jti:
+        return False
+    _cache = cache or default_cache
+    return bool(_cache.get(f"{_BLACKLIST_PREFIX}{jti}"))

--- a/blockauth/utils/web3/wallet.py
+++ b/blockauth/utils/web3/wallet.py
@@ -1,65 +1,168 @@
 """
 Web3 Wallet Authentication Utilities
 
-This module provides utilities for Ethereum wallet signature verification.
-It handles the cryptographic verification of messages signed by Web3 wallets
-like MetaMask, ensuring the authenticity of wallet-based authentication.
+This module provides utilities for Ethereum wallet signature verification
+with replay attack protection via nonce tracking and timestamp validation.
 
 Dependencies:
     - web3: Ethereum Web3 library for blockchain interactions
     - eth_account: Ethereum account utilities for signature verification
 """
 
+import hmac
+import json
+import logging
+import time
+
+from django.core.cache import cache as default_cache
 from eth_account.messages import encode_defunct
 from web3 import Web3
 from web3.middleware import ExtraDataToPOAMiddleware
 
+from blockauth.utils.config import get_config
+
+logger = logging.getLogger(__name__)
+
+# Default: signed messages are valid for 5 minutes
+DEFAULT_MESSAGE_TTL_SECONDS = 300
+
+# Nonce cache prefix and retention (keep nonces for 2x TTL to cover clock skew)
+_NONCE_CACHE_PREFIX = "wallet_nonce_"
+_NONCE_RETENTION_FACTOR = 2
+
 
 class WalletAuthenticator:
     """
-    Ethereum Wallet Signature Authenticator
+    Ethereum Wallet Signature Authenticator with replay protection.
 
-    This class provides methods to verify Ethereum wallet signatures.
-    It supports standard Ethereum signature verification using the Web3 library.
+    Signature verification now requires a structured JSON message containing:
+      - ``nonce``: a unique, single-use value (UUIDv4 recommended)
+      - ``timestamp``: Unix epoch seconds when the message was created
+      - ``body``: the human-readable sign-in text shown to the user
 
-    Example:
-        authenticator = WalletAuthenticator()
-        is_valid = authenticator.verify_signature(
-            address="0x742d35Cc6634C0532925a3b8D4C9db96C4b4d8b6",
-            message="ABC",
-            signature="0x1234567890abcdef1234567890abcdef1234567890abcd..."
-        )
+    A previously-used nonce is rejected. Messages older than
+    ``WALLET_MESSAGE_TTL`` seconds (default 300) are rejected.
+
+    Example (client-side message construction)::
+
+        {
+          "body": "Sign in to MyApp",
+          "nonce": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+          "timestamp": 1712345678
+        }
     """
 
-    def __init__(self):
-        # Initialize Web3 instance and inject POA middleware for compatibility
+    def __init__(self, cache=None):
         self.w3 = Web3()
         self.w3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)
+        self._cache = cache or default_cache
 
-    def verify_signature(self, address, message, signature):
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def verify_signature(self, address: str, message: str, signature: str) -> bool:
         """
-        Verify that the provided signature matches the message and wallet address.
+        Verify signature **and** enforce replay protection.
+
+        The ``message`` parameter must be a JSON string with ``nonce`` and
+        ``timestamp`` keys.  Plain-text messages are rejected.
 
         Args:
-            address (str): Ethereum wallet address (0x...)
-            message (str): The original message that was signed
-            signature (str): The signed message (hex string, e.g. '0x1234...')
+            address: Ethereum wallet address (0x...)
+            message: JSON-encoded message with nonce + timestamp
+            signature: Hex-encoded signature (with or without 0x prefix)
 
         Returns:
-            bool: True if the signature is valid and matches the address, else False
+            True when the signature is valid, the nonce is fresh, and the
+            timestamp is within the allowed TTL window.
 
         Raises:
-            Exception: If the signature is invalid or cannot be processed
+            ValueError: For any validation failure (replay, expired, bad format).
         """
+        # --- 1. Parse & validate the structured message -----------------
+        nonce, timestamp = self._parse_message(message)
+        self._validate_timestamp(timestamp)
+        self._validate_nonce(nonce, address)
+
+        # --- 2. Cryptographic signature check ---------------------------
+        signature_bytes = self._decode_signature(signature)
+        message_encoded = encode_defunct(text=message)
+        recovered_address = self.w3.eth.account.recover_message(message_encoded, signature=signature_bytes)
+
+        if not hmac.compare_digest(recovered_address.lower(), address.lower()):
+            return False
+
+        # --- 3. Mark nonce as consumed (only after sig is valid) --------
+        self._consume_nonce(nonce, address)
+        return True
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _decode_signature(signature: str) -> bytes:
         if signature.startswith("0x"):
             signature = signature[2:]
         signature = signature.strip().lower()
         if len(signature) != 130:
-            raise Exception("Invalid signature length")
+            raise ValueError("Invalid signature length")
         try:
-            signature_bytes = bytes.fromhex(signature)
+            return bytes.fromhex(signature)
         except ValueError:
-            raise Exception("Invalid hex in signature")
-        message_encoded = encode_defunct(text=message)
-        recovered_address = self.w3.eth.account.recover_message(message_encoded, signature=signature_bytes)
-        return recovered_address.lower() == address.lower()
+            raise ValueError("Invalid hex in signature")
+
+    @staticmethod
+    def _parse_message(message: str):
+        """Return (nonce, timestamp) from a JSON message string."""
+        try:
+            parsed = json.loads(message)
+        except (json.JSONDecodeError, TypeError):
+            raise ValueError("Wallet message must be JSON with 'nonce' and 'timestamp' fields.")
+
+        nonce = parsed.get("nonce")
+        timestamp = parsed.get("timestamp")
+
+        if not nonce or not isinstance(nonce, str) or len(nonce) < 16:
+            raise ValueError("Message must contain a 'nonce' string (min 16 chars).")
+        if timestamp is None:
+            raise ValueError("Message must contain a 'timestamp' field.")
+        try:
+            timestamp = int(timestamp)
+        except (TypeError, ValueError):
+            raise ValueError("Timestamp must be a numeric Unix epoch value.")
+
+        return nonce, timestamp
+
+    def _validate_timestamp(self, timestamp: int) -> None:
+        ttl = self._get_ttl()
+        now = int(time.time())
+        age = now - timestamp
+        if age < 0:
+            raise ValueError("Message timestamp is in the future.")
+        if age > ttl:
+            raise ValueError("Message has expired. Please sign a new message.")
+
+    def _validate_nonce(self, nonce: str, address: str) -> None:
+        """Reject a nonce that has already been consumed."""
+        cache_key = self._nonce_key(nonce, address)
+        if self._cache.get(cache_key):
+            raise ValueError("Nonce has already been used. Please sign a new message.")
+
+    def _consume_nonce(self, nonce: str, address: str) -> None:
+        """Mark a nonce as consumed so it cannot be replayed."""
+        ttl = self._get_ttl() * _NONCE_RETENTION_FACTOR
+        cache_key = self._nonce_key(nonce, address)
+        self._cache.set(cache_key, True, ttl)
+
+    @staticmethod
+    def _nonce_key(nonce: str, address: str) -> str:
+        return f"{_NONCE_CACHE_PREFIX}{address.lower()}_{nonce}"
+
+    @staticmethod
+    def _get_ttl() -> int:
+        try:
+            return int(get_config("WALLET_MESSAGE_TTL"))
+        except Exception:
+            return DEFAULT_MESSAGE_TTL_SECONDS

--- a/blockauth/views/basic_auth_views.py
+++ b/blockauth/views/basic_auth_views.py
@@ -43,7 +43,7 @@ from blockauth.utils.config import get_block_auth_user_model, get_config
 from blockauth.utils.custom_exception import ValidationErrorWithCode
 from blockauth.utils.generics import model_to_json, sanitize_log_context
 from blockauth.utils.logger import blockauth_logger
-from blockauth.utils.rate_limiter import OTPThrottle, RequestThrottle
+from blockauth.utils.rate_limiter import EnhancedThrottle, OTPThrottle, RequestThrottle
 from blockauth.utils.token import AUTH_TOKEN_CLASS, generate_auth_token
 
 logger = logging.getLogger(__name__)
@@ -255,9 +255,20 @@ class BasicAuthLoginView(APIView):
     permission_classes = (AllowAny,)
     serializer_class = BasicLoginSerializer
     authentication_classes = []
+    login_throttle = EnhancedThrottle(rate=(10, 60), max_failures=5, cooldown_minutes=15)
 
     @extend_schema(**basic_login_docs)
     def post(self, request):
+        # Check progressive lockout before processing
+        if not self.login_throttle.allow_request(request, "basic_login"):
+            reason = self.login_throttle.get_block_reason()
+            msg = (
+                "Too many failed login attempts. Please try again later."
+                if reason == "cooldown"
+                else "Rate limit exceeded. Please try again later."
+            )
+            return Response(data={"detail": msg}, status=status.HTTP_429_TOO_MANY_REQUESTS)
+
         serializer = self.serializer_class(data=request.data)
         blockauth_logger.info("Basic login attempt", sanitize_log_context(request.data))
         try:
@@ -284,14 +295,17 @@ class BasicAuthLoginView(APIView):
             except ImportError:
                 # Fall back to original implementation
                 access_token, refresh_token = generate_auth_token(token_class=AUTH_TOKEN_CLASS(), user_id=str(user.id))
+            self.login_throttle.record_success(request, "basic_login")
             blockauth_logger.success("Basic login successful", sanitize_log_context(request.data, {"user": user.id}))
             return Response(data={"access": access_token, "refresh": refresh_token}, status=status.HTTP_200_OK)
-        except ValidationError as e:
+        except (ValidationError, ValidationErrorWithCode) as e:
+            self.login_throttle.record_failure(request, "basic_login")
             blockauth_logger.warning(
                 "Basic login validation failed", sanitize_log_context(request.data, {"errors": e.detail})
             )
             raise ValidationErrorWithCode(detail=e.detail)
         except Exception as e:
+            self.login_throttle.record_failure(request, "basic_login")
             blockauth_logger.error("Basic login failed", sanitize_log_context(request.data, {"error": str(e)}))
             logger.error(f"Request failed: {e}", exc_info=True)
             raise APIException()
@@ -352,9 +366,19 @@ class PasswordlessLoginConfirmView(APIView):
     permission_classes = (AllowAny,)
     serializer_class = PasswordlessLoginConfirmationSerializer
     authentication_classes = []
+    login_throttle = EnhancedThrottle(rate=(10, 60), max_failures=5, cooldown_minutes=15)
 
     @extend_schema(**passwordless_confirm_docs)
     def post(self, request):
+        if not self.login_throttle.allow_request(request, "passwordless_login"):
+            reason = self.login_throttle.get_block_reason()
+            msg = (
+                "Too many failed login attempts. Please try again later."
+                if reason == "cooldown"
+                else "Rate limit exceeded. Please try again later."
+            )
+            return Response(data={"detail": msg}, status=status.HTTP_429_TOO_MANY_REQUESTS)
+
         serializer = self.serializer_class(data=request.data)
         blockauth_logger.info("Passwordless login confirmation attempt", sanitize_log_context(request.data))
         try:
@@ -395,17 +419,20 @@ class PasswordlessLoginConfirmView(APIView):
             except ImportError:
                 # Fall back to original implementation
                 access_token, refresh_token = generate_auth_token(token_class=AUTH_TOKEN_CLASS(), user_id=str(user.id))
+            self.login_throttle.record_success(request, "passwordless_login")
             blockauth_logger.success(
                 "Passwordless login confirmed", sanitize_log_context(request.data, {"user": user.id})
             )
             return Response(data={"access": access_token, "refresh": refresh_token}, status=status.HTTP_200_OK)
         except ValidationError as e:
+            self.login_throttle.record_failure(request, "passwordless_login")
             blockauth_logger.warning(
                 "Passwordless login confirmation validation failed",
                 sanitize_log_context(request.data, {"errors": e.detail}),
             )
             raise ValidationErrorWithCode(detail=e.detail)
         except Exception as e:
+            self.login_throttle.record_failure(request, "passwordless_login")
             blockauth_logger.error(
                 "Passwordless login confirmation failed", sanitize_log_context(request.data, {"error": str(e)})
             )
@@ -431,15 +458,27 @@ class AuthRefreshTokenView(APIView):
                 "Refresh token validation failed", sanitize_log_context(request.data, {"errors": serializer.errors})
             )
             raise ValidationErrorWithCode(detail=serializer.errors)
-        refresh_token = serializer.validated_data.get("refresh_token")
+        refresh_token_value = serializer.validated_data.get("refresh_token")
         token = AUTH_TOKEN_CLASS()
-        payload = token.decode_token(refresh_token)
+        payload = token.decode_token(refresh_token_value)
         try:
             if payload["type"] != "refresh":
                 blockauth_logger.error(
                     "Invalid refresh token type", sanitize_log_context(request.data, {"payload": payload})
                 )
                 raise AuthenticationFailed("Invalid token.")
+
+            # --- Refresh token rotation: reject blacklisted tokens ----------
+            from blockauth.utils.token_blacklist import is_blacklisted
+
+            old_jti = payload.get("jti")
+            if is_blacklisted(old_jti):
+                blockauth_logger.warning(
+                    "Blacklisted refresh token reuse attempted",
+                    sanitize_log_context(request.data, {"jti": old_jti}),
+                )
+                raise AuthenticationFailed("Invalid token.")
+
             user_id = payload["user_id"]
 
             # Get user to retrieve is_verified status
@@ -450,14 +489,29 @@ class AuthRefreshTokenView(APIView):
             try:
                 from blockauth.utils.token import generate_auth_token_with_custom_claims
 
-                access_token, refresh_token = generate_auth_token_with_custom_claims(token_class=token, user_id=user_id)
+                access_token, new_refresh_token = generate_auth_token_with_custom_claims(
+                    token_class=token, user_id=user_id
+                )
             except ImportError:
                 # Fall back to original implementation
-                access_token, refresh_token = generate_auth_token(token_class=token, user_id=user_id)
+                access_token, new_refresh_token = generate_auth_token(token_class=token, user_id=user_id)
+
+            # --- Blacklist the old refresh token so it can't be reused ------
+            if get_config("ROTATE_REFRESH_TOKENS") and old_jti:
+                import time
+
+                from blockauth.utils.token_blacklist import blacklist_token
+
+                exp = payload.get("exp", 0)
+                remaining_ttl = max(int(exp) - int(time.time()), 0)
+                blacklist_token(old_jti, remaining_ttl)
+
             blockauth_logger.success(
                 "Refresh token successful", sanitize_log_context(request.data, {"user_id": user_id})
             )
-            return Response(data={"access": access_token, "refresh": refresh_token}, status=status.HTTP_200_OK)
+            return Response(data={"access": access_token, "refresh": new_refresh_token}, status=status.HTTP_200_OK)
+        except AuthenticationFailed:
+            raise
         except Exception as e:
             blockauth_logger.error("Refresh token failed", sanitize_log_context(request.data, {"error": str(e)}))
             logger.error(f"Request failed: {e}", exc_info=True)

--- a/blockauth/views/wallet_auth_views.py
+++ b/blockauth/views/wallet_auth_views.py
@@ -15,6 +15,7 @@ from blockauth.utils.config import get_block_auth_user_model
 from blockauth.utils.custom_exception import ValidationErrorWithCode
 from blockauth.utils.generics import sanitize_log_context
 from blockauth.utils.logger import blockauth_logger
+from blockauth.utils.rate_limiter import EnhancedThrottle
 
 logger = logging.getLogger(__name__)
 _User = get_block_auth_user_model()
@@ -29,9 +30,19 @@ class WalletAuthLoginView(APIView):
     permission_classes = (AllowAny,)
     authentication_classes = []
     serializer_class = WalletLoginSerializer
+    login_throttle = EnhancedThrottle(rate=(10, 60), max_failures=5, cooldown_minutes=15)
 
     @extend_schema(**wallet_login_docs)
     def post(self, request):
+        if not self.login_throttle.allow_request(request, "wallet_login"):
+            reason = self.login_throttle.get_block_reason()
+            msg = (
+                "Too many failed login attempts. Please try again later."
+                if reason == "cooldown"
+                else "Rate limit exceeded. Please try again later."
+            )
+            return Response(data={"detail": msg}, status=status.HTTP_429_TOO_MANY_REQUESTS)
+
         serializer = self.serializer_class(data=request.data)
         blockauth_logger.info("Wallet login attempt", sanitize_log_context(request.data))
 
@@ -53,6 +64,8 @@ class WalletAuthLoginView(APIView):
                     "Wallet login successful", sanitize_log_context(request.data, {"user": auth_result["user"].id})
                 )
 
+            self.login_throttle.record_success(request, "wallet_login")
+
             # Return response
             return Response(
                 data={"access": auth_result["access_token"], "refresh": auth_result["refresh_token"]},
@@ -60,11 +73,13 @@ class WalletAuthLoginView(APIView):
             )
 
         except ValidationError as e:
+            self.login_throttle.record_failure(request, "wallet_login")
             blockauth_logger.warning(
                 "Wallet login validation failed", sanitize_log_context(request.data, {"errors": e.detail})
             )
             raise ValidationErrorWithCode(detail=e.detail)
         except Exception as e:
+            self.login_throttle.record_failure(request, "wallet_login")
             blockauth_logger.error("Wallet login failed", sanitize_log_context(request.data, {"error": str(e)}))
             logger.error(f"Wallet login request failed: {e}", exc_info=True)
             raise APIException()


### PR DESCRIPTION
## Summary

Implements all three **Tier 2 security gaps** from the v0.3.0 audit tracker (#57):

- **Wallet signature replay protection** (HIGH) — `verify_signature()` now requires structured JSON messages with `nonce` + `timestamp`. Used nonces are cached to prevent replay. Messages older than `WALLET_MESSAGE_TTL` (default 5min) are rejected. Address comparison uses `hmac.compare_digest()`.
- **Refresh token rotation** (HIGH) — New `token_blacklist` module (Django cache-backed). `AuthRefreshTokenView` blacklists the old refresh token's `jti` after issuing new tokens. Controlled by `ROTATE_REFRESH_TOKENS` setting (default True).
- **Progressive lockout via EnhancedThrottle** (MEDIUM) — `BasicAuthLoginView`, `PasswordlessLoginConfirmView`, and `WalletAuthLoginView` now call `record_failure()`/`record_success()`. 15-minute cooldown triggers after 5 consecutive failures.

## New settings

| Setting | Default | Description |
|---------|---------|-------------|
| `WALLET_MESSAGE_TTL` | `300` | Seconds before signed wallet messages expire |
| `ROTATE_REFRESH_TOKENS` | `True` | Blacklist old refresh token on rotation |

## Test plan

- [x] 18 tests for wallet replay protection (nonce reuse, expired timestamps, future timestamps, bad format, integration with mocked web3)
- [x] 7 tests for token blacklist (blacklist detection, edge cases, custom cache backend)
- [x] 7 tests for EnhancedThrottle wiring (cooldown after max failures, success resets, rate limits, daily limits, per-identifier isolation)
- [x] All 32 tests passing
- [x] No new lint issues introduced

Closes tier 2 of #57.