### PR TITLE
fix: resolve 10 ghost documentation references

### DIFF
--- a/.claude/SECURITY_STANDARDS.md
+++ b/.claude/SECURITY_STANDARDS.md
@@ -79,8 +79,7 @@ PASSWORD_VALIDATORS = [
      'OPTIONS': {'min_length': 12}},  # MINIMUM 12 characters
     {'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator'},
     {'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator'},
-    {'NAME': 'blockauth.validators.PasswordStrengthValidator'},
-    {'NAME': 'blockauth.validators.PwnedPasswordValidator'},  # Check breaches
+    {'NAME': 'blockauth.utils.validators.BlockAuthPasswordValidator'},
 ]
 
 # MANDATORY complexity requirements

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,8 +87,7 @@ blockauth/
 │   │   └── encryption.py   # Secret encryption service
 │   ├── storage/
 │   │   ├── base.py         # ITOTP2FAStore ABC, TOTP2FAData DTO
-│   │   ├── django_storage.py # Django model storage
-│   │   └── memory_storage.py # In-memory storage (testing)
+│   │   └── django_storage.py # Django model storage
 │   └── tests/              # TOTP tests
 ├── passkey/                 # WebAuthn/Passkey sub-package
 │   ├── config.py           # Passkey configuration
@@ -173,7 +172,7 @@ All endpoints are feature-flag controlled via `BLOCK_AUTH_SETTINGS['FEATURES']`.
 
 ```bash
 # Install from GitHub Releases
-pip install https://github.com/BloclabsHQ/auth-pack/releases/download/v0.3.0/blockauth-0.3.0-py3-none-any.whl
+pip install https://github.com/BloclabsHQ/auth-pack/releases/download/v0.4.0/blockauth-0.4.0-py3-none-any.whl
 
 # Or from git
 pip install git+https://github.com/BloclabsHQ/auth-pack.git@dev
@@ -295,8 +294,8 @@ To release:
 # 1. Bump version in both files
 # 2. Commit and push to dev
 # 3. Tag and push
-git tag v0.3.0
-git push origin v0.3.0
+git tag v0.4.0
+git push origin v0.4.0
 ```
 
 The `publish.yml` workflow validates the tag matches `pyproject.toml`, builds the package, and creates a GitHub Release with sdist + wheel artifacts.

--- a/blockauth/conf.py
+++ b/blockauth/conf.py
@@ -46,6 +46,8 @@ DEFAULTS = {
         "SOCIAL_AUTH": True,  # Master switch for social authentication
         # Passkey/WebAuthn authentication
         "PASSKEY_AUTH": True,  # Enable passkey/WebAuthn authentication (Face ID, Touch ID, Windows Hello)
+        # TOTP 2FA
+        "TOTP_2FA": False,  # Enable TOTP 2FA (requires TOTP_CONFIG.ENCRYPTION_KEY)
     },
     # Trigger classes
     "POST_SIGNUP_TRIGGER": "blockauth.triggers.DummyPostSignupTrigger",

--- a/blockauth/constants/core.py
+++ b/blockauth/constants/core.py
@@ -191,6 +191,8 @@ class ConfigKeys:
     POST_SIGNUP_TRIGGER = "POST_SIGNUP_TRIGGER"  # Post-signup trigger class
     PRE_SIGNUP_TRIGGER = "PRE_SIGNUP_TRIGGER"  # Pre-signup trigger class
     POST_LOGIN_TRIGGER = "POST_LOGIN_TRIGGER"  # Post-login trigger class
+    POST_PASSWORD_CHANGE_TRIGGER = "POST_PASSWORD_CHANGE_TRIGGER"  # Post-password-change trigger class
+    POST_PASSWORD_RESET_TRIGGER = "POST_PASSWORD_RESET_TRIGGER"  # Post-password-reset trigger class
 
     # Utility classes
     DEFAULT_NOTIFICATION_CLASS = "DEFAULT_NOTIFICATION_CLASS"  # Notification handler class

--- a/docs/JWT_EXTENSION_GUIDE.md
+++ b/docs/JWT_EXTENSION_GUIDE.md
@@ -177,11 +177,10 @@ class MyAppConfig(AppConfig):
 
 ## Testing
 
-Run the test script to verify the implementation:
+Run the test suite to verify the implementation:
 
 ```bash
-cd services/auth-pack
-python test_jwt_extension.py
+uv run pytest blockauth/utils/tests/test_token_algorithms.py -v
 ```
 
 ## Migration Guide

--- a/docs/PASSKEY_WEBAUTHN_IMPLEMENTATION_PLAN.md
+++ b/docs/PASSKEY_WEBAUTHN_IMPLEMENTATION_PLAN.md
@@ -1572,7 +1572,7 @@ PyJWT = "^2.8"
 ## File Structure Summary
 
 ```
-services/auth-pack/
+auth-pack/
 ├── blockauth/
 │   ├── passkey/                          # NEW MODULE
 │   │   ├── __init__.py                   # PK-1, PK-44

--- a/docs/TOKEN_USAGE_GUIDE.md
+++ b/docs/TOKEN_USAGE_GUIDE.md
@@ -180,8 +180,8 @@ BLOCK_AUTH_SETTINGS = {
     "ACCESS_TOKEN_LIFETIME": timedelta(minutes=30),
     "REFRESH_TOKEN_LIFETIME": timedelta(days=30),
     
-    # Custom algorithm
-    "ALGORITHM": "HS512",
+    # Custom algorithm (HS256, RS256, or ES256)
+    "ALGORITHM": "HS256",
     
     # Custom secret key
     "JWT_SECRET_KEY": "your-super-secret-key",


### PR DESCRIPTION
## Summary
Ghost audit found 10 stale documentation references. All fixed:

| # | Fix |
|---|-----|
| 1 | Remove non-existent `memory_storage.py` from CLAUDE.md |
| 2 | Update v0.3.0 → v0.4.0 install URLs in CLAUDE.md |
| 3 | Add missing trigger config keys to `ConfigKeys` |
| 4-5 | Add `TOTP_2FA` feature flag to conf.py defaults |
| 6 | Replace phantom validators with real `BlockAuthPasswordValidator` |
| 7-8 | Fix internal monorepo paths in JWT guide |
| 9 | Fix unsupported HS512 → HS256 in token guide |
| 10 | Fix monorepo path in passkey implementation plan |

## Test plan
- [x] `uv run pytest` — 333 passed, 0 failures