### PR TITLE
docs: add GitHub Pages documentation site

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,30 @@
+name: Deploy Docs
+on:
+  push:
+    branches: [main]
+    paths: ['docs/**', 'mkdocs.yml']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: pip install mkdocs-material
+      - run: mkdocs build
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site/
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,9 @@ htmlcov/
 .env
 .env.*
 
+# MkDocs
+site/
+
 # Legacy
 main.py
 identifier.sqlite

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,55 @@
+# Changelog
+
+## v0.4.0 (Unreleased)
+
+### Added
+- GitHub Pages documentation site with MkDocs Material
+- Comprehensive guides for all authentication methods
+
+### Security
+- Wallet replay protection with configurable message TTL (`WALLET_MESSAGE_TTL`)
+- Refresh token rotation with blacklisting (`ROTATE_REFRESH_TOKENS`)
+- Progressive lockout for repeated auth failures
+- Timing-attack remediation with constant-time comparisons
+- Rate limiter hardening
+- Error message sanitization to prevent information leakage
+
+## v0.3.0
+
+### Added
+- **Step-Up Authentication** -- RFC 9470 receipt-based step-up auth (`blockauth.stepup`)
+- **WebAuthn/Passkey Authentication** -- FIDO2 support for Face ID, Touch ID, Windows Hello
+- **TOTP/2FA** -- Time-based one-time passwords with pluggable storage
+- **Custom JWT Claims** -- Pluggable claims provider architecture
+- **KDF System** -- PBKDF2 and Argon2 key derivation for Web2-to-Web3 bridging
+- **Feature Flags** -- Enable/disable any auth feature independently
+- **Rate Limiting** -- Per-request and OTP-specific throttling
+- Email verification flow
+- Password change and reset triggers
+- Wallet email add endpoint
+- OpenAPI/Swagger documentation via drf-spectacular
+
+### Security
+- Algorithm pinning on JWT decode
+- OTP generation with `secrets.choice()`
+- Signature malleability protection for wallet auth
+- Sensitive field filtering in logs
+
+## v0.2.0
+
+### Added
+- OAuth integration (Google, Facebook, LinkedIn)
+- Passwordless login via OTP
+- Web3 wallet authentication
+- Trigger system for auth events
+- Custom notification class support
+
+## v0.1.0
+
+### Added
+- Initial release
+- JWT authentication with HS256
+- Email/password signup and login
+- Token refresh
+- Password reset
+- Django REST Framework integration

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -1,0 +1,217 @@
+# Configuration
+
+All BlockAuth configuration lives in `BLOCK_AUTH_SETTINGS` in your Django settings module. Every key has a sensible default.
+
+## Minimal Configuration
+
+```python
+BLOCK_AUTH_SETTINGS = {
+    'BLOCK_AUTH_USER_MODEL': 'myapp.User',
+}
+```
+
+This enables all features with default token lifetimes and HS256 signing using Django's `SECRET_KEY`.
+
+## Full Configuration Reference
+
+```python
+from datetime import timedelta
+
+BLOCK_AUTH_SETTINGS = {
+    # --- User Model ---
+    'BLOCK_AUTH_USER_MODEL': 'myapp.User',
+
+    # --- JWT Settings ---
+    'SECRET_KEY': 'your-jwt-secret',              # Falls back to Django SECRET_KEY
+    'ALGORITHM': 'HS256',                          # HS256, RS256, or ES256
+    'ACCESS_TOKEN_LIFETIME': timedelta(seconds=3600),  # Default: 1 hour
+    'REFRESH_TOKEN_LIFETIME': timedelta(days=1),       # Default: 1 day
+    'AUTH_HEADER_NAME': 'HTTP_AUTHORIZATION',
+    'USER_ID_FIELD': 'id',
+
+    # Asymmetric signing (RS256/ES256) -- set these instead of SECRET_KEY
+    'JWT_PRIVATE_KEY': None,   # PEM-encoded private key
+    'JWT_PUBLIC_KEY': None,    # PEM-encoded public key
+
+    # --- OTP Settings ---
+    'OTP_VALIDITY': timedelta(minutes=1),   # Default: 1 minute
+    'OTP_LENGTH': 6,                        # Default: 6 digits
+
+    # --- Rate Limiting ---
+    'REQUEST_LIMIT': (3, 30),  # (max_requests, window_seconds)
+
+    # --- Email Verification ---
+    'EMAIL_VERIFICATION_REQUIRED': False,
+
+    # --- Refresh Token Rotation ---
+    'ROTATE_REFRESH_TOKENS': True,  # Blacklist old refresh token on rotation
+
+    # --- Wallet Settings ---
+    'WALLET_MESSAGE_TTL': 300,  # Signed messages expire after 5 minutes
+
+    # --- Feature Flags ---
+    'FEATURES': {
+        'SIGNUP': True,
+        'BASIC_LOGIN': True,
+        'PASSWORDLESS_LOGIN': True,
+        'WALLET_LOGIN': True,
+        'TOKEN_REFRESH': True,
+        'PASSWORD_RESET': True,
+        'PASSWORD_CHANGE': True,
+        'EMAIL_CHANGE': True,
+        'EMAIL_VERIFICATION': True,
+        'WALLET_EMAIL_ADD': True,
+        'SOCIAL_AUTH': True,
+        'PASSKEY_AUTH': True,
+    },
+
+    # --- OAuth Providers ---
+    'AUTH_PROVIDERS': {
+        'GOOGLE': {
+            'CLIENT_ID': os.getenv('GOOGLE_CLIENT_ID'),
+            'CLIENT_SECRET': os.getenv('GOOGLE_CLIENT_SECRET'),
+            'REDIRECT_URI': os.getenv('GOOGLE_REDIRECT_URI'),
+        },
+        'LINKEDIN': {
+            'CLIENT_ID': os.getenv('LINKEDIN_CLIENT_ID'),
+            'CLIENT_SECRET': os.getenv('LINKEDIN_CLIENT_SECRET'),
+            'REDIRECT_URI': os.getenv('LINKEDIN_REDIRECT_URI'),
+        },
+        'FACEBOOK': {
+            'CLIENT_ID': os.getenv('FACEBOOK_CLIENT_ID'),
+            'CLIENT_SECRET': os.getenv('FACEBOOK_CLIENT_SECRET'),
+            'REDIRECT_URI': os.getenv('FACEBOOK_REDIRECT_URI'),
+        },
+    },
+
+    # --- Triggers ---
+    'PRE_SIGNUP_TRIGGER': 'blockauth.triggers.DummyPreSignupTrigger',
+    'POST_SIGNUP_TRIGGER': 'blockauth.triggers.DummyPostSignupTrigger',
+    'POST_LOGIN_TRIGGER': 'blockauth.triggers.DummyPostLoginTrigger',
+    'POST_PASSWORD_CHANGE_TRIGGER': 'blockauth.triggers.DummyPostPasswordChangeTrigger',
+    'POST_PASSWORD_RESET_TRIGGER': 'blockauth.triggers.DummyPostPasswordResetTrigger',
+
+    # --- Notification & Logging ---
+    'DEFAULT_NOTIFICATION_CLASS': 'blockauth.notification.DummyNotification',
+    'BLOCK_AUTH_LOGGER_CLASS': 'blockauth.utils.logger.DummyLogger',
+
+    # --- Client App ---
+    'CLIENT_APP_URL': 'http://localhost:3000',
+}
+```
+
+## Feature Flags
+
+Feature flags control which endpoints are registered. Disabling a feature removes its URL patterns entirely.
+
+| Flag | Default | Controls |
+|------|---------|----------|
+| `SIGNUP` | `True` | `signup/`, `signup/otp/resend/`, `signup/confirm/` |
+| `BASIC_LOGIN` | `True` | `login/basic/` |
+| `PASSWORDLESS_LOGIN` | `True` | `login/passwordless/`, `login/passwordless/confirm/` |
+| `WALLET_LOGIN` | `True` | `login/wallet/` |
+| `TOKEN_REFRESH` | `True` | `token/refresh/` |
+| `PASSWORD_RESET` | `True` | `password/reset/`, `password/reset/confirm/` |
+| `PASSWORD_CHANGE` | `True` | `password/change/` |
+| `EMAIL_CHANGE` | `True` | `email/change/`, `email/change/confirm/` |
+| `EMAIL_VERIFICATION` | `True` | Email verification requirement |
+| `WALLET_EMAIL_ADD` | `True` | `wallet/email/add/` |
+| `SOCIAL_AUTH` | `True` | OAuth provider endpoints |
+| `PASSKEY_AUTH` | `True` | `passkey/*` endpoints |
+
+## JWT Algorithm Configuration
+
+### HS256 (default, symmetric)
+
+```python
+BLOCK_AUTH_SETTINGS = {
+    'ALGORITHM': 'HS256',
+    'SECRET_KEY': 'your-secret-key',  # Or omit to use Django SECRET_KEY
+}
+```
+
+### RS256 (asymmetric)
+
+```python
+BLOCK_AUTH_SETTINGS = {
+    'ALGORITHM': 'RS256',
+    'JWT_PRIVATE_KEY': open('/path/to/private.pem').read(),
+    'JWT_PUBLIC_KEY': open('/path/to/public.pem').read(),
+}
+```
+
+### ES256 (asymmetric, ECDSA)
+
+```python
+BLOCK_AUTH_SETTINGS = {
+    'ALGORITHM': 'ES256',
+    'JWT_PRIVATE_KEY': open('/path/to/ec-private.pem').read(),
+    'JWT_PUBLIC_KEY': open('/path/to/ec-public.pem').read(),
+}
+```
+
+!!! warning
+    For asymmetric algorithms, never expose private keys in version control. Use environment variables or a secrets manager.
+
+## Trigger System
+
+Triggers fire at authentication events. Implement your own by subclassing `BaseTrigger`:
+
+```python
+from blockauth.triggers import BaseTrigger
+
+class MyPostSignupTrigger(BaseTrigger):
+    def execute(self, context: dict):
+        # context contains: user_id, username, email, trigger_type, timestamp
+        send_welcome_email(context['email'])
+```
+
+```python
+BLOCK_AUTH_SETTINGS = {
+    'POST_SIGNUP_TRIGGER': 'myapp.triggers.MyPostSignupTrigger',
+}
+```
+
+## Notification Class
+
+Override the notification class to send OTPs via your preferred channel (email, SMS, push):
+
+```python
+from blockauth.notification import BaseNotification
+
+class MyNotification(BaseNotification):
+    def send(self, event):
+        # event.recipient, event.otp, event.subject
+        send_email(to=event.recipient, body=f"Your code: {event.otp}")
+```
+
+```python
+BLOCK_AUTH_SETTINGS = {
+    'DEFAULT_NOTIFICATION_CLASS': 'myapp.notifications.MyNotification',
+}
+```
+
+## OpenAPI / Swagger Documentation
+
+BlockAuth works with `drf-spectacular` for auto-generated API docs:
+
+```python
+INSTALLED_APPS = [
+    'drf_spectacular',
+    'drf_spectacular_sidecar',
+]
+
+REST_FRAMEWORK = {
+    'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema',
+}
+
+SPECTACULAR_SETTINGS = {
+    'TITLE': 'My API',
+    'VERSION': '1.0.0',
+}
+```
+
+## Next Steps
+
+- [Quick Start](quick-start.md) -- First auth flow in 5 minutes
+- [Settings Reference](../reference/settings.md) -- Every setting with its default

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -1,0 +1,130 @@
+# Installation
+
+## Requirements
+
+- Python >= 3.12
+- Django >= 5.1
+- Django REST Framework >= 3.15
+
+### Core Dependencies
+
+| Package | Version | Purpose |
+|---------|---------|---------|
+| `django` | 5.1.4 | Web framework |
+| `djangorestframework` | 3.15.2 | API framework |
+| `pyjwt` | 2.9.0 | JWT tokens |
+| `requests` | 2.32.3 | HTTP client (OAuth) |
+| `drf-spectacular` | 0.28.0 | OpenAPI schema |
+
+### Optional Dependencies (KDF System)
+
+| Package | Version | Purpose |
+|---------|---------|---------|
+| `cryptography` | >= 41.0.0 | AES-256-GCM encryption |
+| `web3` | >= 6.0.0 | Ethereum integration |
+| `eth-account` | >= 0.9.0 | Wallet management |
+| `argon2-cffi` | >= 21.3.0 | Argon2 KDF algorithm |
+
+## Install Methods
+
+### From GitHub Releases (recommended)
+
+```bash
+pip install https://github.com/BloclabsHQ/auth-pack/releases/download/v0.3.0/blockauth-0.3.0-py3-none-any.whl
+```
+
+With uv:
+
+```bash
+uv add "blockauth @ https://github.com/BloclabsHQ/auth-pack/releases/download/v0.3.0/blockauth-0.3.0-py3-none-any.whl"
+```
+
+### From Git (development)
+
+```bash
+pip install git+https://github.com/BloclabsHQ/auth-pack.git@dev
+```
+
+With uv:
+
+```bash
+uv add "blockauth @ git+https://github.com/BloclabsHQ/auth-pack.git@dev"
+```
+
+### Editable Mode (local development)
+
+```bash
+git clone https://github.com/BloclabsHQ/auth-pack.git
+pip install -e ./auth-pack
+```
+
+## Django Setup
+
+### 1. Add to INSTALLED_APPS
+
+```python
+INSTALLED_APPS = [
+    # ...
+    'rest_framework',
+    'blockauth',
+    # ...
+]
+```
+
+### 2. Configure DRF Authentication
+
+```python
+REST_FRAMEWORK = {
+    'DEFAULT_AUTHENTICATION_CLASSES': (
+        'blockauth.authentication.JWTAuthentication',
+    ),
+}
+```
+
+### 3. Add URL Patterns
+
+```python
+from django.urls import path, include
+
+urlpatterns = [
+    path('auth/', include('blockauth.urls')),
+]
+```
+
+### 4. Create Your User Model
+
+Your user model must inherit from `BlockUser`:
+
+```python
+# myapp/models.py
+from blockauth.models import BlockUser
+
+class User(BlockUser):
+    # Add any custom fields
+    pass
+```
+
+Then set it in your settings:
+
+```python
+BLOCK_AUTH_SETTINGS = {
+    'BLOCK_AUTH_USER_MODEL': 'myapp.User',
+}
+```
+
+### 5. Run Migrations
+
+```bash
+python manage.py migrate
+```
+
+## Verify Installation
+
+```python
+python -c "import blockauth; print(blockauth.__version__)"
+```
+
+## Next Steps
+
+- [Configuration](configuration.md) -- Configure features, tokens, and providers
+- [Quick Start](quick-start.md) -- Build your first auth flow in 5 minutes

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -1,0 +1,131 @@
+# Quick Start
+
+Get BlockAuth running in 5 minutes. This guide covers install, configuration, and your first login.
+
+## 1. Install
+
+```bash
+pip install https://github.com/BloclabsHQ/auth-pack/releases/download/v0.3.0/blockauth-0.3.0-py3-none-any.whl
+```
+
+## 2. Create Your User Model
+
+```python
+# myapp/models.py
+from blockauth.models import BlockUser
+
+class User(BlockUser):
+    pass
+```
+
+## 3. Configure Django Settings
+
+```python
+# settings.py
+from datetime import timedelta
+
+INSTALLED_APPS = [
+    'django.contrib.contenttypes',
+    'django.contrib.auth',
+    'rest_framework',
+    'blockauth',
+    'myapp',
+]
+
+REST_FRAMEWORK = {
+    'DEFAULT_AUTHENTICATION_CLASSES': (
+        'blockauth.authentication.JWTAuthentication',
+    ),
+}
+
+BLOCK_AUTH_SETTINGS = {
+    'BLOCK_AUTH_USER_MODEL': 'myapp.User',
+    'ACCESS_TOKEN_LIFETIME': timedelta(hours=1),
+    'REFRESH_TOKEN_LIFETIME': timedelta(days=7),
+    'DEFAULT_NOTIFICATION_CLASS': 'myapp.notifications.ConsoleNotification',
+}
+```
+
+## 4. Add URLs
+
+```python
+# urls.py
+from django.urls import path, include
+
+urlpatterns = [
+    path('auth/', include('blockauth.urls')),
+]
+```
+
+## 5. Create a Notification Class
+
+BlockAuth sends OTPs through a notification class. For development, print to console:
+
+```python
+# myapp/notifications.py
+class ConsoleNotification:
+    def send(self, event):
+        print(f"OTP for {event.recipient}: {event.otp}")
+```
+
+## 6. Run Migrations
+
+```bash
+python manage.py migrate
+```
+
+## 7. Test the Flow
+
+### Sign Up
+
+```bash
+curl -X POST http://localhost:8000/auth/signup/ \
+  -H "Content-Type: application/json" \
+  -d '{"email": "user@example.com", "password": "SecurePass123!"}'
+```
+
+Check your console for the OTP, then confirm:
+
+```bash
+curl -X POST http://localhost:8000/auth/signup/confirm/ \
+  -H "Content-Type: application/json" \
+  -d '{"email": "user@example.com", "otp": "123456"}'
+```
+
+### Login
+
+```bash
+curl -X POST http://localhost:8000/auth/login/basic/ \
+  -H "Content-Type: application/json" \
+  -d '{"email": "user@example.com", "password": "SecurePass123!"}'
+```
+
+Response:
+
+```json
+{
+  "access": "eyJhbGciOiJIUzI1NiIs...",
+  "refresh": "eyJhbGciOiJIUzI1NiIs..."
+}
+```
+
+### Access a Protected Endpoint
+
+```bash
+curl http://localhost:8000/api/protected/ \
+  -H "Authorization: Bearer eyJhbGciOiJIUzI1NiIs..."
+```
+
+### Refresh Token
+
+```bash
+curl -X POST http://localhost:8000/auth/token/refresh/ \
+  -H "Content-Type: application/json" \
+  -d '{"refresh": "eyJhbGciOiJIUzI1NiIs..."}'
+```
+
+## What's Next?
+
+- [Signup & Login](../guides/signup-login.md) -- All authentication flows in detail
+- [JWT Tokens](../guides/jwt-tokens.md) -- Custom claims, token structure, microservice patterns
+- [Configuration](configuration.md) -- Full settings reference

--- a/docs/guides/jwt-tokens.md
+++ b/docs/guides/jwt-tokens.md
@@ -1,0 +1,223 @@
+# JWT Tokens
+
+BlockAuth uses JWT (JSON Web Tokens) for stateless authentication. Tokens are signed with HS256 by default, with RS256 and ES256 support for asymmetric signing.
+
+## Token Structure
+
+### Access Token Payload
+
+```json
+{
+  "user_id": "550e8400-e29b-41d4-a716-446655440000",
+  "exp": 1640995200,
+  "iat": 1640991600,
+  "type": "access"
+}
+```
+
+### Refresh Token Payload
+
+```json
+{
+  "user_id": "550e8400-e29b-41d4-a716-446655440000",
+  "exp": 1640995200,
+  "iat": 1640991600,
+  "type": "refresh"
+}
+```
+
+Access tokens are short-lived (default: 1 hour). Refresh tokens are longer-lived (default: 1 day) and used to obtain new token pairs.
+
+## Token Generation
+
+```python
+from blockauth.utils.token import generate_auth_token, AUTH_TOKEN_CLASS
+
+access_token, refresh_token = generate_auth_token(
+    token_class=AUTH_TOKEN_CLASS(),
+    user_id=str(user.id),
+)
+```
+
+## Token Decoding
+
+```python
+from blockauth.utils.token import AUTH_TOKEN_CLASS
+
+token_instance = AUTH_TOKEN_CLASS()
+payload = token_instance.decode_token(access_token)
+
+user_id = payload['user_id']
+token_type = payload['type']  # "access" or "refresh"
+```
+
+## Custom Token Configuration
+
+```python
+from blockauth.utils.token import Token
+from datetime import timedelta
+
+custom_token = Token(
+    secret_key="your-custom-secret",
+    algorithm="HS256",
+)
+
+access_token = custom_token.generate_token(
+    user_id="550e8400-e29b-41d4-a716-446655440000",
+    token_type="access",
+    token_lifetime=timedelta(hours=2),
+)
+```
+
+## Custom Claims
+
+BlockAuth's claims provider architecture lets you add custom data to JWT tokens without modifying the core package.
+
+### Create a Claims Provider
+
+```python
+# myapp/jwt_claims.py
+from blockauth.jwt.interfaces import CustomClaimsProvider
+
+class MyClaimsProvider(CustomClaimsProvider):
+    def get_custom_claims(self, user):
+        return {
+            "role": user.role,
+            "org_id": str(user.organization_id),
+            "permissions": list(user.get_permissions()),
+        }
+
+    def validate_custom_claims(self, claims):
+        return "role" in claims
+```
+
+### Register the Provider
+
+Register in your Django app's `ready()` method:
+
+```python
+# myapp/apps.py
+from django.apps import AppConfig
+
+class MyAppConfig(AppConfig):
+    name = 'myapp'
+
+    def ready(self):
+        from blockauth.jwt.token_manager import jwt_manager
+        from .jwt_claims import MyClaimsProvider
+
+        jwt_manager.register_claims_provider(MyClaimsProvider())
+```
+
+### Multiple Providers
+
+You can register multiple providers. Claims are merged into the final token:
+
+```python
+jwt_manager.register_claims_provider(AuthClaimsProvider())
+jwt_manager.register_claims_provider(BillingClaimsProvider())
+```
+
+### Resulting Token
+
+```json
+{
+  "user_id": "123",
+  "exp": 1704067200,
+  "iat": 1704063600,
+  "type": "access",
+  "role": "admin",
+  "org_id": "org-456",
+  "permissions": ["read", "write"]
+}
+```
+
+!!! warning
+    Custom claims cannot override base claims (`user_id`, `exp`, `iat`, `type`). Keep claims minimal -- large tokens impact performance and may exceed header size limits.
+
+## Token Validation in External Services
+
+### Python
+
+```python
+import jwt
+
+def validate_blockauth_token(token_string, secret_key):
+    try:
+        payload = jwt.decode(
+            token_string,
+            secret_key,
+            algorithms=["HS256"],
+            options={"verify_signature": True, "verify_exp": True},
+        )
+        if "user_id" not in payload or "type" not in payload:
+            return None
+        return payload
+    except jwt.ExpiredSignatureError:
+        return None
+    except jwt.InvalidSignatureError:
+        return None
+```
+
+### JavaScript
+
+```javascript
+const jwt = require('jsonwebtoken');
+
+function validateBlockAuthToken(token, secretKey) {
+    try {
+        const payload = jwt.verify(token, secretKey, {
+            algorithms: ['HS256'],
+        });
+        if (!payload.user_id || !payload.type) return null;
+        return payload;
+    } catch (error) {
+        return null;
+    }
+}
+```
+
+## Microservice Patterns
+
+### Centralized Auth, Distributed Validation
+
+Each service validates tokens independently using the shared secret or public key:
+
+```python
+# middleware.py
+from blockauth.utils.token import AUTH_TOKEN_CLASS
+
+class BlockAuthMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+        self.token_instance = AUTH_TOKEN_CLASS()
+
+    def __call__(self, request):
+        auth_header = request.META.get('HTTP_AUTHORIZATION', '')
+        if auth_header.startswith('Bearer '):
+            token = auth_header.split(' ')[1]
+            try:
+                payload = self.token_instance.decode_token(token)
+                request.user_id = payload['user_id']
+            except Exception:
+                pass
+        return self.get_response(request)
+```
+
+## Token Refresh Rotation
+
+When `ROTATE_REFRESH_TOKENS` is `True` (default), each refresh request:
+
+1. Validates the refresh token
+2. Blacklists the old refresh token
+3. Issues a new access + refresh token pair
+
+This limits the damage if a refresh token is compromised.
+
+## Security Best Practices
+
+- Store access tokens in memory only (never `localStorage`)
+- Store refresh tokens in secure HTTP-only cookies
+- Use short access token lifetimes (15-60 minutes)
+- Always pin the algorithm on decode: `algorithms=["HS256"]`
+- For asymmetric signing, keep private keys in a secrets manager

--- a/docs/guides/kdf-system.md
+++ b/docs/guides/kdf-system.md
@@ -1,0 +1,116 @@
+# KDF System
+
+The Key Derivation Function (KDF) system bridges Web2 and Web3 by generating blockchain wallets from email/password credentials. Users get blockchain accounts without managing private keys.
+
+## How It Works
+
+```
+Email + Password --> KDF --> Private Key --> EOA --> Smart Contract Account
+     |               |          |            |              |
+  Web2 Auth    Key Derivation  Hidden    Internal     User's Wallet
+```
+
+The same email/password always generates the same private key (deterministic derivation). The key is then encrypted with dual keys (user password + platform key) for storage.
+
+## Services
+
+### PBKDF2Service
+
+Direct key derivation using PBKDF2-SHA256:
+
+```python
+from blockauth.kdf.services import PBKDF2Service
+
+service = PBKDF2Service(iterations=100000)
+private_key = service.derive_key(email, password, salt)
+```
+
+### Argon2Service
+
+Key derivation using Argon2id (memory-hard, more resistant to GPU attacks):
+
+```python
+from blockauth.kdf.services import Argon2Service
+
+service = Argon2Service()
+private_key = service.derive_key(email, password, salt)
+```
+
+!!! note
+    Argon2 requires the `argon2-cffi` package: `pip install argon2-cffi`
+
+### KeyDerivationService
+
+Full key derivation with wallet address generation:
+
+```python
+from blockauth.kdf.services import KeyDerivationService
+
+kds = KeyDerivationService()
+private_key = kds.derive_private_key(email, password, salt)
+address = kds.get_wallet_address(email, password, salt)
+```
+
+### KDFManager
+
+Manages dual encryption (user key + platform key):
+
+```python
+from blockauth.kdf.services import KDFManager
+
+manager = KDFManager(master_key, platform_salt)
+```
+
+The KDFManager handles:
+
+- Deriving user-specific encryption keys
+- Encrypting private keys with AES-256-GCM
+- Platform-level backup encryption
+- Key recovery when needed
+
+## Configuration
+
+```python
+BLOCK_AUTH_SETTINGS = {
+    'KDF_ENABLED': True,
+    'KDF_ALGORITHM': 'pbkdf2_sha256',       # or 'argon2id'
+    'KDF_ITERATIONS': 100000,                # Production: 100k+
+    'KDF_SECURITY_LEVEL': 'HIGH',            # LOW, MEDIUM, HIGH, CRITICAL
+    'KDF_MASTER_SALT': 'your-32-char-minimum-salt',
+    'MASTER_ENCRYPTION_KEY': '0x' + '64-char-hex-key',
+    'PLATFORM_MASTER_SALT': 'your-platform-salt-32-chars-minimum',
+}
+```
+
+## Security Architecture
+
+```
+Layer 1: User Credentials (Email + Password)
+Layer 2: Key Derivation (PBKDF2/Argon2 with 100k+ iterations)
+Layer 3: Private Key Generation (32-byte deterministic)
+Layer 4: Dual Encryption (AES-256-GCM)
+Layer 5: Secure Storage (Database + Platform key backup)
+```
+
+All key comparisons use `hmac.compare_digest()` for timing-safe comparison.
+
+## Use Cases
+
+- **E-commerce** -- users own NFTs without crypto knowledge
+- **Gaming** -- true ownership of in-game items on blockchain
+- **DeFi** -- access decentralized finance with familiar email/password login
+- **Governance** -- participate in DAOs without MetaMask
+
+## Requirements
+
+The KDF system requires additional dependencies:
+
+```bash
+pip install cryptography>=41.0.0 web3>=6.0.0 eth-account>=0.9.0
+```
+
+For Argon2:
+
+```bash
+pip install argon2-cffi>=21.3.0
+```

--- a/docs/guides/oauth.md
+++ b/docs/guides/oauth.md
@@ -1,0 +1,113 @@
+# OAuth Providers
+
+BlockAuth supports Google, Facebook, and LinkedIn OAuth2 login. Each provider uses a redirect-based flow and requires the `SOCIAL_AUTH` feature flag.
+
+## Provider Configuration
+
+Configure providers in `BLOCK_AUTH_SETTINGS['AUTH_PROVIDERS']`:
+
+```python
+import os
+
+BLOCK_AUTH_SETTINGS = {
+    'AUTH_PROVIDERS': {
+        'GOOGLE': {
+            'CLIENT_ID': os.getenv('GOOGLE_CLIENT_ID'),
+            'CLIENT_SECRET': os.getenv('GOOGLE_CLIENT_SECRET'),
+            'REDIRECT_URI': os.getenv('GOOGLE_REDIRECT_URI'),
+        },
+        'LINKEDIN': {
+            'CLIENT_ID': os.getenv('LINKEDIN_CLIENT_ID'),
+            'CLIENT_SECRET': os.getenv('LINKEDIN_CLIENT_SECRET'),
+            'REDIRECT_URI': os.getenv('LINKEDIN_REDIRECT_URI'),
+        },
+        'FACEBOOK': {
+            'CLIENT_ID': os.getenv('FACEBOOK_CLIENT_ID'),
+            'CLIENT_SECRET': os.getenv('FACEBOOK_CLIENT_SECRET'),
+            'REDIRECT_URI': os.getenv('FACEBOOK_REDIRECT_URI'),
+        },
+    },
+}
+```
+
+!!! warning
+    Never hardcode client secrets. Use environment variables or a secrets manager.
+
+Only providers with configuration present will have their URL patterns registered.
+
+## OAuth Flow
+
+All providers follow the same pattern:
+
+1. **Initiate**: `GET /auth/{provider}/` redirects the user to the provider's consent page
+2. **Callback**: Provider redirects back to `GET /auth/{provider}/callback/` with an authorization code
+3. **Token exchange**: BlockAuth exchanges the code for user info and returns JWT tokens
+
+## Google
+
+### Setup
+
+1. Go to the [Google Cloud Console](https://console.cloud.google.com/)
+2. Create OAuth 2.0 credentials (Web application)
+3. Add your redirect URI: `https://yourdomain.com/auth/google/callback/`
+4. Set `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, and `GOOGLE_REDIRECT_URI`
+
+### Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/auth/google/` | Redirects to Google consent |
+| GET | `/auth/google/callback/` | Handles Google callback |
+
+## Facebook
+
+### Setup
+
+1. Go to [Facebook Developers](https://developers.facebook.com/)
+2. Create an app and add Facebook Login
+3. Add your redirect URI in Valid OAuth Redirect URIs
+4. Set `FACEBOOK_CLIENT_ID`, `FACEBOOK_CLIENT_SECRET`, and `FACEBOOK_REDIRECT_URI`
+
+### Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/auth/facebook/` | Redirects to Facebook consent |
+| GET | `/auth/facebook/callback/` | Handles Facebook callback |
+
+## LinkedIn
+
+### Setup
+
+1. Go to [LinkedIn Developer Portal](https://developer.linkedin.com/)
+2. Create an app and add Sign In with LinkedIn using OpenID Connect
+3. Add your redirect URI
+4. Set `LINKEDIN_CLIENT_ID`, `LINKEDIN_CLIENT_SECRET`, and `LINKEDIN_REDIRECT_URI`
+
+### Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/auth/linkedin/` | Redirects to LinkedIn consent |
+| GET | `/auth/linkedin/callback/` | Handles LinkedIn callback |
+
+## Callback Response
+
+On successful OAuth login, BlockAuth creates or retrieves the user and returns JWT tokens:
+
+```json
+{
+  "access": "eyJ...",
+  "refresh": "eyJ..."
+}
+```
+
+If the user doesn't exist, a new account is created with the email from the provider.
+
+## Troubleshooting
+
+**Redirect URI mismatch**: Ensure the redirect URI in your provider dashboard matches the one in `BLOCK_AUTH_SETTINGS` exactly, including trailing slashes and protocol (HTTPS in production).
+
+**ALLOWED_HOSTS**: Your callback domain must be in Django's `ALLOWED_HOSTS`.
+
+**HTTPS required**: Most providers require HTTPS redirect URIs in production. Use `SECURE_SSL_REDIRECT = True`.

--- a/docs/guides/passkey-webauthn.md
+++ b/docs/guides/passkey-webauthn.md
@@ -1,0 +1,128 @@
+# Passkeys (WebAuthn)
+
+BlockAuth supports FIDO2/WebAuthn passkey authentication -- Face ID, Touch ID, Windows Hello, and hardware security keys. Requires the `PASSKEY_AUTH` feature flag.
+
+## How It Works
+
+WebAuthn uses public-key cryptography. The private key never leaves the user's device. The server only stores a public key and credential ID.
+
+**No biometric data is processed server-side.** Biometric matching happens entirely within the device's secure enclave.
+
+## Registration Flow
+
+### Step 1: Get Registration Options
+
+```bash
+POST /auth/passkey/register/options/
+Authorization: Bearer <access_token>
+
+{}
+```
+
+Returns WebAuthn registration options (challenge, relying party info, user info, supported algorithms).
+
+### Step 2: Create Credential
+
+Client-side: pass the options to `navigator.credentials.create()` to trigger the browser's passkey UI.
+
+### Step 3: Verify Registration
+
+```bash
+POST /auth/passkey/register/verify/
+Authorization: Bearer <access_token>
+
+{
+  "credential": { ... }  // Response from navigator.credentials.create()
+}
+```
+
+## Authentication Flow
+
+### Step 1: Get Authentication Options
+
+```bash
+POST /auth/passkey/auth/options/
+
+{
+  "email": "user@example.com"
+}
+```
+
+### Step 2: Sign Challenge
+
+Client-side: pass the options to `navigator.credentials.get()`.
+
+### Step 3: Verify Authentication
+
+```bash
+POST /auth/passkey/auth/verify/
+
+{
+  "credential": { ... }  // Response from navigator.credentials.get()
+}
+```
+
+Returns JWT tokens on success.
+
+## Credential Management
+
+### List Credentials
+
+```bash
+GET /auth/passkey/credentials/
+Authorization: Bearer <access_token>
+```
+
+### Delete a Credential
+
+```bash
+DELETE /auth/passkey/credentials/<credential-uuid>/
+Authorization: Bearer <access_token>
+```
+
+## Storage Backend
+
+BlockAuth provides two storage backends for passkey credentials:
+
+- **DjangoStorage** (default) -- stores credentials in the database via Django ORM
+- **MemoryStorage** -- in-memory storage for testing
+
+Implement `ICredentialStore` for custom storage:
+
+```python
+from blockauth.passkey.storage.base import ICredentialStore, CredentialData
+
+class MyCredentialStore(ICredentialStore):
+    def save_credential(self, credential: CredentialData) -> None:
+        ...
+
+    def get_credential(self, credential_id: bytes) -> CredentialData | None:
+        ...
+
+    def get_credentials_for_user(self, user_id: str) -> list[CredentialData]:
+        ...
+
+    def delete_credential(self, credential_id: bytes) -> None:
+        ...
+```
+
+## Data Stored Server-Side
+
+| Data | Classification |
+|------|---------------|
+| Public keys | Personal data |
+| Credential IDs | Personal data |
+| Sign counters | Technical metadata |
+| AAGUID | Device type identifier |
+| Fingerprints, face scans | **Never stored** -- device only |
+| Private keys | **Never stored** -- device only |
+
+This implementation is GDPR compliant with low privacy risk. See the [Data Protection Impact Assessment](https://github.com/BloclabsHQ/auth-pack/blob/dev/docs/WEBAUTHN_PASSKEY_DPIA.md) for details.
+
+## Cleanup
+
+Stale challenges and expired credentials can be cleaned up with:
+
+```bash
+python manage.py blockauth_cleanup
+```

--- a/docs/guides/signup-login.md
+++ b/docs/guides/signup-login.md
@@ -1,0 +1,182 @@
+# Signup & Login
+
+BlockAuth provides three authentication methods: email/password, passwordless OTP, and Web3 wallet. All are controlled by [feature flags](../getting-started/configuration.md#feature-flags).
+
+## Signup Flow
+
+The signup flow uses a two-step OTP verification:
+
+1. User submits email and password
+2. BlockAuth sends an OTP via the configured notification class
+3. User confirms with the OTP
+
+### Step 1: Register
+
+```bash
+POST /auth/signup/
+
+{
+  "email": "user@example.com",
+  "password": "SecurePass123!"
+}
+```
+
+The password is validated against Django's password validators. BlockAuth includes `BlockAuthPasswordValidator` for additional strength checks.
+
+### Step 2: Confirm OTP
+
+```bash
+POST /auth/signup/confirm/
+
+{
+  "email": "user@example.com",
+  "otp": "123456"
+}
+```
+
+Returns JWT tokens on success:
+
+```json
+{
+  "access": "eyJ...",
+  "refresh": "eyJ..."
+}
+```
+
+### Resend OTP
+
+If the OTP expires (default: 1 minute), request a new one:
+
+```bash
+POST /auth/signup/otp/resend/
+
+{
+  "email": "user@example.com"
+}
+```
+
+!!! note
+    OTP resend is rate-limited. See [Settings](../reference/settings.md) for `REQUEST_LIMIT` configuration.
+
+## Basic Login
+
+Email and password authentication:
+
+```bash
+POST /auth/login/basic/
+
+{
+  "email": "user@example.com",
+  "password": "SecurePass123!"
+}
+```
+
+Returns:
+
+```json
+{
+  "access": "eyJ...",
+  "refresh": "eyJ..."
+}
+```
+
+## Passwordless Login
+
+OTP-based login without a password. Requires the `PASSWORDLESS_LOGIN` feature flag.
+
+### Step 1: Request OTP
+
+```bash
+POST /auth/login/passwordless/
+
+{
+  "email": "user@example.com"
+}
+```
+
+### Step 2: Confirm
+
+```bash
+POST /auth/login/passwordless/confirm/
+
+{
+  "email": "user@example.com",
+  "otp": "123456"
+}
+```
+
+## Password Management
+
+### Reset Password
+
+For users who forgot their password:
+
+```bash
+# Step 1: Request reset OTP
+POST /auth/password/reset/
+
+{
+  "email": "user@example.com"
+}
+
+# Step 2: Set new password
+POST /auth/password/reset/confirm/
+
+{
+  "email": "user@example.com",
+  "otp": "123456",
+  "new_password": "NewSecurePass456!"
+}
+```
+
+### Change Password
+
+For authenticated users:
+
+```bash
+POST /auth/password/change/
+Authorization: Bearer <access_token>
+
+{
+  "old_password": "SecurePass123!",
+  "new_password": "NewSecurePass456!"
+}
+```
+
+## Email Change
+
+Two-step OTP verification for email changes:
+
+```bash
+# Step 1: Request change
+POST /auth/email/change/
+Authorization: Bearer <access_token>
+
+{
+  "new_email": "newemail@example.com"
+}
+
+# Step 2: Confirm
+POST /auth/email/change/confirm/
+
+{
+  "email": "newemail@example.com",
+  "otp": "123456"
+}
+```
+
+## Token Refresh
+
+Exchange a refresh token for new access and refresh tokens:
+
+```bash
+POST /auth/token/refresh/
+
+{
+  "refresh": "eyJ..."
+}
+```
+
+When `ROTATE_REFRESH_TOKENS` is enabled (default), the old refresh token is blacklisted and a new pair is issued.
+
+See [JWT Tokens](jwt-tokens.md) for token structure and custom claims.

--- a/docs/guides/step-up-auth.md
+++ b/docs/guides/step-up-auth.md
@@ -1,0 +1,113 @@
+# Step-Up Authentication
+
+The step-up authentication module (`blockauth.stepup`) implements RFC 9470-style receipt-based step-up auth. After a user completes an additional factor (e.g., TOTP), a short-lived signed receipt is issued. Other services validate this receipt before allowing sensitive operations.
+
+This module is Django-independent -- it uses only PyJWT and the Python standard library.
+
+## Concepts
+
+- **Receipt**: A short-lived HS256 JWT proving the user completed a step-up challenge
+- **Issuer**: The service that verifies the additional factor and creates the receipt
+- **Validator**: The service that checks the receipt before allowing a sensitive operation
+- **Scope**: Restricts the receipt to a class of operations (e.g., `mpc`, `withdrawal`)
+- **Audience**: Prevents cross-service replay (`aud` claim)
+
+## Issuing a Receipt
+
+After the user passes TOTP (or any step-up factor):
+
+```python
+from blockauth.stepup import ReceiptIssuer
+
+issuer = ReceiptIssuer(
+    secret=RECEIPT_SHARED_SECRET,       # min 32 characters
+    issuer="my-auth-service",
+    default_audience="my-wallet-service",
+    default_scope="mpc",
+    default_ttl_seconds=120,            # 2 minutes
+)
+
+receipt_token = issuer.issue(subject=str(user.id))
+# Return receipt_token in the API response
+```
+
+## Validating a Receipt
+
+In the consuming service:
+
+```python
+from blockauth.stepup import ReceiptValidator, ReceiptValidationError
+
+validator = ReceiptValidator(
+    secret=RECEIPT_SHARED_SECRET,
+    expected_audience="my-wallet-service",
+    expected_scope="mpc",
+)
+
+try:
+    claims = validator.validate(
+        token=receipt_from_header,
+        expected_subject=authenticated_user_id,  # anti-IDOR check
+    )
+    # claims.subject, claims.scope, claims.jti, etc.
+except ReceiptValidationError as e:
+    # e.reason -- human-readable message
+    # e.code -- machine-readable code
+    return 403, {"error": e.reason}
+```
+
+## Receipt JWT Claims
+
+```json
+{
+  "sub": "user-uuid",
+  "type": "stepup_receipt",
+  "aud": "my-wallet-service",
+  "scope": "mpc",
+  "iat": 1740000000,
+  "exp": 1740000120,
+  "jti": "random-hex-16-bytes",
+  "iss": "my-auth-service"
+}
+```
+
+## Validation Checks
+
+| Check | Error Code |
+|-------|------------|
+| HS256 signature valid | `receipt_signature_invalid` |
+| Not expired (`exp > now`) | `receipt_expired` |
+| `type == "stepup_receipt"` | `receipt_wrong_type` |
+| `aud` matches expected | `receipt_audience_mismatch` |
+| `scope` matches expected | `receipt_scope_mismatch` |
+| `sub` matches authenticated user | `receipt_subject_mismatch` |
+
+## Middleware Pattern
+
+The receipt is typically passed as an HTTP header (`X-TOTP-Receipt`). Apply middleware to protected endpoints:
+
+- **Header present**: must be valid or request is rejected (403)
+- **Header absent**: pass through (for users who didn't do TOTP)
+- **Enforce mode**: reject all requests without a valid receipt (opt-in for strict environments)
+
+## API Reference
+
+### `ReceiptIssuer(secret, *, issuer, default_audience, default_scope, default_ttl_seconds)`
+
+Create an issuer. `secret` must be >= 32 characters.
+
+- `issue(subject, *, audience=None, scope=None, ttl_seconds=None)` returns `str` (JWT)
+
+### `ReceiptValidator(secret, *, expected_audience, expected_scope)`
+
+Create a validator.
+
+- `validate(token, *, expected_subject=None)` returns `ReceiptClaims`
+
+### `ReceiptClaims` (frozen dataclass)
+
+Fields: `subject`, `audience`, `scope`, `issued_at`, `expires_at`, `jti`, `issuer`
+
+### `ReceiptValidationError`
+
+Fields: `reason` (str, human-readable), `code` (str, machine-readable)

--- a/docs/guides/totp-2fa.md
+++ b/docs/guides/totp-2fa.md
@@ -1,0 +1,113 @@
+# TOTP 2FA
+
+BlockAuth includes a TOTP (Time-based One-Time Password) module for two-factor authentication. Compatible with Google Authenticator, Authy, 1Password, and other TOTP apps.
+
+## Architecture
+
+The TOTP module uses a pluggable storage backend and encryption service:
+
+- **TOTPService** -- generates secrets, creates QR codes, verifies codes
+- **Storage** -- `ITOTP2FAStore` interface with Django and in-memory implementations
+- **Encryption** -- secrets are encrypted at rest
+
+## Setup Flow
+
+### 1. Enable TOTP for a User
+
+Generate a TOTP secret and provisioning URI:
+
+```python
+from blockauth.totp.services.totp_service import TOTPService
+
+totp_service = TOTPService(storage=my_storage, encryption=my_encryption)
+
+# Generate setup data (secret + QR code URI)
+setup_data = totp_service.setup(user_id=str(user.id), issuer="MyApp")
+# setup_data.provisioning_uri -- for QR code generation
+# setup_data.secret -- backup codes (show once, then discard)
+```
+
+### 2. User Scans QR Code
+
+Display the provisioning URI as a QR code in your frontend. The user scans it with their authenticator app.
+
+### 3. Verify Setup
+
+Have the user enter a code from their app to confirm setup:
+
+```python
+is_valid = totp_service.verify(user_id=str(user.id), code="123456")
+```
+
+## Verification
+
+On login or sensitive operations, verify the TOTP code:
+
+```python
+is_valid = totp_service.verify(user_id=str(user.id), code="123456")
+if not is_valid:
+    raise AuthenticationError("Invalid 2FA code")
+```
+
+## Storage Backends
+
+### Django Storage (production)
+
+Uses Django ORM to store encrypted TOTP secrets:
+
+```python
+from blockauth.totp.storage.django_storage import DjangoTOTPStorage
+
+storage = DjangoTOTPStorage()
+```
+
+### Memory Storage (testing)
+
+```python
+from blockauth.totp.storage.memory_storage import MemoryTOTPStorage
+
+storage = MemoryTOTPStorage()
+```
+
+### Custom Storage
+
+Implement `ITOTP2FAStore`:
+
+```python
+from blockauth.totp.storage.base import ITOTP2FAStore, TOTP2FAData
+
+class MyTOTPStorage(ITOTP2FAStore):
+    def save(self, data: TOTP2FAData) -> None:
+        ...
+
+    def get(self, user_id: str) -> TOTP2FAData | None:
+        ...
+
+    def delete(self, user_id: str) -> None:
+        ...
+```
+
+## Encryption
+
+TOTP secrets are encrypted before storage. Implement `ISecretEncryption` for custom encryption:
+
+```python
+from blockauth.totp.services.encryption import ISecretEncryption
+
+class MyEncryption(ISecretEncryption):
+    def encrypt(self, plaintext: str) -> str:
+        ...
+
+    def decrypt(self, ciphertext: str) -> str:
+        ...
+```
+
+## Integration with Step-Up Auth
+
+TOTP verification can issue a [step-up receipt](step-up-auth.md) for sensitive operations:
+
+1. User verifies TOTP code
+2. Auth service issues a short-lived receipt
+3. Other services validate the receipt before allowing sensitive operations
+
+See [Step-Up Auth](step-up-auth.md) for details.

--- a/docs/guides/wallet-auth.md
+++ b/docs/guides/wallet-auth.md
@@ -1,0 +1,74 @@
+# Wallet Authentication
+
+BlockAuth supports Web3 wallet authentication via Ethereum signature verification. Users sign a message with their wallet (MetaMask, etc.) and BlockAuth verifies the signature to authenticate.
+
+Requires the `WALLET_LOGIN` feature flag.
+
+## How It Works
+
+1. Client requests a challenge message from the server
+2. User signs the message with their wallet
+3. Client sends the signed message, signature, and wallet address to BlockAuth
+4. BlockAuth recovers the signer address from the signature and verifies it matches
+
+## Login
+
+```bash
+POST /auth/login/wallet/
+
+{
+  "wallet_address": "0x1234567890abcdef1234567890abcdef12345678",
+  "message": "Sign this message to authenticate with BlockAuth: 1704067200",
+  "signature": "0x..."
+}
+```
+
+Returns JWT tokens on success:
+
+```json
+{
+  "access": "eyJ...",
+  "refresh": "eyJ..."
+}
+```
+
+If the wallet address is not associated with an existing account, a new account is created.
+
+## Replay Protection
+
+Signed messages have a TTL to prevent replay attacks. Configure with:
+
+```python
+BLOCK_AUTH_SETTINGS = {
+    'WALLET_MESSAGE_TTL': 300,  # 5 minutes (default)
+}
+```
+
+Messages older than the TTL are rejected.
+
+## Add Email to Wallet Account
+
+Wallet-only accounts can add an email address for password-based login:
+
+```bash
+POST /auth/wallet/email/add/
+Authorization: Bearer <access_token>
+
+{
+  "email": "user@example.com"
+}
+```
+
+Requires the `WALLET_EMAIL_ADD` feature flag.
+
+## Security Considerations
+
+- Wallet addresses are validated for correct format (0x + 40 hex chars)
+- Zero address (`0x0000...0000`) is rejected
+- Signature malleability is checked (s-value validation)
+- Message size is limited to prevent DoS
+- All signature verification uses `eth_account` for ECDSA recovery
+
+## Integration with KDF
+
+The [KDF System](kdf-system.md) complements wallet auth by generating blockchain wallets from email/password credentials, bridging Web2 users into Web3 without requiring them to manage private keys.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,63 @@
+# BlockAuth
+
+Comprehensive Python authentication package bridging Web2 and Web3. Built on Django and Django REST Framework.
+
+BlockAuth provides JWT authentication, OAuth integration, passwordless login, Web3 wallet authentication, TOTP/2FA, WebAuthn passkeys, step-up authentication, and a KDF system that enables blockchain access without crypto knowledge.
+
+## Features
+
+- **JWT Authentication** -- HS256, RS256, ES256 with customizable claims providers and refresh tokens
+- **OAuth Integration** -- Google, Facebook, LinkedIn providers
+- **Passwordless Login** -- OTP-based authentication via email
+- **Web3 Wallet Auth** -- Ethereum wallet signature verification (MetaMask, etc.)
+- **Passkey/WebAuthn** -- FIDO2 passwordless with Face ID, Touch ID, Windows Hello
+- **TOTP/2FA** -- Time-based one-time passwords with pluggable storage
+- **Step-Up Auth** -- RFC 9470 receipt-based step-up authentication
+- **KDF System** -- Email/password to blockchain wallet generation (PBKDF2, Argon2)
+- **Rate Limiting** -- Per-request and OTP-specific throttling
+- **Feature Flags** -- Enable/disable any auth feature independently
+- **Custom JWT Claims** -- Pluggable claims provider architecture
+- **Trigger System** -- Hooks for signup, login, password change events
+
+## Quick Install
+
+```bash
+pip install https://github.com/BloclabsHQ/auth-pack/releases/download/v0.3.0/blockauth-0.3.0-py3-none-any.whl
+```
+
+```python
+# settings.py
+INSTALLED_APPS = [
+    'rest_framework',
+    'blockauth',
+]
+
+BLOCK_AUTH_SETTINGS = {
+    'BLOCK_AUTH_USER_MODEL': 'myapp.User',
+}
+
+# urls.py
+urlpatterns = [
+    path('auth/', include('blockauth.urls')),
+]
+```
+
+See the [Quick Start](getting-started/quick-start.md) guide for a complete walkthrough.
+
+## Architecture
+
+BlockAuth is organized into focused sub-packages:
+
+| Package | Purpose |
+|---------|---------|
+| `blockauth.jwt` | JWT token management and custom claims |
+| `blockauth.kdf` | Key derivation for Web2-to-Web3 bridging |
+| `blockauth.totp` | TOTP/2FA with pluggable storage |
+| `blockauth.passkey` | WebAuthn/FIDO2 passkey authentication |
+| `blockauth.stepup` | RFC 9470 step-up authentication receipts |
+| `blockauth.views` | DRF API views for all auth endpoints |
+| `blockauth.utils` | Rate limiting, validators, permissions |
+
+## License
+
+MIT

--- a/docs/reference/api-endpoints.md
+++ b/docs/reference/api-endpoints.md
@@ -1,0 +1,93 @@
+# API Endpoints
+
+All endpoints are feature-flag controlled via `BLOCK_AUTH_SETTINGS['FEATURES']`. Disabling a feature removes its URL patterns entirely.
+
+## Authentication
+
+| Method | Path | Feature Flag | Description |
+|--------|------|-------------|-------------|
+| POST | `signup/` | `SIGNUP` | Register with email/phone + password |
+| POST | `signup/otp/resend/` | `SIGNUP` | Resend signup OTP |
+| POST | `signup/confirm/` | `SIGNUP` | Confirm signup with OTP |
+| POST | `login/basic/` | `BASIC_LOGIN` | Email/password login |
+| POST | `login/passwordless/` | `PASSWORDLESS_LOGIN` | Request passwordless OTP |
+| POST | `login/passwordless/confirm/` | `PASSWORDLESS_LOGIN` | Confirm passwordless login |
+| POST | `login/wallet/` | `WALLET_LOGIN` | Web3 wallet signature auth |
+| POST | `token/refresh/` | `TOKEN_REFRESH` | Refresh JWT tokens |
+
+## Password Management
+
+| Method | Path | Feature Flag | Description |
+|--------|------|-------------|-------------|
+| POST | `password/reset/` | `PASSWORD_RESET` | Request password reset OTP |
+| POST | `password/reset/confirm/` | `PASSWORD_RESET` | Confirm password reset with new password |
+| POST | `password/change/` | `PASSWORD_CHANGE` | Change password (authenticated) |
+
+## Email & Wallet
+
+| Method | Path | Feature Flag | Description |
+|--------|------|-------------|-------------|
+| POST | `email/change/` | `EMAIL_CHANGE` | Request email change OTP |
+| POST | `email/change/confirm/` | `EMAIL_CHANGE` | Confirm email change |
+| POST | `wallet/email/add/` | `WALLET_EMAIL_ADD` | Add email to wallet account |
+
+## OAuth Providers
+
+Requires `SOCIAL_AUTH` feature flag and provider configuration in `AUTH_PROVIDERS`.
+
+| Method | Path | Provider | Description |
+|--------|------|----------|-------------|
+| GET | `google/` | Google | Initiate Google OAuth |
+| GET | `google/callback/` | Google | Google OAuth callback |
+| GET | `facebook/` | Facebook | Initiate Facebook OAuth |
+| GET | `facebook/callback/` | Facebook | Facebook OAuth callback |
+| GET | `linkedin/` | LinkedIn | Initiate LinkedIn OAuth |
+| GET | `linkedin/callback/` | LinkedIn | LinkedIn OAuth callback |
+
+## Passkey / WebAuthn
+
+Requires `PASSKEY_AUTH` feature flag.
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `passkey/register/options/` | Get registration options |
+| POST | `passkey/register/verify/` | Verify registration |
+| POST | `passkey/auth/options/` | Get authentication options |
+| POST | `passkey/auth/verify/` | Verify authentication |
+| GET | `passkey/credentials/` | List credentials |
+| DELETE | `passkey/credentials/<uuid>/` | Delete credential |
+
+## Rate Limiting
+
+All endpoints are rate-limited. The default limit is 3 requests per 30 seconds per (identifier, subject, IP address). Configure with:
+
+```python
+BLOCK_AUTH_SETTINGS = {
+    'REQUEST_LIMIT': (3, 30),  # (max_requests, window_seconds)
+}
+```
+
+OTP endpoints have additional OTP-specific throttling.
+
+## Authentication Header
+
+Protected endpoints require a JWT access token in the `Authorization` header:
+
+```
+Authorization: Bearer <access_token>
+```
+
+The header name is configurable via `AUTH_HEADER_NAME` (default: `HTTP_AUTHORIZATION`).
+
+## Response Format
+
+Successful authentication endpoints return:
+
+```json
+{
+  "access": "<jwt_access_token>",
+  "refresh": "<jwt_refresh_token>"
+}
+```
+
+Errors return standard DRF error responses with appropriate HTTP status codes.

--- a/docs/reference/management-commands.md
+++ b/docs/reference/management-commands.md
@@ -1,0 +1,34 @@
+# Management Commands
+
+## blockauth_cleanup
+
+Cleans up expired data: stale OTPs, expired WebAuthn challenges, and orphaned credentials.
+
+```bash
+python manage.py blockauth_cleanup
+```
+
+### What It Cleans
+
+- **Expired OTPs** -- removes OTP records past their validity window
+- **Expired challenges** -- removes WebAuthn challenge records that were never completed
+- **Stale credentials** -- optionally removes credentials that haven't been used within a configurable period
+
+### Usage
+
+Run periodically (e.g., via cron or Celery beat) to keep the database clean:
+
+```bash
+# Cron: daily at 3 AM
+0 3 * * * cd /path/to/project && python manage.py blockauth_cleanup
+```
+
+```python
+# Celery beat
+CELERY_BEAT_SCHEDULE = {
+    'blockauth-cleanup': {
+        'task': 'myapp.tasks.run_blockauth_cleanup',
+        'schedule': crontab(hour=3, minute=0),
+    },
+}
+```

--- a/docs/reference/models.md
+++ b/docs/reference/models.md
@@ -1,0 +1,75 @@
+# Models
+
+## BlockUser
+
+`blockauth.models.BlockUser` is the abstract base model for user accounts. Your user model must inherit from it.
+
+```python
+from blockauth.models import BlockUser
+
+class User(BlockUser):
+    # Add custom fields
+    organization = models.ForeignKey('Organization', null=True, on_delete=models.SET_NULL)
+    role = models.CharField(max_length=50, default='user')
+```
+
+BlockUser extends Django's `AbstractBaseUser` and provides fields required by BlockAuth's authentication flows (email, wallet address, verification status, etc.).
+
+Set your model in settings:
+
+```python
+BLOCK_AUTH_SETTINGS = {
+    'BLOCK_AUTH_USER_MODEL': 'myapp.User',
+}
+```
+
+## OTP
+
+`blockauth.models.OTP` stores one-time passwords for signup confirmation, passwordless login, password reset, and email change.
+
+Key fields:
+
+- `email` -- recipient email
+- `otp` -- the code (generated with `secrets.choice()`)
+- `subject` -- OTP purpose (`OTPSubject` enum: SIGNUP, LOGIN, PASSWORD_RESET, EMAIL_CHANGE)
+- `created_at` -- timestamp for expiry calculation
+- `is_used` -- prevents reuse
+
+OTPs expire based on the `OTP_VALIDITY` setting (default: 1 minute).
+
+## TOTP2FA
+
+`blockauth.totp.models.TOTP2FA` stores encrypted TOTP secrets for two-factor authentication.
+
+Key fields:
+
+- `user` -- foreign key to user
+- `encrypted_secret` -- TOTP secret (encrypted at rest)
+- `is_active` -- whether 2FA is enabled
+- `created_at` -- setup timestamp
+
+## PasskeyCredential
+
+`blockauth.passkey.models.Credential` stores WebAuthn credentials.
+
+Key fields:
+
+- `id` -- UUID primary key
+- `user` -- foreign key to user
+- `credential_id` -- WebAuthn credential identifier (binary)
+- `public_key` -- credential public key (binary)
+- `sign_count` -- signature counter (clone detection)
+- `aaguid` -- authenticator attestation GUID
+- `name` -- user-provided credential name
+- `created_at` -- registration timestamp
+- `last_used_at` -- last authentication timestamp
+
+## Migrations
+
+Run migrations after installing BlockAuth:
+
+```bash
+python manage.py migrate
+```
+
+BlockAuth's migrations create the OTP, TOTP2FA, and Credential tables. Your user model migration is managed by your app.

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -1,0 +1,104 @@
+# Settings Reference
+
+All settings are configured in `BLOCK_AUTH_SETTINGS` in your Django settings module. Every setting has a default value.
+
+## JWT Settings
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `SECRET_KEY` | Django `SECRET_KEY` | Secret key for HS256 JWT signing |
+| `ALGORITHM` | `"HS256"` | JWT signing algorithm (HS256, RS256, ES256) |
+| `ACCESS_TOKEN_LIFETIME` | `timedelta(seconds=3600)` | Access token expiration (1 hour) |
+| `REFRESH_TOKEN_LIFETIME` | `timedelta(days=1)` | Refresh token expiration (1 day) |
+| `AUTH_HEADER_NAME` | `"HTTP_AUTHORIZATION"` | HTTP header for JWT tokens |
+| `USER_ID_FIELD` | `"id"` | User model field used as `user_id` in JWT |
+| `JWT_PRIVATE_KEY` | `None` | PEM private key for RS256/ES256 signing |
+| `JWT_PUBLIC_KEY` | `None` | PEM public key for RS256/ES256 verification |
+| `ROTATE_REFRESH_TOKENS` | `True` | Blacklist old refresh token on rotation |
+
+## OTP Settings
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `OTP_VALIDITY` | `timedelta(minutes=1)` | OTP expiration time |
+| `OTP_LENGTH` | `6` | Number of digits in OTP codes |
+
+## Rate Limiting
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `REQUEST_LIMIT` | `(3, 30)` | `(max_requests, window_seconds)` per identifier+subject+IP |
+
+## Email
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `EMAIL_VERIFICATION_REQUIRED` | `False` | Require email verification for non-auth endpoints |
+
+## Wallet
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `WALLET_MESSAGE_TTL` | `300` | Signed wallet message expiry in seconds (5 minutes) |
+
+## Feature Flags
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `FEATURES.SIGNUP` | `True` | Enable user registration |
+| `FEATURES.BASIC_LOGIN` | `True` | Enable email/password login |
+| `FEATURES.PASSWORDLESS_LOGIN` | `True` | Enable passwordless OTP login |
+| `FEATURES.WALLET_LOGIN` | `True` | Enable wallet-based authentication |
+| `FEATURES.TOKEN_REFRESH` | `True` | Enable JWT token refresh |
+| `FEATURES.PASSWORD_RESET` | `True` | Enable password reset |
+| `FEATURES.PASSWORD_CHANGE` | `True` | Enable password change |
+| `FEATURES.EMAIL_CHANGE` | `True` | Enable email change |
+| `FEATURES.EMAIL_VERIFICATION` | `True` | Enable email verification |
+| `FEATURES.WALLET_EMAIL_ADD` | `True` | Enable adding email to wallet accounts |
+| `FEATURES.SOCIAL_AUTH` | `True` | Master switch for social authentication |
+| `FEATURES.PASSKEY_AUTH` | `True` | Enable WebAuthn passkey authentication |
+
+## Triggers
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `PRE_SIGNUP_TRIGGER` | `"blockauth.triggers.DummyPreSignupTrigger"` | Class called before signup |
+| `POST_SIGNUP_TRIGGER` | `"blockauth.triggers.DummyPostSignupTrigger"` | Class called after signup |
+| `POST_LOGIN_TRIGGER` | `"blockauth.triggers.DummyPostLoginTrigger"` | Class called after login |
+| `POST_PASSWORD_CHANGE_TRIGGER` | `"blockauth.triggers.DummyPostPasswordChangeTrigger"` | Class called after password change |
+| `POST_PASSWORD_RESET_TRIGGER` | `"blockauth.triggers.DummyPostPasswordResetTrigger"` | Class called after password reset |
+
+## Notification & Logging
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `DEFAULT_NOTIFICATION_CLASS` | `"blockauth.notification.DummyNotification"` | OTP delivery class |
+| `BLOCK_AUTH_LOGGER_CLASS` | `"blockauth.utils.logger.DummyLogger"` | Logger implementation |
+
+## OAuth Providers
+
+Configure in `AUTH_PROVIDERS`. Only providers with configuration present have endpoints registered.
+
+```python
+'AUTH_PROVIDERS': {
+    'GOOGLE': {
+        'CLIENT_ID': '...',
+        'CLIENT_SECRET': '...',
+        'REDIRECT_URI': '...',
+    },
+    'LINKEDIN': { ... },
+    'FACEBOOK': { ... },
+}
+```
+
+## User Model
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `BLOCK_AUTH_USER_MODEL` | *(required)* | Dotted path to your user model (e.g., `"myapp.User"`) |
+
+## Client App
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `CLIENT_APP_URL` | `None` | URL of the frontend application |

--- a/docs/security/overview.md
+++ b/docs/security/overview.md
@@ -1,0 +1,69 @@
+# Security Overview
+
+BlockAuth is designed with security as a core principle. This page summarizes the security measures built into the package.
+
+## Password Security
+
+- Passwords are hashed using Django's `set_password()` (bcrypt recommended with 14+ rounds)
+- `BlockAuthPasswordValidator` enforces complexity requirements
+- Passwords are never logged or included in trigger context
+
+## JWT Security
+
+- Algorithm pinning on decode: `algorithms=[...]` prevents algorithm confusion attacks
+- Required claims validation: `exp`, `iat`, `user_id`, `type`
+- Token type enforcement: access tokens cannot be used as refresh tokens
+- Short-lived access tokens (default: 1 hour) with refresh rotation
+- Refresh token blacklisting on rotation (`ROTATE_REFRESH_TOKENS`)
+
+## OTP Security
+
+- Generated with `secrets.choice()` (cryptographically secure random)
+- Short validity window (default: 1 minute)
+- Single-use: marked as used after verification
+- Rate-limited: prevents brute-force attempts
+
+## Wallet Security
+
+- Signature verification with ECDSA recovery
+- Signature malleability protection (s-value check)
+- Zero address rejection
+- Message size limits (DoS prevention)
+- Replay protection via TTL (`WALLET_MESSAGE_TTL`)
+
+## KDF Security
+
+- PBKDF2 with 100k+ iterations or Argon2id (memory-hard)
+- Timing-safe comparisons with `hmac.compare_digest()`
+- Dual encryption: user password + platform key
+- 256-bit minimum key lengths
+
+## Rate Limiting
+
+- Per-request throttling on all auth endpoints
+- OTP-specific rate limiting
+- Configurable limits per (identifier, subject, IP address)
+- Progressive lockout for repeated failures
+
+## WebAuthn / Passkeys
+
+- No biometric data processed server-side
+- Credential sign counter validation (clone detection)
+- Challenge expiration
+- GDPR compliant (see [DPIA](https://github.com/BloclabsHQ/auth-pack/blob/dev/docs/WEBAUTHN_PASSKEY_DPIA.md))
+
+## Step-Up Authentication
+
+- Short-lived receipts (default: 120 seconds)
+- Audience-scoped to prevent cross-service replay
+- Subject binding to prevent IDOR attacks
+- Unique JTI per receipt
+
+## General Practices
+
+- No sensitive data in logs (passwords, tokens, keys filtered by `sensitive_fields`)
+- No `traceback.print_exc()` in production paths
+- Input validation on all endpoints via DRF serializers
+- Feature flags to reduce attack surface by disabling unused features
+
+For the full security standards, see [Security Standards](security-standards.md).

--- a/docs/security/security-standards.md
+++ b/docs/security/security-standards.md
@@ -1,0 +1,95 @@
+# Security Standards
+
+This page summarizes the mandatory security standards for BlockAuth. The full standards document is maintained at [`.claude/SECURITY_STANDARDS.md`](https://github.com/BloclabsHQ/auth-pack/blob/dev/.claude/SECURITY_STANDARDS.md) in the repository.
+
+## Immediate Rules
+
+### Never
+
+- Log sensitive data (passwords, tokens, private keys)
+- Use weak random (`random.random()`, `uuid.uuid4()` for security tokens)
+- Hardcode secrets in source code
+- Use `eval()`, `exec()`, or `pickle.loads()` with user data
+- Trust user input without validation
+
+### Always
+
+- Use `secrets.token_urlsafe()` for token generation
+- Hash passwords with bcrypt (14+ rounds) via Django's `set_password()`
+- Validate all input with Django validators
+- Use parameterized queries (Django ORM)
+
+## Password Standards
+
+- Minimum 12 characters
+- Require uppercase, lowercase, numbers, and special characters
+- Maximum 3 consecutive identical characters
+- Check against common password lists
+- Prevent reuse of last 5 passwords
+
+## JWT Standards
+
+- HS256 with 256-bit minimum secret key
+- Algorithm pinning on decode
+- Required claims: `exp`, `iat`, `user_id`, `type`
+- Access token lifetime: configurable (recommended <= 15 minutes for high-security)
+- Refresh token rotation with blacklisting
+
+## Key Derivation Standards
+
+- PBKDF2: minimum 600,000 iterations (NIST 2024 recommendation)
+- Key length: 256 bits minimum
+- Salt length: 256 bits minimum
+- Unique salt per user
+
+## Rate Limiting
+
+| Endpoint Type | Recommended Limit |
+|--------------|-------------------|
+| Login | 5/minute |
+| Registration | 3/hour |
+| Password reset | 3/hour |
+| Token refresh | 10/minute |
+| KDF derivation | 10/hour |
+
+## Input Validation
+
+- Email: Django `validate_email` + format normalization
+- Ethereum address: regex `^0x[a-fA-F0-9]{40}$` + checksum validation
+- Zero address rejection
+- Message size limits
+
+## Security Headers (for deploying services)
+
+```python
+# Recommended Django settings
+SECURE_SSL_REDIRECT = True
+SESSION_COOKIE_SECURE = True
+SESSION_COOKIE_HTTPONLY = True
+SESSION_COOKIE_SAMESITE = 'Strict'
+CSRF_COOKIE_SECURE = True
+```
+
+## Audit Logging
+
+All authentication events should be logged:
+
+- Login attempts (success and failure)
+- Password changes and resets
+- MFA enable/disable
+- Token generation and revocation
+- Rate limit exceeded
+- Permission denied
+
+## Pre-Deployment Checklist
+
+- [ ] `DEBUG = False`
+- [ ] Secret key is unique and >= 50 characters
+- [ ] JWT secret is unique and >= 32 characters
+- [ ] HTTPS enforced (`SECURE_SSL_REDIRECT`)
+- [ ] `ALLOWED_HOSTS` does not contain `*`
+- [ ] Rate limiting is configured
+- [ ] Security headers middleware is active
+- [ ] Audit logging is enabled
+- [ ] Dependencies scanned for vulnerabilities
+- [ ] No hardcoded secrets in codebase

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,65 @@
+site_name: BlockAuth
+site_description: Comprehensive Python authentication bridging Web2 and Web3
+site_url: https://bloclabshq.github.io/auth-pack/
+repo_url: https://github.com/BloclabsHQ/auth-pack
+repo_name: BloclabsHQ/auth-pack
+
+theme:
+  name: material
+  palette:
+    - scheme: default
+      primary: deep purple
+      accent: amber
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - scheme: slate
+      primary: deep purple
+      accent: amber
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.expand
+    - search.suggest
+    - content.code.copy
+
+nav:
+  - Home: index.md
+  - Getting Started:
+    - Installation: getting-started/installation.md
+    - Configuration: getting-started/configuration.md
+    - Quick Start: getting-started/quick-start.md
+  - Guides:
+    - Signup & Login: guides/signup-login.md
+    - JWT Tokens: guides/jwt-tokens.md
+    - OAuth Providers: guides/oauth.md
+    - Wallet Authentication: guides/wallet-auth.md
+    - Passkeys (WebAuthn): guides/passkey-webauthn.md
+    - TOTP 2FA: guides/totp-2fa.md
+    - KDF System: guides/kdf-system.md
+    - Step-Up Auth: guides/step-up-auth.md
+  - Reference:
+    - API Endpoints: reference/api-endpoints.md
+    - Settings: reference/settings.md
+    - Models: reference/models.md
+    - Management Commands: reference/management-commands.md
+  - Security:
+    - Overview: security/overview.md
+    - Standards: security/security-standards.md
+  - Changelog: changelog.md
+
+markdown_extensions:
+  - pymdownx.highlight
+  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
+  - admonition
+  - tables
+  - toc:
+      permalink: true
+
+plugins:
+  - search

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ dev = [
     "pytest>=8.0.0",
     "pytest-django>=4.8.0",
     "mypy>=1.10.0",
+    "mkdocs-material>=9.7.6",
 ]
 
 [tool.uv]

--- a/uv.lock
+++ b/uv.lock
@@ -195,6 +195,29 @@ wheels = [
 ]
 
 [[package]]
+name = "babel"
+version = "2.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/b2/51899539b6ceeeb420d40ed3cd4b7a40519404f9baf3d4ac99dc413a834b/babel-2.18.0.tar.gz", hash = "sha256:b80b99a14bd085fcacfa15c9165f651fbb3406e66cc603abf11c5750937c992d", size = 9959554 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl", hash = "sha256:e2b422b277c2b9a9630c1d7903c2a00d0830c409c59ac8cae9081c92f1aeba35", size = 10196845 },
+]
+
+[[package]]
+name = "backrefs"
+version = "6.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/a6/e325ec73b638d3ede4421b5445d4a0b8b219481826cc079d510100af356c/backrefs-6.2.tar.gz", hash = "sha256:f44ff4d48808b243b6c0cdc6231e22195c32f77046018141556c66f8bab72a49", size = 7012303 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/39/3765df263e08a4df37f4f43cb5aa3c6c17a4bdd42ecfe841e04c26037171/backrefs-6.2-py310-none-any.whl", hash = "sha256:0fdc7b012420b6b144410342caeb8adc54c6866cf12064abc9bb211302e496f8", size = 381075 },
+    { url = "https://files.pythonhosted.org/packages/0f/f0/35240571e1b67ffb19dafb29ab34150b6f59f93f717b041082cdb1bfceb1/backrefs-6.2-py311-none-any.whl", hash = "sha256:08aa7fae530c6b2361d7bdcbda1a7c454e330cc9dbcd03f5c23205e430e5c3be", size = 392874 },
+    { url = "https://files.pythonhosted.org/packages/e3/63/77e8c9745b4d227cce9f5e0a6f68041278c5f9b18588b35905f5f19c1beb/backrefs-6.2-py312-none-any.whl", hash = "sha256:c3f4b9cb2af8cda0d87ab4f57800b57b95428488477be164dd2b47be54db0c90", size = 398787 },
+    { url = "https://files.pythonhosted.org/packages/c5/71/c754b1737ad99102e03fa3235acb6cb6d3ac9d6f596cbc3e5f236705abd8/backrefs-6.2-py313-none-any.whl", hash = "sha256:12df81596ab511f783b7d87c043ce26bc5b0288cf3bb03610fe76b8189282b2b", size = 400747 },
+    { url = "https://files.pythonhosted.org/packages/af/75/be12ba31a6eb20dccef2320cd8ccb3f7d9013b68ba4c70156259fee9e409/backrefs-6.2-py314-none-any.whl", hash = "sha256:e5f805ae09819caa1aa0623b4a83790e7028604aa2b8c73ba602c4454e665de7", size = 412602 },
+    { url = "https://files.pythonhosted.org/packages/21/f8/d02f650c47d05034dcd6f9c8cf94f39598b7a89c00ecda0ecb2911bc27e9/backrefs-6.2-py39-none-any.whl", hash = "sha256:664e33cd88c6840b7625b826ecf2555f32d491800900f5a541f772c485f7cda7", size = 381077 },
+]
+
+[[package]]
 name = "bitarray"
 version = "3.8.1"
 source = { registry = "https://pypi.org/simple" }
@@ -288,7 +311,7 @@ wheels = [
 
 [[package]]
 name = "blockauth"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "argon2-cffi" },
@@ -311,6 +334,7 @@ dev = [
     { name = "black" },
     { name = "flake8" },
     { name = "isort" },
+    { name = "mkdocs-material" },
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-django" },
@@ -338,6 +362,7 @@ dev = [
     { name = "black", specifier = ">=26.3.0" },
     { name = "flake8", specifier = ">=7.0.0" },
     { name = "isort", specifier = ">=5.13.0" },
+    { name = "mkdocs-material", specifier = ">=9.7.6" },
     { name = "mypy", specifier = ">=1.10.0" },
     { name = "pytest", specifier = ">=8.0.0" },
     { name = "pytest-django", specifier = ">=4.8.0" },
@@ -1017,6 +1042,18 @@ wheels = [
 ]
 
 [[package]]
+name = "ghp-import"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/29/d40217cbe2f6b1359e00c6c307bb3fc876ba74068cbab3dde77f03ca0dc4/ghp-import-2.1.0.tar.gz", hash = "sha256:9c535c4c61193c2df8871222567d7fd7e5014d835f97dc7b7439069e2413d343", size = 10943 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/ec/67fbef5d497f86283db54c22eec6f6140243aae73265799baaaa19cd17fb/ghp_import-2.1.0-py3-none-any.whl", hash = "sha256:8337dd7b50877f163d4c0289bc1f1c7f127550241988d568c1db512c4324a619", size = 11034 },
+]
+
+[[package]]
 name = "hexbytes"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1059,6 +1096,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ef/7c/ec4ab396d31b3b395e2e999c8f46dec78c5e29209fac49d1f4dace04041d/isort-8.0.1.tar.gz", hash = "sha256:171ac4ff559cdc060bcfff550bc8404a486fee0caab245679c2abe7cb253c78d", size = 769592 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3e/95/c7c34aa53c16353c56d0b802fba48d5f5caa2cdee7958acbcb795c830416/isort-8.0.1-py3-none-any.whl", hash = "sha256:28b89bc70f751b559aeca209e6120393d43fbe2490de0559662be7a9787e3d75", size = 89733 },
+]
+
+[[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899 },
 ]
 
 [[package]]
@@ -1149,12 +1198,162 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown"
+version = "3.10.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/f4/69fa6ed85ae003c2378ffa8f6d2e3234662abd02c10d216c0ba96081a238/markdown-3.10.2.tar.gz", hash = "sha256:994d51325d25ad8aa7ce4ebaec003febcce822c3f8c911e3b17c52f7f589f950", size = 368805 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/1f/77fa3081e4f66ca3576c896ae5d31c3002ac6607f9747d2e3aa49227e464/markdown-3.10.2-py3-none-any.whl", hash = "sha256:e91464b71ae3ee7afd3017d9f358ef0baf158fd9a298db92f1d4761133824c36", size = 108180 },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/72/147da192e38635ada20e0a2e1a51cf8823d2119ce8883f7053879c2199b5/markupsafe-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53197da72cc091b024dd97249dfc7794d6a56530370992a5e1a08983ad9230e", size = 11615 },
+    { url = "https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce", size = 12020 },
+    { url = "https://files.pythonhosted.org/packages/1e/2c/799f4742efc39633a1b54a92eec4082e4f815314869865d876824c257c1e/markupsafe-3.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a7e8ae81ae39e62a41ec302f972ba6ae23a5c5396c8e60113e9066ef893da0d", size = 24332 },
+    { url = "https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d", size = 22947 },
+    { url = "https://files.pythonhosted.org/packages/2c/54/887f3092a85238093a0b2154bd629c89444f395618842e8b0c41783898ea/markupsafe-3.0.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:94c6f0bb423f739146aec64595853541634bde58b2135f27f61c1ffd1cd4d16a", size = 21962 },
+    { url = "https://files.pythonhosted.org/packages/c9/2f/336b8c7b6f4a4d95e91119dc8521402461b74a485558d8f238a68312f11c/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:be8813b57049a7dc738189df53d69395eba14fb99345e0a5994914a3864c8a4b", size = 23760 },
+    { url = "https://files.pythonhosted.org/packages/32/43/67935f2b7e4982ffb50a4d169b724d74b62a3964bc1a9a527f5ac4f1ee2b/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:83891d0e9fb81a825d9a6d61e3f07550ca70a076484292a70fde82c4b807286f", size = 21529 },
+    { url = "https://files.pythonhosted.org/packages/89/e0/4486f11e51bbba8b0c041098859e869e304d1c261e59244baa3d295d47b7/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:77f0643abe7495da77fb436f50f8dab76dbc6e5fd25d39589a0f1fe6548bfa2b", size = 23015 },
+    { url = "https://files.pythonhosted.org/packages/2f/e1/78ee7a023dac597a5825441ebd17170785a9dab23de95d2c7508ade94e0e/markupsafe-3.0.3-cp312-cp312-win32.whl", hash = "sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d", size = 14540 },
+    { url = "https://files.pythonhosted.org/packages/aa/5b/bec5aa9bbbb2c946ca2733ef9c4ca91c91b6a24580193e891b5f7dbe8e1e/markupsafe-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c", size = 15105 },
+    { url = "https://files.pythonhosted.org/packages/e5/f1/216fc1bbfd74011693a4fd837e7026152e89c4bcf3e77b6692fba9923123/markupsafe-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f", size = 13906 },
+    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622 },
+    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029 },
+    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374 },
+    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980 },
+    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990 },
+    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784 },
+    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588 },
+    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041 },
+    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543 },
+    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113 },
+    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911 },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658 },
+    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066 },
+    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639 },
+    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569 },
+    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284 },
+    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801 },
+    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769 },
+    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642 },
+    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612 },
+    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200 },
+    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973 },
+    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619 },
+    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029 },
+    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408 },
+    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005 },
+    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048 },
+    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821 },
+    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606 },
+    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043 },
+    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747 },
+    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341 },
+    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073 },
+    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661 },
+    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069 },
+    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670 },
+    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598 },
+    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261 },
+    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835 },
+    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733 },
+    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672 },
+    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819 },
+    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426 },
+    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146 },
+]
+
+[[package]]
 name = "mccabe"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e7/ff/0ffefdcac38932a54d2b5eed4e0ba8a408f215002cd178ad1df0f2806ff8/mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325", size = 9658 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/27/1a/1f68f9ba0c207934b35b86a8ca3aad8395a3d6dd7921c0686e23853ff5a9/mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e", size = 7350 },
+]
+
+[[package]]
+name = "mergedeep"
+version = "1.3.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3a/41/580bb4006e3ed0361b8151a01d324fb03f420815446c7def45d02f74c270/mergedeep-1.3.4.tar.gz", hash = "sha256:0096d52e9dad9939c3d975a774666af186eda617e6ca84df4c94dec30004f2a8", size = 4661 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/19/04f9b178c2d8a15b076c8b5140708fa6ffc5601fb6f1e975537072df5b2a/mergedeep-1.3.4-py3-none-any.whl", hash = "sha256:70775750742b25c0d8f36c55aed03d24c3384d17c951b3175d898bd778ef0307", size = 6354 },
+]
+
+[[package]]
+name = "mkdocs"
+version = "1.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "ghp-import" },
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "markupsafe" },
+    { name = "mergedeep" },
+    { name = "mkdocs-get-deps" },
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "pyyaml" },
+    { name = "pyyaml-env-tag" },
+    { name = "watchdog" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bc/c6/bbd4f061bd16b378247f12953ffcb04786a618ce5e904b8c5a01a0309061/mkdocs-1.6.1.tar.gz", hash = "sha256:7b432f01d928c084353ab39c57282f29f92136665bdd6abf7c1ec8d822ef86f2", size = 3889159 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/5b/dbc6a8cddc9cfa9c4971d59fb12bb8d42e161b7e7f8cc89e49137c5b279c/mkdocs-1.6.1-py3-none-any.whl", hash = "sha256:db91759624d1647f3f34aa0c3f327dd2601beae39a366d6e064c03468d35c20e", size = 3864451 },
+]
+
+[[package]]
+name = "mkdocs-get-deps"
+version = "0.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mergedeep" },
+    { name = "platformdirs" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ce/25/b3cccb187655b9393572bde9b09261d267c3bf2f2cdabe347673be5976a6/mkdocs_get_deps-0.2.2.tar.gz", hash = "sha256:8ee8d5f316cdbbb2834bc1df6e69c08fe769a83e040060de26d3c19fad3599a1", size = 11047 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/29/744136411e785c4b0b744d5413e56555265939ab3a104c6a4b719dad33fd/mkdocs_get_deps-0.2.2-py3-none-any.whl", hash = "sha256:e7878cbeac04860b8b5e0ca31d3abad3df9411a75a32cde82f8e44b6c16ff650", size = 9555 },
+]
+
+[[package]]
+name = "mkdocs-material"
+version = "9.7.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "babel" },
+    { name = "backrefs" },
+    { name = "colorama" },
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "mkdocs" },
+    { name = "mkdocs-material-extensions" },
+    { name = "paginate" },
+    { name = "pygments" },
+    { name = "pymdown-extensions" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/45/29/6d2bcf41ae40802c4beda2432396fff97b8456fb496371d1bc7aad6512ec/mkdocs_material-9.7.6.tar.gz", hash = "sha256:00bdde50574f776d328b1862fe65daeaf581ec309bd150f7bff345a098c64a69", size = 4097959 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/01/bc663630c510822c95c47a66af9fa7a443c295b47d5f041e5e6ae62ef659/mkdocs_material-9.7.6-py3-none-any.whl", hash = "sha256:71b84353921b8ea1ba84fe11c50912cc512da8fe0881038fcc9a0761c0e635ba", size = 9305470 },
+]
+
+[[package]]
+name = "mkdocs-material-extensions"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/79/9b/9b4c96d6593b2a541e1cb8b34899a6d021d208bb357042823d4d2cabdbe7/mkdocs_material_extensions-1.3.1.tar.gz", hash = "sha256:10c9511cea88f568257f960358a467d12b970e1f7b2c0e5fb2bb48cab1928443", size = 11847 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/54/662a4743aa81d9582ee9339d4ffa3c8fd40a4965e033d77b9da9774d3960/mkdocs_material_extensions-1.3.1-py3-none-any.whl", hash = "sha256:adff8b62700b25cb77b53358dad940f3ef973dd6db797907c49e3c2ef3ab4e31", size = 8728 },
 ]
 
 [[package]]
@@ -1315,6 +1514,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366 },
+]
+
+[[package]]
+name = "paginate"
+version = "0.5.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/46/68dde5b6bc00c1296ec6466ab27dddede6aec9af1b99090e1107091b3b84/paginate-0.5.7.tar.gz", hash = "sha256:22bd083ab41e1a8b4f3690544afb2c60c25e5c9a63a30fa2f483f6c60c8e5945", size = 19252 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/96/04b8e52da071d28f5e21a805b19cb9390aa17a47462ac87f5e2696b9566d/paginate-0.5.7-py2.py3-none-any.whl", hash = "sha256:b885e2af73abcf01d9559fd5216b57ef722f8c42affbb63942377668e35c7591", size = 13746 },
 ]
 
 [[package]]
@@ -1607,6 +1815,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pymdown-extensions"
+version = "10.21.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/08/f1c908c581fd11913da4711ea7ba32c0eee40b0190000996bb863b0c9349/pymdown_extensions-10.21.2.tar.gz", hash = "sha256:c3f55a5b8a1d0edf6699e35dcbea71d978d34ff3fa79f3d807b8a5b3fa90fbdc", size = 853922 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/27/a2fc51a4a122dfd1015e921ae9d22fee3d20b0b8080d9a704578bf9deece/pymdown_extensions-10.21.2-py3-none-any.whl", hash = "sha256:5c0fd2a2bea14eb39af8ff284f1066d898ab2187d81b889b75d46d4348c01638", size = 268901 },
+]
+
+[[package]]
 name = "pyopenssl"
 version = "26.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1645,6 +1866,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/13/2b/db9a193df89e5660137f5428063bcc2ced7ad790003b26974adf5c5ceb3b/pytest_django-4.12.0.tar.gz", hash = "sha256:df94ec819a83c8979c8f6de13d9cdfbe76e8c21d39473cfe2b40c9fc9be3c758", size = 91156 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/83/a5/41d091f697c09609e7ef1d5d61925494e0454ebf51de7de05f0f0a728f1d/pytest_django-4.12.0-py3-none-any.whl", hash = "sha256:3ff300c49f8350ba2953b90297d23bf5f589db69545f56f1ec5f8cff5da83e85", size = 26123 },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892 },
 ]
 
 [[package]]
@@ -1745,6 +1978,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923 },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062 },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341 },
+]
+
+[[package]]
+name = "pyyaml-env-tag"
+version = "1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/2e/79c822141bfd05a853236b504869ebc6b70159afc570e1d5a20641782eaa/pyyaml_env_tag-1.1.tar.gz", hash = "sha256:2eb38b75a2d21ee0475d6d97ec19c63287a7e140231e4214969d0eac923cd7ff", size = 5737 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/11/432f32f8097b03e3cd5fe57e88efb685d964e2e5178a48ed61e841f7fdce/pyyaml_env_tag-1.1-py3-none-any.whl", hash = "sha256:17109e1a528561e32f026364712fee1264bc2ea6715120891174ed1b980d2e04", size = 4722 },
 ]
 
 [[package]]
@@ -1958,6 +2203,15 @@ wheels = [
 ]
 
 [[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050 },
+]
+
+[[package]]
 name = "sqlparse"
 version = "0.5.5"
 source = { registry = "https://pypi.org/simple" }
@@ -2042,6 +2296,30 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ca/b7/4c0f736ca824b3a25b15e8213d1bcfc15f8ac2ae48d1b445b310892dc4da/uuid6-2025.0.1.tar.gz", hash = "sha256:cd0af94fa428675a44e32c5319ec5a3485225ba2179eefcf4c3f205ae30a81bd", size = 13932 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3d/b2/93faaab7962e2aa8d6e174afb6f76be2ca0ce89fde14d3af835acebcaa59/uuid6-2025.0.1-py3-none-any.whl", hash = "sha256:80530ce4d02a93cdf82e7122ca0da3ebbbc269790ec1cb902481fa3e9cc9ff99", size = 6979 },
+]
+
+[[package]]
+name = "watchdog"
+version = "6.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/7d/7f3d619e951c88ed75c6037b246ddcf2d322812ee8ea189be89511721d54/watchdog-6.0.0.tar.gz", hash = "sha256:9ddf7c82fda3ae8e24decda1338ede66e1c99883db93711d8fb941eaa2d8c282", size = 131220 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/ea/3930d07dafc9e286ed356a679aa02d777c06e9bfd1164fa7c19c288a5483/watchdog-6.0.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:bdd4e6f14b8b18c334febb9c4425a878a2ac20efd1e0b231978e7b150f92a948", size = 96471 },
+    { url = "https://files.pythonhosted.org/packages/12/87/48361531f70b1f87928b045df868a9fd4e253d9ae087fa4cf3f7113be363/watchdog-6.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c7c15dda13c4eb00d6fb6fc508b3c0ed88b9d5d374056b239c4ad1611125c860", size = 88449 },
+    { url = "https://files.pythonhosted.org/packages/5b/7e/8f322f5e600812e6f9a31b75d242631068ca8f4ef0582dd3ae6e72daecc8/watchdog-6.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6f10cb2d5902447c7d0da897e2c6768bca89174d0c6e1e30abec5421af97a5b0", size = 89054 },
+    { url = "https://files.pythonhosted.org/packages/68/98/b0345cabdce2041a01293ba483333582891a3bd5769b08eceb0d406056ef/watchdog-6.0.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:490ab2ef84f11129844c23fb14ecf30ef3d8a6abafd3754a6f75ca1e6654136c", size = 96480 },
+    { url = "https://files.pythonhosted.org/packages/85/83/cdf13902c626b28eedef7ec4f10745c52aad8a8fe7eb04ed7b1f111ca20e/watchdog-6.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:76aae96b00ae814b181bb25b1b98076d5fc84e8a53cd8885a318b42b6d3a5134", size = 88451 },
+    { url = "https://files.pythonhosted.org/packages/fe/c4/225c87bae08c8b9ec99030cd48ae9c4eca050a59bf5c2255853e18c87b50/watchdog-6.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a175f755fc2279e0b7312c0035d52e27211a5bc39719dd529625b1930917345b", size = 89057 },
+    { url = "https://files.pythonhosted.org/packages/a9/c7/ca4bf3e518cb57a686b2feb4f55a1892fd9a3dd13f470fca14e00f80ea36/watchdog-6.0.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:7607498efa04a3542ae3e05e64da8202e58159aa1fa4acddf7678d34a35d4f13", size = 79079 },
+    { url = "https://files.pythonhosted.org/packages/5c/51/d46dc9332f9a647593c947b4b88e2381c8dfc0942d15b8edc0310fa4abb1/watchdog-6.0.0-py3-none-manylinux2014_armv7l.whl", hash = "sha256:9041567ee8953024c83343288ccc458fd0a2d811d6a0fd68c4c22609e3490379", size = 79078 },
+    { url = "https://files.pythonhosted.org/packages/d4/57/04edbf5e169cd318d5f07b4766fee38e825d64b6913ca157ca32d1a42267/watchdog-6.0.0-py3-none-manylinux2014_i686.whl", hash = "sha256:82dc3e3143c7e38ec49d61af98d6558288c415eac98486a5c581726e0737c00e", size = 79076 },
+    { url = "https://files.pythonhosted.org/packages/ab/cc/da8422b300e13cb187d2203f20b9253e91058aaf7db65b74142013478e66/watchdog-6.0.0-py3-none-manylinux2014_ppc64.whl", hash = "sha256:212ac9b8bf1161dc91bd09c048048a95ca3a4c4f5e5d4a7d1b1a7d5752a7f96f", size = 79077 },
+    { url = "https://files.pythonhosted.org/packages/2c/3b/b8964e04ae1a025c44ba8e4291f86e97fac443bca31de8bd98d3263d2fcf/watchdog-6.0.0-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:e3df4cbb9a450c6d49318f6d14f4bbc80d763fa587ba46ec86f99f9e6876bb26", size = 79078 },
+    { url = "https://files.pythonhosted.org/packages/62/ae/a696eb424bedff7407801c257d4b1afda455fe40821a2be430e173660e81/watchdog-6.0.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:2cce7cfc2008eb51feb6aab51251fd79b85d9894e98ba847408f662b3395ca3c", size = 79077 },
+    { url = "https://files.pythonhosted.org/packages/b5/e8/dbf020b4d98251a9860752a094d09a65e1b436ad181faf929983f697048f/watchdog-6.0.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:20ffe5b202af80ab4266dcd3e91aae72bf2da48c0d33bdb15c66658e685e94e2", size = 79078 },
+    { url = "https://files.pythonhosted.org/packages/07/f6/d0e5b343768e8bcb4cda79f0f2f55051bf26177ecd5651f84c07567461cf/watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a", size = 79065 },
+    { url = "https://files.pythonhosted.org/packages/db/d9/c495884c6e548fce18a8f40568ff120bc3a4b7b99813081c8ac0c936fa64/watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680", size = 79070 },
+    { url = "https://files.pythonhosted.org/packages/33/e8/e40370e6d74ddba47f002a32919d91310d6074130fe4e17dabcafc15cbf1/watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f", size = 79067 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add MkDocs Material documentation site with 20 pages covering all BlockAuth features
- Add GitHub Actions workflow to auto-deploy to GitHub Pages on push to main
- Dark/light mode, search, code copy, navigation tabs

## Pages
- **Home** — landing page with features and quick install
- **Getting Started** — installation, configuration (all settings with defaults), quick start guide
- **Guides** (8) — signup/login, JWT tokens, OAuth, wallet auth, passkeys, TOTP 2FA, KDF, step-up auth
- **Reference** (4) — API endpoints, settings, models, management commands
- **Security** (2) — overview, standards
- **Changelog** — v0.1.0 through v0.4.0

## After merge to main
Enable GitHub Pages in repo settings: Settings → Pages → Source: GitHub Actions

Site will be at: https://bloclabshq.github.io/auth-pack/