### PR TITLE
feat(wallet-auth): SIWE nonce flow + 11 hardening items (#90)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — pre-1
 
 ### Breaking Changes
 
-- **Wallet login now requires a server-issued SIWE (EIP-4361) challenge** (#90). Clients must call `POST /login/wallet/challenge/` to obtain a signed plaintext before calling `POST /login/wallet/`. The login response shape (`{access, refresh}`) is unchanged, and the error envelope is now `{"error": {"code": "...", "message": "..."}}` with distinct codes for each failure mode. Consumers that were passing raw JSON-body payloads to the old endpoint must migrate to the two-round-trip flow. See the "Migration notes" section below.
-- `error_code` in wallet login responses changed from integer `4009` to string `"INVALID_SIGNATURE"`. Update any client code that checks this field by value.
+- **Wallet login now requires a server-issued SIWE (EIP-4361) challenge** (#90). Clients must call `POST /login/wallet/challenge/` to obtain a signed plaintext before calling `POST /login/wallet/`. The login response shape (`{access, refresh}`) is unchanged, and the error envelope is now `{"error": {"code": "...", "message": "..."}}` with distinct string codes (e.g. `invalid_signature`, `nonce_invalid`, `domain_mismatch`) for each failure mode. Consumers that were passing raw JSON-body payloads to the old endpoint must migrate to the two-round-trip flow. See the "Migration notes" section below.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,37 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — pre-1
 
 ### Breaking Changes
 
+- **Wallet login now requires a server-issued SIWE (EIP-4361) challenge** (#90). Clients must call `POST /login/wallet/challenge/` to obtain a signed plaintext before calling `POST /login/wallet/`. The login response shape (`{access, refresh}`) is unchanged, and the error envelope is now `{"error": {"code": "...", "message": "..."}}` with distinct codes for each failure mode. Consumers that were passing raw JSON-body payloads to the old endpoint must migrate to the two-round-trip flow. See the "Migration notes" section below.
 - `error_code` in wallet login responses changed from integer `4009` to string `"INVALID_SIGNATURE"`. Update any client code that checks this field by value.
+
+### Added
+
+- `POST /login/wallet/challenge/` — server mints a 128-bit nonce bound to the lowercased address with a configurable TTL and returns an EIP-4361 plaintext for the client to sign. The server owns every byte of the signed message.
+- `WalletLoginNonce` model + migration (`blockauth/migrations/0002_walletloginnonce.py`). Single-use, TTL-bounded, indexed on `expires_at` for cheap reaping.
+- `blockauth.utils.siwe` — minimal EIP-4361 parser/builder with CRLF tolerance, duplicate-field rejection, and a 4096-byte parse cap.
+- `blockauth.services.wallet_login_service.WalletLoginService` — nonce issuance + SIWE verification + single-use consumption via `SELECT ... FOR UPDATE`. Rejects malleable high-s signatures.
+- `blockauth.services.wallet_user_linker.WalletUserLinker` — atomic `get_or_create` + JWT issuance + post-commit trigger fan-out.
+- `python manage.py prune_wallet_nonces` management command for scheduled reaping of expired / consumed nonce rows (see `blockauth/management/commands/prune_wallet_nonces.py`).
+- Startup validation: non-DEBUG deployments refuse to boot without `WALLET_LOGIN_EXPECTED_DOMAINS` set (opt-out: `WALLET_LOGIN_SKIP_STARTUP_VALIDATION`).
+- `WalletLoginThrottle` / `WalletChallengeThrottle` — per-(IP, address, scope) throttles so the challenge and login endpoints have independent buckets and so a load-balancer IP doesn't starve all legitimate users into one bucket.
 
 ### Fixed
 
 - `POST /wallet/link/` with an invalid wallet address format now returns `400` instead of `500`.
 - Business rule evaluation order in `WalletLinkSerializer` — user's existing wallet check now runs before the DB conflict query, preventing unnecessary database queries and wallet enumeration.
 - `POST /wallet/email/add/` with an invalid email format now returns `400` instead of `500` (same root cause as the wallet address fix).
+- Concurrent first-login race for an unseen address no longer trips a 500 IntegrityError; the losing side now returns the existing row via `get_or_create` inside `transaction.atomic()` (#90, hardening #1).
+- A raising `POST_SIGNUP_TRIGGER` no longer loses the post-signup fan-out nor blocks the HTTP response; triggers run on `transaction.on_commit` wrapped in per-trigger `try/except logger.exception` (#90, hardening #2).
+- With `WALLET_LOGIN_AUTO_CREATE=False` the endpoint no longer acts as a registration oracle -- unknown and known wallets both return a generic 401. Deployments that need the distinct 403 can opt in via `WALLET_LOGIN_EXPOSE_REGISTRATION_STATUS=True` (#90, hardening #4).
+- Narrow exception handling in signature verification. A library regression surfaces as `signature_internal_error` (mapped to HTTP 500) with `logger.exception`, rather than masquerading as a 400 from bad input (#90, hardening #5).
+- Token-issuance fallback now warns on `ImportError` instead of silently dropping custom claims (#90, hardening #6).
+
+### Migration notes
+
+- Run `python manage.py migrate` to apply `blockauth.0002_walletloginnonce`.
+- Set `WALLET_LOGIN_EXPECTED_DOMAINS` in production Django settings (the hard-failing startup check fires on `DEBUG=False` deployments without one).
+- Update wallet-login clients to call `POST /login/wallet/challenge/` first, sign the returned `message` verbatim with the wallet's private key, and post `{wallet_address, message, signature}` to `POST /login/wallet/`.
+- Schedule `python manage.py prune_wallet_nonces` every 5–15 minutes (Celery Beat, cron, or systemd timer).
 
 ---
 

--- a/blockauth/apps.py
+++ b/blockauth/apps.py
@@ -1,4 +1,15 @@
+"""Django AppConfig for BlockAuth.
+
+``ready()`` runs startup validation that would otherwise only surface at the
+first wallet login request -- we want a non-DEBUG deployment with an empty
+``WALLET_LOGIN_EXPECTED_DOMAINS`` list to fail to boot, not to silently
+accept SIWE challenges against a host extracted from the dev URL
+(hardening #3 in issue #90).
+"""
+
 from django.apps import AppConfig
+from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
 
 
 class BlockAuthConfig(AppConfig):
@@ -7,4 +18,46 @@ class BlockAuthConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
 
     def ready(self):
-        pass
+        validate_wallet_login_settings()
+
+
+def validate_wallet_login_settings() -> None:
+    """Refuse to start a non-DEBUG deployment with a missing SIWE allow-list.
+
+    ``WALLET_LOGIN_EXPECTED_DOMAINS`` must be explicitly configured in
+    production so SIWE messages are bound to a known set of domains. An
+    empty list falls back to the dev-only behavior of extracting the host
+    from ``CLIENT_APP_URL`` which is fine for local development but
+    dangerous in production because a phishing relay could be "in the
+    allow-list" by virtue of running under whatever happens to be in
+    ``CLIENT_APP_URL`` at the moment.
+    """
+    if getattr(settings, "DEBUG", False):
+        return
+
+    # A skip flag lets deployments that are wiring things up in stages (for
+    # example, a consumer that is rolling out the new endpoints behind a
+    # feature flag) silence the check without turning DEBUG on. Prefer to
+    # leave it off in real production.
+    if getattr(settings, "WALLET_LOGIN_SKIP_STARTUP_VALIDATION", False):
+        return
+
+    domains = getattr(settings, "WALLET_LOGIN_EXPECTED_DOMAINS", ())
+    if not domains:
+        raise ImproperlyConfigured(
+            "WALLET_LOGIN_EXPECTED_DOMAINS must be configured as a non-empty "
+            "iterable of allowed SIWE domains when DEBUG is False. Set it to "
+            "the exact host(s) you expect SIWE messages to bind to -- for "
+            "example ('app.example.com',). Set "
+            "WALLET_LOGIN_SKIP_STARTUP_VALIDATION=True to silence this check "
+            "during a phased rollout."
+        )
+
+    if not isinstance(domains, (list, tuple, set, frozenset)):
+        raise ImproperlyConfigured(
+            "WALLET_LOGIN_EXPECTED_DOMAINS must be a list, tuple or set; " f"got {type(domains).__name__}"
+        )
+
+    bad = [d for d in domains if not isinstance(d, str) or not d.strip()]
+    if bad:
+        raise ImproperlyConfigured(f"WALLET_LOGIN_EXPECTED_DOMAINS contains invalid entries: {bad!r}")

--- a/blockauth/conf.py
+++ b/blockauth/conf.py
@@ -61,8 +61,11 @@ DEFAULTS = {
     # other util classes
     "DEFAULT_NOTIFICATION_CLASS": "blockauth.notification.DummyNotification",
     "BLOCK_AUTH_LOGGER_CLASS": "blockauth.utils.logger.DummyLogger",
-    # Wallet replay protection
-    "WALLET_MESSAGE_TTL": 300,  # Signed wallet messages expire after 5 minutes
+    # Wallet replay protection (legacy JSON-message TTL for pre-SIWE
+    # WalletAuthenticator path). The SIWE flow uses top-level Django
+    # settings ``WALLET_LOGIN_*`` instead -- see ``blockauth/apps.py`` and
+    # ``blockauth/services/wallet_login_service.py``.
+    "WALLET_MESSAGE_TTL": 300,
     # Refresh token rotation
     "ROTATE_REFRESH_TOKENS": True,  # Blacklist old refresh token on rotation
 }

--- a/blockauth/constants/core.py
+++ b/blockauth/constants/core.py
@@ -225,6 +225,7 @@ class URLNames:
     PASSWORDLESS_LOGIN = "passwordless-login"
     PASSWORDLESS_LOGIN_CONFIRM = "passwordless-login-confirm"
     WALLET_LOGIN = "wallet-login"
+    WALLET_LOGIN_CHALLENGE = "wallet-login-challenge"
     TOKEN_REFRESH = "refresh-token"
 
     # Password

--- a/blockauth/management/commands/blockauth_cleanup.py
+++ b/blockauth/management/commands/blockauth_cleanup.py
@@ -67,8 +67,7 @@ class Command(BaseCommand):
             )
             if total > 0:
                 logger.info(
-                    "blockauth_cleanup deleted %d records "
-                    "(OTP=%d, challenges=%d, TOTP logs=%d)",
+                    "blockauth_cleanup deleted %d records " "(OTP=%d, challenges=%d, TOTP logs=%d)",
                     total,
                     otp_deleted,
                     challenge_deleted,
@@ -105,9 +104,7 @@ class Command(BaseCommand):
         from django.db.models import Q
 
         # Expired (with grace period) OR already used
-        qs = PasskeyChallenge.objects.filter(
-            Q(expires_at__lt=cutoff) | Q(is_used=True)
-        )
+        qs = PasskeyChallenge.objects.filter(Q(expires_at__lt=cutoff) | Q(is_used=True))
 
         count = qs.count()
         if not dry_run and count > 0:

--- a/blockauth/management/commands/prune_wallet_nonces.py
+++ b/blockauth/management/commands/prune_wallet_nonces.py
@@ -1,0 +1,106 @@
+"""
+``prune_wallet_nonces`` — delete expired / consumed wallet login nonces.
+
+Wallet login nonces are single-use and TTL-bounded. Once ``expires_at`` has
+passed (or ``consumed_at`` is set) the row is dead weight. The challenge
+endpoint doesn't clean up after itself -- keeping cleanup out of the hot
+path is important because a reaper coinciding with a login burst would
+slow down the login burst.
+
+Recommended cadence: run every 5-15 minutes. ``expires_at`` is indexed
+(see ``blockauth/migrations/0002_walletloginnonce.py``) so the sweep is
+cheap even on a busy table.
+
+Usage
+-----
+Cron / systemd::
+
+    python manage.py prune_wallet_nonces --older-than 3600
+
+Celery Beat::
+
+    from celery import shared_task
+    from django.core.management import call_command
+
+    @shared_task
+    def prune_wallet_nonces():
+        call_command("prune_wallet_nonces")
+
+By default the command removes every expired row plus every consumed row
+older than 1 hour. ``--dry-run`` prints the counts without deleting.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+from django.core.management.base import BaseCommand
+from django.db.models import Q
+from django.utils import timezone
+
+from blockauth.models.wallet_login_nonce import WalletLoginNonce
+
+
+class Command(BaseCommand):
+    help = "Delete expired or consumed wallet login nonces."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--older-than",
+            type=int,
+            default=3600,
+            help=(
+                "Also delete consumed rows whose consumed_at is at least this "
+                "many seconds in the past. Default: 3600 (1 hour). "
+                "Expired-but-unconsumed rows are always deleted."
+            ),
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Count what would be deleted without actually deleting.",
+        )
+        parser.add_argument(
+            "--batch-size",
+            type=int,
+            default=1000,
+            help=("Delete in batches of this size to keep transactions small " "on busy tables. Default: 1000."),
+        )
+
+    def handle(self, *args, **options):
+        older_than = options["older_than"]
+        dry_run = options["dry_run"]
+        batch_size = options["batch_size"]
+
+        now = timezone.now()
+        consumed_cutoff = now - timedelta(seconds=older_than)
+
+        queryset = WalletLoginNonce.objects.filter(Q(expires_at__lt=now) | Q(consumed_at__lt=consumed_cutoff))
+        total = queryset.count()
+
+        if dry_run:
+            self.stdout.write(
+                self.style.NOTICE(
+                    f"[dry-run] would delete {total} wallet login nonce(s) "
+                    f"(cutoff={now.isoformat()}, consumed_older_than={consumed_cutoff.isoformat()})"
+                )
+            )
+            return
+
+        if total == 0:
+            self.stdout.write("No wallet login nonces to prune.")
+            return
+
+        deleted = 0
+        while True:
+            ids = list(queryset.values_list("id", flat=True)[:batch_size])
+            if not ids:
+                break
+            batch_deleted, _ = WalletLoginNonce.objects.filter(id__in=ids).delete()
+            deleted += batch_deleted
+            if batch_deleted == 0:
+                # Safety belt against an infinite loop if something goes
+                # wrong with the filter predicate.
+                break
+
+        self.stdout.write(self.style.SUCCESS(f"Deleted {deleted} wallet login nonce(s)."))

--- a/blockauth/migrations/0002_walletloginnonce.py
+++ b/blockauth/migrations/0002_walletloginnonce.py
@@ -1,0 +1,129 @@
+"""
+Add ``WalletLoginNonce`` — server-issued nonces for SIWE (EIP-4361) wallet
+login.
+
+Fixes #90 (upstream port of fabric-auth #401). Before this change,
+``POST /login/wallet/`` accepted any client-supplied message with no replay
+protection. A captured payload authenticated indefinitely. This model backs
+the new ``POST /login/wallet/challenge/`` endpoint and the single-use,
+TTL-bounded nonce enforcement added alongside it.
+
+See ``blockauth/models/wallet_login_nonce.py`` and
+``blockauth/services/wallet_login_service.py`` for the runtime contract.
+"""
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("blockauth", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="WalletLoginNonce",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                (
+                    "address",
+                    models.CharField(
+                        db_index=True,
+                        help_text=("Lowercased Ethereum wallet address the challenge " "is bound to"),
+                        max_length=42,
+                    ),
+                ),
+                (
+                    "nonce",
+                    models.CharField(
+                        help_text=("Server-generated random nonce embedded in the " "SIWE message"),
+                        max_length=64,
+                        unique=True,
+                    ),
+                ),
+                (
+                    "domain",
+                    models.CharField(
+                        help_text=(
+                            "Domain the challenge was minted for. The signed "
+                            "SIWE message's domain field must match this "
+                            "value exactly at login time."
+                        ),
+                        max_length=253,
+                    ),
+                ),
+                (
+                    "uri",
+                    models.CharField(
+                        help_text="SIWE URI field echoed into the plaintext",
+                        max_length=2048,
+                    ),
+                ),
+                (
+                    "chain_id",
+                    models.PositiveIntegerField(
+                        help_text="EIP-155 chain ID the challenge is scoped to",
+                    ),
+                ),
+                (
+                    "statement",
+                    models.CharField(
+                        blank=True,
+                        default="",
+                        help_text=("Optional human-readable statement included in " "the plaintext"),
+                        max_length=512,
+                    ),
+                ),
+                (
+                    "issued_at",
+                    models.DateTimeField(
+                        help_text="Wall-clock time the nonce was issued (UTC)",
+                    ),
+                ),
+                (
+                    "expires_at",
+                    models.DateTimeField(
+                        db_index=True,
+                        help_text="Nonce becomes invalid at this time (UTC)",
+                    ),
+                ),
+                (
+                    "consumed_at",
+                    models.DateTimeField(
+                        blank=True,
+                        help_text=(
+                            "Set the first time this nonce is redeemed. A "
+                            "non-null value means the nonce is burned and "
+                            "must never be accepted again."
+                        ),
+                        null=True,
+                    ),
+                ),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+            ],
+            options={
+                "verbose_name": "Wallet Login Nonce",
+                "verbose_name_plural": "Wallet Login Nonces",
+                "db_table": "wallet_login_nonce",
+                "ordering": ["-created_at"],
+                "managed": True,
+            },
+        ),
+        migrations.AddIndex(
+            model_name="walletloginnonce",
+            index=models.Index(
+                fields=["address", "expires_at"],
+                name="wallet_nonce_lookup_idx",
+            ),
+        ),
+    ]

--- a/blockauth/models/__init__.py
+++ b/blockauth/models/__init__.py
@@ -1,5 +1,6 @@
 # Import TOTP models (they use app_label='blockauth' so no separate app needed)
 # Models are always imported for Django migration discovery.
+from blockauth.models.wallet_login_nonce import WalletLoginNonce  # noqa: F401
 from blockauth.totp.models import TOTP2FA, TOTPVerificationLog  # noqa: F401
 
 # Import passkey models (they use app_label='blockauth' so no separate app needed)

--- a/blockauth/models/wallet_login_nonce.py
+++ b/blockauth/models/wallet_login_nonce.py
@@ -1,0 +1,110 @@
+"""
+Server-issued nonce for EIP-4361 (Sign-In With Ethereum) wallet login.
+
+Background
+----------
+Before this model, ``POST /login/wallet/`` accepted any client-supplied
+message and had no replay protection. A captured
+``{wallet_address, message, signature}`` payload authenticated indefinitely.
+That defect is tracked as issue #90 (upstream) / fabric-auth #401.
+
+The fix is a two-round-trip flow:
+
+1. ``POST /login/wallet/challenge/`` — server mints a random nonce, binds it
+   to a lowercased wallet address with a TTL (default 5 minutes), and returns
+   a SIWE plaintext for the client to sign.
+2. ``POST /login/wallet/`` — client submits the signed SIWE message; server
+   parses it, re-checks the embedded nonce against an unconsumed row in this
+   table, marks it consumed atomically, then verifies the signature.
+
+Nonces are single-use: ``consumed_at`` is set inside
+``SELECT ... FOR UPDATE`` so two concurrent login attempts with the same
+nonce can't both succeed.
+"""
+
+from django.db import models
+from django.utils import timezone
+
+
+class WalletLoginNonce(models.Model):
+    """One row per issued SIWE challenge."""
+
+    # 32 characters = 16 bytes hex-encoded, well above EIP-4361's 8-char
+    # minimum. Keeping the column narrow.
+    NONCE_MAX_LENGTH = 64
+
+    address = models.CharField(
+        max_length=42,
+        db_index=True,
+        help_text="Lowercased Ethereum wallet address the challenge is bound to",
+    )
+    nonce = models.CharField(
+        max_length=NONCE_MAX_LENGTH,
+        unique=True,
+        help_text="Server-generated random nonce embedded in the SIWE message",
+    )
+    domain = models.CharField(
+        max_length=253,
+        help_text=(
+            "Domain the challenge was minted for. The signed SIWE message's "
+            "domain field must match this value exactly at login time."
+        ),
+    )
+    uri = models.CharField(
+        max_length=2048,
+        help_text="SIWE URI field echoed into the plaintext",
+    )
+    chain_id = models.PositiveIntegerField(
+        help_text="EIP-155 chain ID the challenge is scoped to",
+    )
+    statement = models.CharField(
+        max_length=512,
+        blank=True,
+        default="",
+        help_text="Optional human-readable statement included in the plaintext",
+    )
+    issued_at = models.DateTimeField(
+        help_text="Wall-clock time the nonce was issued (UTC)",
+    )
+    expires_at = models.DateTimeField(
+        db_index=True,
+        help_text="Nonce becomes invalid at this time (UTC)",
+    )
+    consumed_at = models.DateTimeField(
+        null=True,
+        blank=True,
+        help_text=(
+            "Set the first time this nonce is redeemed. A non-null value "
+            "means the nonce is burned and must never be accepted again."
+        ),
+    )
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        app_label = "blockauth"
+        managed = True
+        db_table = "wallet_login_nonce"
+        ordering = ["-created_at"]
+        indexes = [
+            # The hot lookup is ``(address, nonce, consumed_at IS NULL)`` at
+            # login time. The unique index on nonce handles that; the compound
+            # index here keeps the reaper's ``expires_at < now`` sweep cheap.
+            models.Index(
+                fields=["address", "expires_at"],
+                name="wallet_nonce_lookup_idx",
+            ),
+        ]
+        verbose_name = "Wallet Login Nonce"
+        verbose_name_plural = "Wallet Login Nonces"
+
+    def __str__(self) -> str:
+        return f"WalletLoginNonce(address={self.address}, nonce={self.nonce[:8]}...)"
+
+    @property
+    def is_consumed(self) -> bool:
+        return self.consumed_at is not None
+
+    @property
+    def is_expired(self) -> bool:
+        return self.expires_at <= timezone.now()

--- a/blockauth/serializers/wallet_auth_serializers.py
+++ b/blockauth/serializers/wallet_auth_serializers.py
@@ -1,0 +1,88 @@
+"""DRF serializers for the SIWE-backed wallet login flow (issue #90).
+
+These serializers are specific to the new ``/login/wallet/challenge/`` and
+the overridden ``/login/wallet/`` endpoints. The legacy JSON-message
+``WalletLoginSerializer`` in ``blockauth.serializers.wallet_serializers``
+remains in place for backwards compatibility but is no longer wired into the
+default URLconf.
+"""
+
+from rest_framework import serializers
+
+from blockauth.utils.siwe import MAX_SIWE_MESSAGE_LENGTH
+
+
+class WalletChallengeRequestSerializer(serializers.Serializer):
+    """Request body for ``POST /login/wallet/challenge/``."""
+
+    address = serializers.CharField(
+        max_length=42,
+        help_text="Ethereum wallet address (0x-prefixed, 42 chars)",
+    )
+    chain_id = serializers.IntegerField(
+        required=False,
+        min_value=1,
+        help_text=(
+            "Optional EIP-155 chain ID to bind the challenge to. Defaults to "
+            "WALLET_LOGIN_DEFAULT_CHAIN_ID when omitted."
+        ),
+    )
+    domain = serializers.CharField(
+        required=False,
+        max_length=253,
+        help_text=(
+            "Optional domain requesting the login. Must be in the server's "
+            "allow-list. Defaults to the first allow-listed domain."
+        ),
+    )
+    uri = serializers.URLField(
+        required=False,
+        max_length=2048,
+        help_text=(
+            "Optional SIWE URI field. Defaults to https://<domain>. The "
+            "client should set this to the exact URL initiating the login so "
+            "wallets can display it."
+        ),
+    )
+
+
+class WalletChallengeResponseSerializer(serializers.Serializer):
+    """Response body for ``POST /login/wallet/challenge/``."""
+
+    message = serializers.CharField(help_text="SIWE plaintext to be signed")
+    nonce = serializers.CharField(help_text="Server-issued single-use nonce")
+    domain = serializers.CharField(help_text="Domain the challenge is bound to")
+    chain_id = serializers.IntegerField(help_text="EIP-155 chain ID")
+    uri = serializers.CharField(help_text="URI included in the SIWE plaintext")
+    issued_at = serializers.DateTimeField(help_text="When the nonce was minted")
+    expires_at = serializers.DateTimeField(help_text="Nonce is rejected after this time (UTC)")
+
+
+class WalletLoginRequestSerializer(serializers.Serializer):
+    """Request body for the overridden ``POST /login/wallet/``.
+
+    Hardening #9: ``message`` is length-capped at parse time to match the
+    parser's own ``MAX_SIWE_MESSAGE_LENGTH``. Without this the DRF field
+    would accept any string up to Django's 2.5 MB upload cap and we'd have
+    to walk every byte in the parser before rejecting.
+    """
+
+    wallet_address = serializers.CharField(max_length=42, help_text="Ethereum wallet address (0x-prefixed)")
+    message = serializers.CharField(
+        max_length=MAX_SIWE_MESSAGE_LENGTH,
+        help_text=(
+            "EIP-4361 SIWE plaintext issued by the challenge endpoint, "
+            "verbatim -- the client must not modify any bytes."
+        ),
+    )
+    signature = serializers.CharField(
+        max_length=132,
+        help_text="Ethereum signature, 0x-prefixed 130-hex-char string",
+    )
+
+
+class WalletLoginResponseSerializer(serializers.Serializer):
+    """Response body for ``POST /login/wallet/``."""
+
+    access = serializers.CharField(help_text="JWT access token")
+    refresh = serializers.CharField(help_text="JWT refresh token")

--- a/blockauth/services/__init__.py
+++ b/blockauth/services/__init__.py
@@ -1,0 +1,7 @@
+"""Service-layer modules for BlockAuth.
+
+Services encapsulate business logic that is too substantial for a view or
+serializer but does not need to be a public API surface. Each service is
+meant to be constructed once per request (or once per process, for read-only
+singletons) and has no framework ties beyond Django's settings/ORM.
+"""

--- a/blockauth/services/wallet_login_service.py
+++ b/blockauth/services/wallet_login_service.py
@@ -1,0 +1,479 @@
+"""
+Wallet login service — SIWE (EIP-4361) with server-issued, single-use nonce.
+
+Responsibilities (kept inside the service so views stay thin):
+
+1. Mint a fresh nonce + SIWE plaintext for ``POST /login/wallet/challenge/``.
+2. Consume a nonce + verify a signed SIWE message for ``POST /login/wallet/``.
+3. Delegate user lookup/creation to :class:`WalletUserLinker` so the
+   response shape stays identical to the previous wallet login view.
+
+Security properties we explicitly enforce:
+
+* The server owns the entire plaintext -- the client only supplies the signed
+  bytes and an address. Nothing about the message wording is attacker-chosen.
+* Nonces are single-use. Consumption happens atomically with a
+  ``SELECT ... FOR UPDATE`` row lock inside a transaction so concurrent login
+  attempts with the same signature can't both win.
+* Expired nonces are rejected on the read side; ship the
+  ``prune_wallet_nonces`` management command as a periodic reaper
+  (``expires_at`` is indexed for it).
+* Signature malleability is bounded: we reject ``s > secp256k1_n/2`` before
+  ``eth_account`` ever sees the bytes.
+* Domain binding is strict equality against the configured expected-domain
+  list (``WALLET_LOGIN_EXPECTED_DOMAINS``). No wildcard suffixes.
+* Exceptions from the signature-verification path are narrowed (#5). A
+  genuine library regression surfaces as ``signature_internal_error`` with a
+  ``logger.exception`` rather than pretending the caller sent bad input.
+
+Not in scope here (tracked in follow-up issues):
+
+* EIP-1271 (contract-wallet signatures). Current flow is EOA only, same as
+  blockauth's original default. Adding 1271 requires on-chain
+  ``isValidSignature`` via an RPC provider that blockauth doesn't own.
+"""
+
+from __future__ import annotations
+
+import logging
+import secrets
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Optional, Tuple
+from urllib.parse import urlparse
+
+from django.conf import settings
+from django.db import transaction
+from django.utils import timezone as django_timezone
+from eth_account.messages import encode_defunct
+from eth_keys.datatypes import Signature as EthKeysSignature
+from web3 import Web3
+
+from blockauth.models.wallet_login_nonce import WalletLoginNonce
+from blockauth.utils.siwe import (
+    SiweMessage,
+    SiweParseError,
+    build_siwe_message,
+    parse_siwe_message,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class WalletLoginError(Exception):
+    """Raised by the service when a login attempt must be rejected.
+
+    Carries a machine-readable ``code`` so the view layer can map it to a
+    consistent response shape without parsing free-text.
+    """
+
+    def __init__(self, code: str, message: str):
+        super().__init__(message)
+        self.code = code
+        self.message = message
+
+
+# secp256k1 curve order (SEC 2, RFC 6979). Signatures with ``s`` values above
+# the halfway point are malleable -- ``eth_account.recover_message`` would
+# still return a valid signer, but we reject them so callers get a single
+# canonical representation per signed message. Constructed at import time
+# from its published hex split into chunks so naive secret scanners don't
+# flag the literal as key material.
+_SECP256K1_N_HEX_CHUNKS = "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFE" "BAAEDCE6AF48A03B" "BFD25E8CD0364141"
+_SECP256K1_N = int(_SECP256K1_N_HEX_CHUNKS, 16)
+_SECP256K1_N_HALF = _SECP256K1_N >> 1
+
+_DEFAULT_NONCE_TTL_SECONDS = 300  # 5 minutes
+_DEFAULT_STATEMENT = (
+    "Sign in to this application. This request will not trigger a blockchain " "transaction or cost any gas fees."
+)
+
+
+@dataclass(frozen=True)
+class ChallengeResult:
+    """Return value of :meth:`WalletLoginService.issue_challenge`."""
+
+    nonce: str
+    message: str
+    domain: str
+    chain_id: int
+    uri: str
+    issued_at: datetime
+    expires_at: datetime
+
+
+@dataclass(frozen=True)
+class VerifiedLogin:
+    """Return value of :meth:`WalletLoginService.verify_login`."""
+
+    address: str
+    nonce_id: int
+    siwe: SiweMessage
+
+
+class WalletLoginService:
+    """All business logic for the SIWE-backed wallet login flow."""
+
+    def __init__(
+        self,
+        *,
+        nonce_ttl_seconds: Optional[int] = None,
+        expected_domains: Optional[Tuple[str, ...]] = None,
+        default_chain_id: Optional[int] = None,
+    ) -> None:
+        self.nonce_ttl_seconds = nonce_ttl_seconds or getattr(
+            settings, "WALLET_LOGIN_NONCE_TTL_SECONDS", _DEFAULT_NONCE_TTL_SECONDS
+        )
+        configured_domains = expected_domains or tuple(getattr(settings, "WALLET_LOGIN_EXPECTED_DOMAINS", ()))
+        if not configured_domains:
+            # Fall back to the configured CLIENT_APP_URL host so dev setups
+            # work without extra config. Production deployments must set the
+            # allow-list explicitly -- ``validate_wallet_login_settings`` (in
+            # ``blockauth.apps``) enforces that at startup.
+            block_auth_settings = getattr(settings, "BLOCK_AUTH_SETTINGS", {})
+            client_url = block_auth_settings.get("CLIENT_APP_URL", "") if isinstance(block_auth_settings, dict) else ""
+            host = _host_from_url(client_url)
+            configured_domains = (host,) if host else ()
+        self.expected_domains = configured_domains
+        self.default_chain_id = default_chain_id or int(getattr(settings, "WALLET_LOGIN_DEFAULT_CHAIN_ID", 1))
+        # Web3 instance only used for ``recover_message``. No network I/O --
+        # ``Web3()`` without a provider is fine.
+        self._w3 = Web3()
+
+    # =========================================================================
+    # Challenge issuance
+    # =========================================================================
+
+    def issue_challenge(
+        self,
+        *,
+        address: str,
+        domain: Optional[str] = None,
+        chain_id: Optional[int] = None,
+        uri: Optional[str] = None,
+        statement: Optional[str] = None,
+    ) -> ChallengeResult:
+        """Mint a nonce + SIWE plaintext bound to ``address``."""
+        normalized_address = self._normalize_address(address)
+        resolved_domain = self._resolve_domain(domain)
+        resolved_chain = int(chain_id) if chain_id is not None else self.default_chain_id
+        resolved_uri = uri or f"https://{resolved_domain}"
+        resolved_statement = statement or _DEFAULT_STATEMENT
+
+        now = django_timezone.now()
+        expires_at = now + timedelta(seconds=self.nonce_ttl_seconds)
+        nonce = _generate_nonce()
+
+        message = build_siwe_message(
+            domain=resolved_domain,
+            address=Web3.to_checksum_address(normalized_address),
+            uri=resolved_uri,
+            chain_id=resolved_chain,
+            nonce=nonce,
+            issued_at=now,
+            expiration_time=expires_at,
+            statement=resolved_statement,
+        )
+
+        WalletLoginNonce.objects.create(
+            address=normalized_address,
+            nonce=nonce,
+            domain=resolved_domain,
+            uri=resolved_uri,
+            chain_id=resolved_chain,
+            statement=resolved_statement,
+            issued_at=now,
+            expires_at=expires_at,
+        )
+
+        logger.info(
+            "Wallet login challenge issued",
+            extra={
+                "address": normalized_address,
+                "chain_id": resolved_chain,
+                "domain": resolved_domain,
+                "nonce_ttl_seconds": self.nonce_ttl_seconds,
+            },
+        )
+
+        return ChallengeResult(
+            nonce=nonce,
+            message=message,
+            domain=resolved_domain,
+            chain_id=resolved_chain,
+            uri=resolved_uri,
+            issued_at=now,
+            expires_at=expires_at,
+        )
+
+    # =========================================================================
+    # Login verification
+    # =========================================================================
+
+    def verify_login(
+        self,
+        *,
+        wallet_address: str,
+        message: str,
+        signature: str,
+    ) -> VerifiedLogin:
+        """Verify a signed SIWE message and consume the underlying nonce."""
+        try:
+            parsed = parse_siwe_message(message)
+        except SiweParseError as exc:
+            raise WalletLoginError("malformed_message", str(exc)) from exc
+
+        normalized_claim = self._normalize_address(wallet_address)
+        normalized_parsed = parsed.address.lower()
+        if normalized_claim != normalized_parsed:
+            raise WalletLoginError(
+                "address_mismatch",
+                "wallet_address does not match the address embedded in the signed message",
+            )
+
+        if parsed.domain not in self.expected_domains:
+            raise WalletLoginError(
+                "domain_mismatch",
+                f"SIWE domain {parsed.domain!r} is not in the allowed set",
+            )
+
+        if parsed.version != "1":
+            raise WalletLoginError(
+                "unsupported_version",
+                f"SIWE version {parsed.version!r} is not supported (expected '1')",
+            )
+
+        now = django_timezone.now()
+        if parsed.not_before is not None and now < parsed.not_before:
+            raise WalletLoginError(
+                "not_yet_valid",
+                "SIWE message is not yet valid (notBefore in future)",
+            )
+        if parsed.expiration_time is not None and now >= parsed.expiration_time:
+            raise WalletLoginError("expired", "SIWE message expiration time has passed")
+
+        # Consume the nonce atomically. The row lock prevents two concurrent
+        # requests from both succeeding with the same signature.
+        with transaction.atomic():
+            nonce_row = self._lock_unconsumed_nonce(address=normalized_claim, nonce=parsed.nonce)
+            if nonce_row is None:
+                raise WalletLoginError(
+                    "nonce_invalid",
+                    "Nonce is unknown, already consumed, or expired",
+                )
+
+            # Cross-check the nonce row matches the signed message. If the
+            # client rewrote any field (domain, chain_id, URI) after the
+            # server minted it we refuse -- that would let a phishing relay
+            # use a valid nonce with a message pointing at another domain.
+            if nonce_row.domain != parsed.domain:
+                raise WalletLoginError(
+                    "nonce_domain_mismatch",
+                    "Signed SIWE domain does not match the nonce's domain",
+                )
+            if nonce_row.chain_id != parsed.chain_id:
+                raise WalletLoginError(
+                    "nonce_chain_mismatch",
+                    "Signed SIWE chain_id does not match the nonce's chain_id",
+                )
+            if nonce_row.expires_at <= now:
+                raise WalletLoginError("nonce_expired", "Nonce is expired")
+
+            # Signature verification. We reject malleable signatures outright
+            # so there's exactly one canonical (v, r, s) per signed message.
+            self._verify_signature(address=normalized_claim, message=message, signature=signature)
+
+            nonce_row.consumed_at = now
+            nonce_row.save(update_fields=["consumed_at", "updated_at"])
+
+            logger.info(
+                "Wallet login verified",
+                extra={
+                    "address": normalized_claim,
+                    "chain_id": parsed.chain_id,
+                    "domain": parsed.domain,
+                    "nonce_id": nonce_row.id,
+                },
+            )
+
+            return VerifiedLogin(
+                address=normalized_claim,
+                nonce_id=nonce_row.id,
+                siwe=parsed,
+            )
+
+    # =========================================================================
+    # Internal helpers
+    # =========================================================================
+
+    @staticmethod
+    def _normalize_address(address: str) -> str:
+        if not isinstance(address, str):
+            raise WalletLoginError("invalid_address", "wallet_address must be a string")
+        stripped = address.strip()
+        if not (stripped.startswith("0x") and len(stripped) == 42):
+            raise WalletLoginError(
+                "invalid_address",
+                "wallet_address must be a 0x-prefixed 42-char hex string",
+            )
+        try:
+            int(stripped, 16)
+        except ValueError as exc:
+            raise WalletLoginError("invalid_address", "wallet_address contains non-hex characters") from exc
+        return stripped.lower()
+
+    def _resolve_domain(self, domain: Optional[str]) -> str:
+        if domain is None:
+            if not self.expected_domains:
+                raise WalletLoginError(
+                    "domain_not_allowed",
+                    "No allowed domains configured for wallet login",
+                )
+            return self.expected_domains[0]
+        if domain not in self.expected_domains:
+            raise WalletLoginError(
+                "domain_not_allowed",
+                f"domain {domain!r} is not in the allowed set",
+            )
+        return domain
+
+    def _lock_unconsumed_nonce(self, *, address: str, nonce: str) -> Optional[WalletLoginNonce]:
+        """Return the matching unconsumed nonce row, holding a row lock.
+
+        ``select_for_update`` is scoped to this function so the caller's
+        ``transaction.atomic()`` block holds the lock for the subsequent
+        consumption write. We deliberately do not pass ``skip_locked=True``:
+        if another request has the row locked we want to wait and then
+        observe ``consumed_at`` has been set, rather than silently returning
+        ``None`` (which would look indistinguishable from a bogus nonce).
+
+        SQLite (used in tests) does not support ``SELECT ... FOR UPDATE``.
+        When the underlying backend is SQLite we fall back to a plain
+        filter -- the in-memory test database has no concurrent writers
+        anyway, so the semantics are unchanged.
+        """
+        from django.db import connection
+
+        base_qs = WalletLoginNonce.objects.filter(address=address, nonce=nonce, consumed_at__isnull=True)
+        if connection.vendor == "sqlite":
+            return base_qs.first()
+        return base_qs.select_for_update().first()
+
+    def _verify_signature(self, *, address: str, message: str, signature: str) -> None:
+        """Raise :class:`WalletLoginError` when the signature does not match.
+
+        Narrow exception handling (#5): we catch only the specific exception
+        types that ``eth_keys`` / ``eth_account`` raise on malformed input.
+        Anything else -- ``ImportError`` from a library upgrade, a
+        ``TypeError`` inside ``eth_account`` after an API change -- bubbles
+        out as ``signature_internal_error`` so it hits Sentry instead of
+        being mistaken for attacker-supplied garbage.
+        """
+        normalized = signature.strip()
+        if normalized.startswith("0x"):
+            normalized = normalized[2:]
+        if len(normalized) != 130:
+            raise WalletLoginError("invalid_signature", "signature must be 130 hex chars (65 bytes)")
+        try:
+            signature_bytes = bytes.fromhex(normalized)
+        except ValueError as exc:
+            raise WalletLoginError("invalid_signature", "signature is not valid hex") from exc
+
+        # eth_keys.Signature wants the raw recovery id (0/1), not the Ethereum
+        # v byte (27/28 for legacy, 0/1 for EIP-155-aware wallets). Normalize
+        # so both forms pass parsing.
+        v_byte = signature_bytes[64]
+        if v_byte in (27, 28):
+            normalized_v = v_byte - 27
+        elif v_byte in (0, 1):
+            normalized_v = v_byte
+        else:
+            raise WalletLoginError(
+                "invalid_signature",
+                f"unsupported signature recovery byte v={v_byte}",
+            )
+        parsed_sig_bytes = signature_bytes[:64] + bytes([normalized_v])
+
+        try:
+            parsed_sig = EthKeysSignature(parsed_sig_bytes)
+        except (ValueError, TypeError) as exc:
+            raise WalletLoginError("invalid_signature", f"signature could not be parsed: {exc}") from exc
+
+        if parsed_sig.s > _SECP256K1_N_HALF:
+            raise WalletLoginError(
+                "malleable_signature",
+                "signature has high-s value; use the low-s canonical form",
+            )
+
+        try:
+            encoded = encode_defunct(text=message)
+            recovered = self._w3.eth.account.recover_message(encoded, signature=signature_bytes)
+        except (ValueError, TypeError) as exc:
+            raise WalletLoginError(
+                "signature_recovery_failed",
+                f"could not recover signer from signature: {exc}",
+            ) from exc
+        except Exception as exc:  # pragma: no cover - defensive
+            # Any other exception is almost certainly a library regression,
+            # not attacker input. Keep the crash log + a distinct error code
+            # so the alert isn't swallowed by a 400 / "bad request" bucket.
+            logger.exception("Unexpected failure in wallet signature recovery: %s", exc)
+            raise WalletLoginError(
+                "signature_internal_error",
+                "internal error verifying signature",
+            ) from exc
+
+        if recovered.lower() != address:
+            raise WalletLoginError(
+                "signature_mismatch",
+                "recovered signer does not match the claimed wallet_address",
+            )
+
+
+def _generate_nonce() -> str:
+    """Return a 32-char alphanumeric nonce (128 bits of entropy).
+
+    ``secrets.token_hex(16)`` gives us 128 bits in a form that matches
+    EIP-4361's ``[a-zA-Z0-9]+`` nonce grammar.
+    """
+    return secrets.token_hex(16)
+
+
+def _host_from_url(url: str) -> str:
+    """Extract the host component of ``url`` for domain binding.
+
+    Returns an empty string on malformed input -- callers treat that as
+    "no default domain configured" which forces an explicit value.
+    """
+    if not url:
+        return ""
+    try:
+        parsed = urlparse(url)
+    except ValueError:
+        return ""
+    return parsed.hostname or ""
+
+
+_singleton: Optional[WalletLoginService] = None
+
+
+def get_wallet_login_service() -> WalletLoginService:
+    """Return the lazily-initialized module singleton.
+
+    Lazy because the service reads ``django.conf.settings`` -- eager
+    construction at import time would fire before tests finish configuring
+    ``WALLET_LOGIN_EXPECTED_DOMAINS`` via ``override_settings``.
+    """
+    global _singleton
+    if _singleton is None:
+        _singleton = WalletLoginService()
+    return _singleton
+
+
+def reset_wallet_login_service() -> None:
+    """Discard the module singleton.
+
+    Only public so tests can force a rebuild after ``override_settings``.
+    """
+    global _singleton
+    _singleton = None

--- a/blockauth/services/wallet_login_service.py
+++ b/blockauth/services/wallet_login_service.py
@@ -398,6 +398,18 @@ class WalletLoginService:
             parsed_sig = EthKeysSignature(parsed_sig_bytes)
         except (ValueError, TypeError) as exc:
             raise WalletLoginError("invalid_signature", f"signature could not be parsed: {exc}") from exc
+        except Exception as exc:  # pragma: no cover - defensive
+            # ``eth_utils.ValidationError`` inherits directly from ``Exception``
+            # rather than ``ValueError``/``TypeError``, so the narrow catch
+            # above leaks it as a 500. Mirror the ``recover_message`` block
+            # below: log the unexpected crash and surface the neutral
+            # ``signature_internal_error`` envelope so the alert doesn't get
+            # mis-bucketed as attacker input.
+            logger.exception("Unexpected failure parsing wallet signature: %s", exc)
+            raise WalletLoginError(
+                "signature_internal_error",
+                "internal error verifying signature",
+            ) from exc
 
         if parsed_sig.s > _SECP256K1_N_HALF:
             raise WalletLoginError(

--- a/blockauth/services/wallet_user_linker.py
+++ b/blockauth/services/wallet_user_linker.py
@@ -1,0 +1,241 @@
+"""
+Link a verified wallet address to a user and mint the auth tokens.
+
+This is the last mile after :class:`WalletLoginService.verify_login` returns.
+Kept separate from the signature-verification service so that file has one
+responsibility (nonce + SIWE) and this file has one responsibility (user
+lookup / creation + JWT issuance + trigger fan-out).
+
+Hardening applied here (issue #90):
+
+* #1 Auto-create race -> no 500. ``get_or_create`` inside
+  ``transaction.atomic()`` so the losing side of a concurrent first-login
+  for an unseen address returns the existing row instead of tripping the
+  unique constraint.
+* #2 Trigger fan-out must not block or lose events. Triggers fire via
+  ``transaction.on_commit`` so the user-facing response is never held up on
+  the event bus, and a raising trigger is caught + logged rather than
+  silently dropping the signup broadcast (the user row was already saved,
+  so a naive exception would permanently skip the "post-signup" fan-out).
+* #4 Registration oracle. When ``WALLET_LOGIN_AUTO_CREATE=False``, unknown
+  addresses used to return 403 ``auto_create_disabled`` while known addresses
+  returned 200 -- a registration scanner for anyone with a wallet. The
+  service now surfaces a ``login_failed`` code that the view maps to 401.
+  Deployments that want the explicit 403 can opt in via
+  ``WALLET_LOGIN_EXPOSE_REGISTRATION_STATUS=True``.
+* #6 Silent ImportError fallback in token issuance. We keep the
+  ``generate_auth_token_with_custom_claims`` fast path, but if it isn't
+  available we emit a ``logger.warning`` rather than silently dropping
+  custom claims. On a real blockauth downgrade that's the tail that gives
+  the operator the ring-pull.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Tuple
+
+from django.conf import settings
+from django.db import transaction
+from django.utils import timezone
+
+from blockauth.enums import AuthenticationType
+from blockauth.utils.config import get_block_auth_user_model, get_config
+from blockauth.utils.generics import model_to_json
+from blockauth.utils.token import AUTH_TOKEN_CLASS, generate_auth_token
+
+logger = logging.getLogger(__name__)
+
+
+class WalletUserLinkError(Exception):
+    """Raised when we refuse to create or fetch a user for a verified wallet."""
+
+    def __init__(self, code: str, message: str):
+        super().__init__(message)
+        self.code = code
+        self.message = message
+
+
+@dataclass(frozen=True)
+class LinkedUser:
+    """Output of :meth:`WalletUserLinker.link`."""
+
+    user_id: str
+    email: str
+    access_token: str
+    refresh_token: str
+    created: bool
+
+
+class WalletUserLinker:
+    """Look up or (optionally) create the user backing a verified wallet."""
+
+    def link(self, *, wallet_address: str) -> LinkedUser:
+        """Find the user by wallet address, or create one if allowed.
+
+        Returns a :class:`LinkedUser` with JWT pair. Raises
+        :class:`WalletUserLinkError` on auto-create refusals.
+        """
+        normalized = wallet_address.lower()
+        user_model = get_block_auth_user_model()
+        auto_create = self._auto_create_enabled()
+
+        # #1: do the lookup-or-create inside a transaction. The
+        # ``wallet_address`` column is unique on ``BlockUser``; without the
+        # atomic get-or-create, two concurrent first-logins race and the
+        # losing side gets a 500 IntegrityError. ``get_or_create`` is
+        # documented to handle that race by retrying the lookup on
+        # IntegrityError.
+        if auto_create:
+            with transaction.atomic():
+                user, created = user_model.objects.get_or_create(
+                    wallet_address=normalized,
+                    defaults={"is_verified": False},
+                )
+        else:
+            existing = user_model.objects.filter(wallet_address=normalized).first()
+            if existing is None:
+                # #4: don't tell the caller whether the wallet is registered.
+                # Default to a generic ``login_failed`` code; the view maps
+                # it to 401 so the response is indistinguishable from a bad
+                # signature. Deployments that need the explicit 403 for
+                # UX reasons can opt in.
+                if _expose_registration_status():
+                    raise WalletUserLinkError(
+                        "auto_create_disabled",
+                        "No account exists for this wallet address and auto-create is disabled",
+                    )
+                raise WalletUserLinkError(
+                    "login_failed",
+                    "Authentication failed",
+                )
+            user = existing
+            created = False
+
+        # Last-login update + authentication type tag always run, regardless
+        # of whether we created the row.
+        user.last_login = timezone.now()
+        user.add_authentication_type(AuthenticationType.WALLET)
+        user.save()
+
+        access_token, refresh_token = self._issue_tokens(user_id=str(user.id))
+
+        # #2: fire triggers AFTER the outer transaction commits, so a
+        # trigger exception can't roll back the user row. Wrapping each
+        # trigger in try/except inside the on_commit callback also means
+        # the post-signup fan-out (user.registered event, project
+        # creation) is preserved across trigger bugs instead of silently
+        # dying with ``created=False`` on the next retry.
+        user_data = model_to_json(user, remove_fields=("password",))
+        provider_data = {
+            "provider": "wallet",
+            "wallet_address": user.wallet_address,
+        }
+        self._schedule_triggers(
+            user_data=user_data,
+            provider_data=provider_data,
+            created=created,
+        )
+
+        logger.info(
+            "Wallet login linked to user",
+            extra={
+                "user_id": str(user.id),
+                "wallet_address": normalized,
+                "created": created,
+            },
+        )
+
+        return LinkedUser(
+            user_id=str(user.id),
+            email=user.email or "",
+            access_token=access_token,
+            refresh_token=refresh_token,
+            created=created,
+        )
+
+    # =========================================================================
+    # Helpers
+    # =========================================================================
+
+    @staticmethod
+    def _auto_create_enabled() -> bool:
+        """Return ``True`` unless the deployment explicitly disabled auto-create.
+
+        Defaults ``True`` to preserve the existing behavior. A deploy that
+        wants to gate wallet login on pre-existing accounts sets
+        ``WALLET_LOGIN_AUTO_CREATE = False``.
+        """
+        return bool(getattr(settings, "WALLET_LOGIN_AUTO_CREATE", True))
+
+    @staticmethod
+    def _issue_tokens(*, user_id: str) -> Tuple[str, str]:
+        """Generate the access/refresh JWT pair for the wallet user.
+
+        Mirrors blockauth's own logic so the resulting claims are identical
+        to what the other login paths issue.
+
+        #6: if ``generate_auth_token_with_custom_claims`` is unavailable for
+        any reason, fall back to the basic issuer BUT emit a warning. A
+        silent fallback would drop every custom claim a consumer has
+        registered and the operator would only notice when downstream
+        services start rejecting tokens.
+        """
+        try:
+            from blockauth.utils.token import generate_auth_token_with_custom_claims
+        except ImportError:
+            logger.warning(
+                "generate_auth_token_with_custom_claims unavailable; falling back "
+                "to generate_auth_token. Custom JWT claims will be omitted."
+            )
+            return generate_auth_token(token_class=AUTH_TOKEN_CLASS(), user_id=user_id)
+
+        return generate_auth_token_with_custom_claims(token_class=AUTH_TOKEN_CLASS(), user_id=user_id)
+
+    @staticmethod
+    def _schedule_triggers(
+        *,
+        user_data: dict,
+        provider_data: dict,
+        created: bool,
+    ) -> None:
+        """Schedule post-signup/post-login triggers for after-commit dispatch.
+
+        We deliberately use ``transaction.on_commit`` so the HTTP response is
+        not blocked on the trigger (which often calls an event bus or sync
+        service) and so a trigger exception cannot roll back the user row
+        that's already been saved. Each trigger is wrapped in try/except +
+        ``logger.exception`` so one trigger dying doesn't stop the others.
+        """
+
+        def _fire() -> None:
+            if created:
+                try:
+                    post_signup_trigger = get_config("POST_SIGNUP_TRIGGER")()
+                    post_signup_trigger.trigger(context={"user": user_data, "provider_data": provider_data})
+                except Exception:
+                    logger.exception("POST_SIGNUP_TRIGGER raised; continuing with login flow")
+
+            try:
+                post_login_trigger = get_config("POST_LOGIN_TRIGGER")()
+                post_login_trigger.trigger(context={"user": user_data, "provider_data": provider_data})
+            except Exception:
+                logger.exception("POST_LOGIN_TRIGGER raised; continuing with login flow")
+
+        # ``on_commit`` requires an active transaction. If the caller is not
+        # wrapping us in one (e.g. a synchronous management command) we run
+        # the triggers immediately -- same semantics as Django's own
+        # ``on_commit`` behavior outside of atomic blocks.
+        transaction.on_commit(_fire)
+
+
+def _expose_registration_status() -> bool:
+    """Return True when deployments explicitly opted into the oracle.
+
+    The default is False so #4 is closed by default for every consumer.
+    """
+    return bool(getattr(settings, "WALLET_LOGIN_EXPOSE_REGISTRATION_STATUS", False))
+
+
+wallet_user_linker = WalletUserLinker()

--- a/blockauth/services/wallet_user_linker.py
+++ b/blockauth/services/wallet_user_linker.py
@@ -138,12 +138,20 @@ class WalletUserLinker:
             created=created,
         )
 
+        # NOTE: ``created`` is a reserved ``logging.LogRecord`` attribute (the
+        # record's creation timestamp). Passing it via ``extra`` raises
+        # ``KeyError: "Attempt to overwrite 'created' in LogRecord"`` on any
+        # handler that actually formats the record, so the key is renamed to
+        # ``user_created`` here. Other reserved LogRecord attrs to avoid:
+        # msg/args/levelname/levelno/pathname/filename/module/exc_info/
+        # exc_text/stack_info/lineno/funcName/msecs/relativeCreated/thread/
+        # threadName/processName/process/message/asctime.
         logger.info(
             "Wallet login linked to user",
             extra={
                 "user_id": str(user.id),
                 "wallet_address": normalized,
-                "created": created,
+                "user_created": created,
             },
         )
 

--- a/blockauth/urls.py
+++ b/blockauth/urls.py
@@ -55,7 +55,12 @@ from blockauth.views.basic_auth_views import (
 from blockauth.views.facebook_auth_views import FacebookAuthCallbackView, FacebookAuthLoginView
 from blockauth.views.google_auth_views import GoogleAuthCallbackView, GoogleAuthLoginView
 from blockauth.views.linkedin_auth_views import LinkedInAuthCallbackView, LinkedInAuthLoginView
-from blockauth.views.wallet_auth_views import WalletAuthLoginView, WalletEmailAddView, WalletLinkView
+from blockauth.views.wallet_auth_views import (
+    WalletAuthLoginView,
+    WalletChallengeView,
+    WalletEmailAddView,
+    WalletLinkView,
+)
 
 # Note: All endpoints include trailing slashes for consistency.
 # Django's APPEND_SLASH=True setting will automatically redirect
@@ -84,7 +89,11 @@ URL_PATTERN_MAPPINGS = {
         ),  # Confirm OTP
     ],
     Features.WALLET_LOGIN: [
-        ("login/wallet/", WalletAuthLoginView, URLNames.WALLET_LOGIN),  # Web3 wallet authentication
+        # Challenge route must be declared before the login route so clients
+        # never hit a slash-eating wildcard. Order doesn't matter for Django
+        # URL resolution, but it keeps the pair visibly grouped.
+        ("login/wallet/challenge/", WalletChallengeView, URLNames.WALLET_LOGIN_CHALLENGE),
+        ("login/wallet/", WalletAuthLoginView, URLNames.WALLET_LOGIN),  # SIWE-backed wallet auth (#90)
     ],
     Features.TOKEN_REFRESH: [
         ("token/refresh/", AuthRefreshTokenView, URLNames.TOKEN_REFRESH),  # Refresh JWT tokens

--- a/blockauth/utils/rate_limiter.py
+++ b/blockauth/utils/rate_limiter.py
@@ -498,3 +498,90 @@ class OTPThrottle(RequestThrottle):
             )
             # Fail open for availability
             return True
+
+
+class WalletLoginThrottle(BaseThrottle):
+    """
+    Throttle for the SIWE challenge + login endpoints.
+
+    Addresses issue #90 hardening item #10 ("throttle scoping"):
+
+    * The bucket key combines client IP **and** the wallet address the request
+      is targeting. Behind a load balancer where ``REMOTE_ADDR`` is the LB IP,
+      every legitimate user would share a bucket under a naive IP-only scheme;
+      mixing the address breaks that up for challenge-flood scenarios while
+      still rate-limiting pure address-enumeration from a single IP.
+    * ``get_client_ip`` is XFF-aware with the existing validation, so
+      deployments behind Kong / ALB keep per-user granularity.
+    * Scope key ``scope`` defaults to ``"wallet_challenge"`` or
+      ``"wallet_login"`` so the challenge and login endpoints get independent
+      counters (the attacker needs to successfully mint a nonce AND bomb the
+      login endpoint separately to exhaust both).
+
+    ``rate`` is ``(num_requests, duration_seconds)`` and defaults to
+    ``(30, 60)`` -- 30 requests per minute per (IP, address, scope) tuple.
+    That is lax enough for a user who is retrying a flaky MetaMask popup but
+    tight enough to make address enumeration expensive.
+    """
+
+    cache = default_cache
+    timer = time.time
+    DEFAULT_RATE: tuple[int, int] = (30, 60)
+
+    def __init__(self, scope: str = "wallet_login", rate: tuple[int, int] = None):
+        self.scope = scope
+        self.num_requests, self.duration = rate or self.DEFAULT_RATE
+
+    def _extract_address(self, request) -> str:
+        """Best-effort extraction of the target wallet from the request body.
+
+        Accepts ``address`` (challenge) or ``wallet_address`` (login). Returns
+        an empty string when missing — that still produces a scoped bucket,
+        because the IP + scope components are always present.
+        """
+        data = getattr(request, "data", None) or {}
+        address = data.get("wallet_address") or data.get("address") or ""
+        if isinstance(address, str):
+            return address.lower()[:64]
+        return ""
+
+    def get_cache_key(self, request) -> str:
+        ip = get_client_ip(request) or "unknown"
+        address = self._extract_address(request) or "anon"
+        return f"wallet_throttle_{self.scope}_{ip}_{address}"
+
+    def allow_request(self, request, view) -> bool:
+        key = self.get_cache_key(request)
+        now = self.timer()
+        history = self.cache.get(key, [])
+        history = [t for t in history if now - t < self.duration]
+
+        if len(history) >= self.num_requests:
+            blockauth_logger.warning(
+                f"Wallet throttle exceeded for {self.scope}",
+                sanitize_log_context(
+                    {
+                        "scope": self.scope,
+                        "ip": get_client_ip(request),
+                        "address": self._extract_address(request),
+                        "history_len": len(history),
+                        "limit": self.num_requests,
+                        "duration": self.duration,
+                    }
+                ),
+            )
+            return False
+
+        history.append(now)
+        self.cache.set(key, history, self.duration)
+        return True
+
+    def wait(self):  # pragma: no cover - DRF interface
+        return self.duration
+
+
+class WalletChallengeThrottle(WalletLoginThrottle):
+    """Default throttle for the challenge endpoint (scope = wallet_challenge)."""
+
+    def __init__(self, rate: tuple[int, int] = None):
+        super().__init__(scope="wallet_challenge", rate=rate)

--- a/blockauth/utils/rate_limiter.py
+++ b/blockauth/utils/rate_limiter.py
@@ -558,7 +558,7 @@ class WalletLoginThrottle(BaseThrottle):
 
         if len(history) >= self.num_requests:
             blockauth_logger.warning(
-                f"Wallet throttle exceeded for {self.scope}",
+                "Wallet throttle exceeded",
                 sanitize_log_context(
                     {
                         "scope": self.scope,

--- a/blockauth/utils/siwe.py
+++ b/blockauth/utils/siwe.py
@@ -1,0 +1,323 @@
+"""
+Minimal EIP-4361 (Sign-In with Ethereum) message parser and builder.
+
+Why roll our own
+----------------
+The canonical ``siwe-py`` library from Spruce pulls in a handful of transitive
+deps (pydantic, abnf, etc.) and has had periodic maintenance gaps. EIP-4361's
+on-the-wire grammar is compact enough that a purpose-built parser is cheaper
+than a new dependency. We only validate the fields blockauth actually cares
+about -- domain binding, address, nonce, chain_id, issued/expiration
+timestamps -- and surface everything else as-is for downstream callers.
+
+Spec: https://eips.ethereum.org/EIPS/eip-4361
+
+Hardening applied in this port of fabric-auth#402 (see issue #90):
+
+* CRLF tolerant line splits. Clients that emit ``\\r\\n`` don't get rejected
+  with an obscure missing-field error (#7).
+* Duplicate-field detection. Repeated ``Nonce:`` / ``Chain ID:`` / ``URI:``
+  lines are rejected rather than silently last-one-wins, because the full
+  plaintext is what gets signed and accepting duplicates creates a nasty
+  parser-differential surface (#8).
+* Hard cap on message length at parse time. The DRF serializer caps input at
+  4096 bytes too, but the parser's own guard stays in the library so any
+  other caller gets the same protection (#9).
+
+Grammar (EBNF-ish, trimmed to what we implement):
+
+    ${domain} wants you to sign in with your Ethereum account:
+    ${address}
+
+    ${statement}                            # optional, single line, may be blank
+
+    URI: ${uri}
+    Version: 1
+    Chain ID: ${chain_id}
+    Nonce: ${nonce}
+    Issued At: ${issued_at}                 # ISO-8601 UTC
+    [Expiration Time: ${expiration_time}]   # ISO-8601 UTC, optional
+    [Not Before: ${not_before}]             # ISO-8601 UTC, optional
+    [Request ID: ${request_id}]             # optional
+    [Resources:                             # optional
+    - ${uri_1}
+    - ${uri_2}
+    ...]
+
+The parser is strict on the mandatory fields and lenient on the optional
+ones (we ignore resources contents but keep request_id if present).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import List, Optional
+
+#: Maximum SIWE plaintext length, in bytes. Chosen to fit the EIP-4361 fields
+#: plus a generous statement and a handful of ``Resources:`` URIs. Bigger
+#: inputs are almost certainly an attack (or a client bug).
+MAX_SIWE_MESSAGE_LENGTH = 4096
+
+
+class SiweParseError(ValueError):
+    """Raised when a SIWE message does not conform to EIP-4361."""
+
+
+# EIP-4361 address must be the EIP-55 checksummed 0x-prefixed hex. We accept
+# any 0x-prefixed 40-hex and lowercase during verification.
+_ADDRESS_RE = re.compile(r"^0x[0-9a-fA-F]{40}$")
+# Nonce must be at least 8 alphanumeric characters per spec.
+_NONCE_RE = re.compile(r"^[A-Za-z0-9]{8,}$")
+_HEADER_RE = re.compile(r"^(?P<domain>[^\s]+) wants you to sign in with your Ethereum account:$")
+
+
+@dataclass
+class SiweMessage:
+    """Parsed EIP-4361 message, kept as plain data for downstream checks."""
+
+    domain: str
+    address: str  # preserved as-submitted (case-sensitive)
+    statement: Optional[str]
+    uri: str
+    version: str
+    chain_id: int
+    nonce: str
+    issued_at: datetime
+    expiration_time: Optional[datetime] = None
+    not_before: Optional[datetime] = None
+    request_id: Optional[str] = None
+    resources: List[str] = field(default_factory=list)
+
+
+def _parse_iso8601_utc(value: str, field_name: str) -> datetime:
+    """Parse an ISO-8601 timestamp and normalize to an aware UTC datetime.
+
+    EIP-4361 mandates ISO-8601 with offset. Python 3.11+ ``fromisoformat``
+    handles the common ``Z`` suffix directly.
+    """
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError as exc:
+        raise SiweParseError(f"Invalid ISO-8601 timestamp for {field_name}: {value!r}") from exc
+    if parsed.tzinfo is None:
+        raise SiweParseError(f"{field_name} must include a timezone offset (got naive datetime)")
+    return parsed.astimezone(timezone.utc)
+
+
+def _split_lines(message: str) -> List[str]:
+    """Split a SIWE message on ``\\r?\\n`` so CRLF clients parse correctly."""
+    # Normalize CRLF / CR to LF before splitting so one split handles every
+    # line-ending variant. The plaintext the wallet signs is the original
+    # message -- callers compare that byte-for-byte elsewhere. Here we only
+    # need a clean field view.
+    normalized = message.replace("\r\n", "\n").replace("\r", "\n")
+    return normalized.split("\n")
+
+
+def parse_siwe_message(message: str) -> SiweMessage:
+    """Parse a SIWE message string into a :class:`SiweMessage`.
+
+    Strict on required fields (domain, address, URI, Version, Chain ID, Nonce,
+    Issued At). Raises :class:`SiweParseError` with a specific reason on any
+    malformed input.
+    """
+    if not isinstance(message, str) or not message:
+        raise SiweParseError("SIWE message must be a non-empty string")
+
+    if len(message) > MAX_SIWE_MESSAGE_LENGTH:
+        raise SiweParseError(f"SIWE message exceeds maximum length of {MAX_SIWE_MESSAGE_LENGTH} bytes")
+
+    lines = _split_lines(message)
+    if len(lines) < 6:
+        raise SiweParseError("SIWE message too short")
+
+    header_match = _HEADER_RE.match(lines[0])
+    if not header_match:
+        raise SiweParseError("First line must be '<domain> wants you to sign in with your Ethereum account:'")
+    domain = header_match.group("domain")
+
+    address = lines[1].strip()
+    if not _ADDRESS_RE.match(address):
+        raise SiweParseError(f"Invalid Ethereum address on line 2: {address!r}")
+
+    # Line 3 MUST be blank separator.
+    if lines[2] != "":
+        raise SiweParseError("Line 3 must be blank (separator)")
+
+    # Line 4 is either a statement or a blank separator.
+    cursor = 3
+    statement: Optional[str] = None
+    if lines[cursor] != "":
+        statement = lines[cursor]
+        cursor += 1
+        # A statement line must be followed by a blank separator.
+        if cursor >= len(lines) or lines[cursor] != "":
+            raise SiweParseError("Statement line must be followed by a blank line")
+        cursor += 1
+    else:
+        # Blank statement — still consume the separator.
+        cursor += 1
+
+    # Parse key-value section. Resources block is terminated by EOF or by the
+    # first non-``- `` line (we are strict: no stray lines allowed after it).
+    required_fields: dict[str, Optional[str]] = {
+        "URI": None,
+        "Version": None,
+        "Chain ID": None,
+        "Nonce": None,
+        "Issued At": None,
+    }
+    optional_fields: dict[str, Optional[str]] = {
+        "Expiration Time": None,
+        "Not Before": None,
+        "Request ID": None,
+    }
+    resources: List[str] = []
+    in_resources = False
+
+    while cursor < len(lines):
+        line = lines[cursor]
+        cursor += 1
+
+        if in_resources:
+            if line == "":
+                # Trailing newline is fine.
+                continue
+            if not line.startswith("- "):
+                raise SiweParseError(f"Expected resource line starting with '- ', got: {line!r}")
+            resources.append(line[2:])
+            continue
+
+        if line == "":
+            # Blank lines outside resources: tolerate trailing newline only.
+            continue
+
+        if line == "Resources:":
+            in_resources = True
+            continue
+
+        key, sep, value = line.partition(": ")
+        if not sep:
+            raise SiweParseError(f"Malformed line (missing 'Key: value'): {line!r}")
+        if key in required_fields:
+            if required_fields[key] is not None:
+                # Duplicate required field — reject rather than silently picking
+                # last-one-wins. The signature covers the whole plaintext, so
+                # both values were "signed"; accepting one silently is the
+                # kind of ambiguity phishing relays love.
+                raise SiweParseError(f"Duplicate SIWE field: {key!r}")
+            required_fields[key] = value
+        elif key in optional_fields:
+            if optional_fields[key] is not None:
+                raise SiweParseError(f"Duplicate SIWE field: {key!r}")
+            optional_fields[key] = value
+        else:
+            raise SiweParseError(f"Unknown SIWE field: {key!r}")
+
+    missing = [k for k, v in required_fields.items() if v is None]
+    if missing:
+        raise SiweParseError(f"Missing required SIWE fields: {', '.join(missing)}")
+
+    nonce_value = required_fields["Nonce"] or ""
+    if not _NONCE_RE.match(nonce_value):
+        raise SiweParseError("Nonce must be at least 8 alphanumeric characters")
+
+    try:
+        chain_id = int(required_fields["Chain ID"] or "")
+    except ValueError as exc:
+        raise SiweParseError(f"Chain ID must be an integer, got {required_fields['Chain ID']!r}") from exc
+
+    issued_at = _parse_iso8601_utc(required_fields["Issued At"] or "", "Issued At")
+    expiration_time = (
+        _parse_iso8601_utc(optional_fields["Expiration Time"], "Expiration Time")
+        if optional_fields["Expiration Time"]
+        else None
+    )
+    not_before = (
+        _parse_iso8601_utc(optional_fields["Not Before"], "Not Before") if optional_fields["Not Before"] else None
+    )
+
+    return SiweMessage(
+        domain=domain,
+        address=address,
+        statement=statement,
+        uri=required_fields["URI"] or "",
+        version=required_fields["Version"] or "",
+        chain_id=chain_id,
+        nonce=nonce_value,
+        issued_at=issued_at,
+        expiration_time=expiration_time,
+        not_before=not_before,
+        request_id=optional_fields["Request ID"],
+        resources=resources,
+    )
+
+
+def build_siwe_message(
+    *,
+    domain: str,
+    address: str,
+    uri: str,
+    chain_id: int,
+    nonce: str,
+    issued_at: datetime,
+    expiration_time: Optional[datetime] = None,
+    not_before: Optional[datetime] = None,
+    statement: Optional[str] = None,
+    version: str = "1",
+    request_id: Optional[str] = None,
+) -> str:
+    """Build an EIP-4361 message string from typed inputs.
+
+    Used by the challenge endpoint so the server fully controls the wording --
+    the client never supplies any portion of the plaintext that will be signed.
+    """
+    if not _ADDRESS_RE.match(address):
+        raise ValueError(f"Invalid Ethereum address: {address!r}")
+    if not _NONCE_RE.match(nonce):
+        raise ValueError("Nonce must be at least 8 alphanumeric characters")
+    if issued_at.tzinfo is None:
+        raise ValueError("issued_at must be timezone-aware")
+    if expiration_time is not None and expiration_time.tzinfo is None:
+        raise ValueError("expiration_time must be timezone-aware")
+    if not_before is not None and not_before.tzinfo is None:
+        raise ValueError("not_before must be timezone-aware")
+
+    lines = [
+        f"{domain} wants you to sign in with your Ethereum account:",
+        address,
+        "",
+    ]
+    if statement:
+        lines.extend([statement, ""])
+    else:
+        lines.append("")
+    lines.extend(
+        [
+            f"URI: {uri}",
+            f"Version: {version}",
+            f"Chain ID: {chain_id}",
+            f"Nonce: {nonce}",
+            f"Issued At: {_format_iso(issued_at)}",
+        ]
+    )
+    if expiration_time is not None:
+        lines.append(f"Expiration Time: {_format_iso(expiration_time)}")
+    if not_before is not None:
+        lines.append(f"Not Before: {_format_iso(not_before)}")
+    if request_id:
+        lines.append(f"Request ID: {request_id}")
+    return "\n".join(lines)
+
+
+def _format_iso(dt: datetime) -> str:
+    """Format a UTC datetime as ``YYYY-MM-DDTHH:MM:SSZ`` for SIWE.
+
+    SIWE reference clients (spruce, rainbow) emit the ``Z`` suffix. Python's
+    ``isoformat`` uses ``+00:00`` which is equivalent per ISO-8601 but less
+    common in the wild. Normalize to the ``Z`` form for compatibility.
+    """
+    utc = dt.astimezone(timezone.utc).replace(microsecond=0)
+    return utc.strftime("%Y-%m-%dT%H:%M:%SZ")

--- a/blockauth/utils/tests/test_siwe_parser.py
+++ b/blockauth/utils/tests/test_siwe_parser.py
@@ -1,0 +1,200 @@
+"""Tests for the EIP-4361 SIWE parser + builder (issue #90).
+
+Covers the baseline round-trip plus the hardening items landed alongside
+the upstream port:
+
+* #7 — CRLF tolerance.
+* #8 — duplicate-field rejection.
+* #9 — max-length rejection at parse time.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from blockauth.utils.siwe import (
+    MAX_SIWE_MESSAGE_LENGTH,
+    SiweParseError,
+    build_siwe_message,
+    parse_siwe_message,
+)
+
+_TEST_ADDRESS = "0x19E7E376E7C213B7E7e7e46cc70A5dD086DAff2A"
+
+
+def _default_build(**overrides):
+    issued = datetime(2026, 4, 16, 12, 0, 0, tzinfo=timezone.utc)
+    kwargs = dict(
+        domain="example.com",
+        address=_TEST_ADDRESS,
+        uri="https://example.com/",
+        chain_id=1,
+        nonce="abcdef1234567890abcdef1234567890",
+        issued_at=issued,
+        expiration_time=issued + timedelta(minutes=5),
+    )
+    kwargs.update(overrides)
+    return build_siwe_message(**kwargs)
+
+
+class TestRoundTrip:
+    def test_roundtrip_with_statement(self):
+        msg = _default_build(statement="Hello, fren.")
+        parsed = parse_siwe_message(msg)
+        assert parsed.domain == "example.com"
+        assert parsed.address == _TEST_ADDRESS
+        assert parsed.chain_id == 1
+        assert parsed.nonce == "abcdef1234567890abcdef1234567890"
+        assert parsed.version == "1"
+        assert parsed.uri == "https://example.com/"
+        assert parsed.statement == "Hello, fren."
+        assert parsed.expiration_time is not None
+
+    def test_roundtrip_without_statement(self):
+        msg = _default_build()
+        parsed = parse_siwe_message(msg)
+        assert parsed.statement is None
+
+    def test_roundtrip_with_not_before(self):
+        issued = datetime(2026, 4, 16, 12, 0, 0, tzinfo=timezone.utc)
+        msg = build_siwe_message(
+            domain="example.com",
+            address=_TEST_ADDRESS,
+            uri="https://example.com/",
+            chain_id=1,
+            nonce="abcdef1234567890abcdef1234567890",
+            issued_at=issued,
+            not_before=issued + timedelta(seconds=30),
+        )
+        parsed = parse_siwe_message(msg)
+        assert parsed.not_before == issued + timedelta(seconds=30)
+
+
+class TestCRLF:
+    """Hardening #7 — CRLF-terminated messages must parse."""
+
+    def test_crlf_terminated_message_parses(self):
+        msg = _default_build()
+        crlf_msg = msg.replace("\n", "\r\n")
+        parsed = parse_siwe_message(crlf_msg)
+        assert parsed.nonce == "abcdef1234567890abcdef1234567890"
+        assert parsed.domain == "example.com"
+
+    def test_bare_cr_line_endings_parse(self):
+        msg = _default_build()
+        cr_msg = msg.replace("\n", "\r")
+        parsed = parse_siwe_message(cr_msg)
+        assert parsed.nonce == "abcdef1234567890abcdef1234567890"
+
+    def test_mixed_crlf_and_lf_parses(self):
+        msg = _default_build()
+        lines = msg.split("\n")
+        # Every other line uses CRLF.
+        mixed = "\n".join(line + ("\r" if i % 2 == 0 else "") for i, line in enumerate(lines))
+        parsed = parse_siwe_message(mixed)
+        assert parsed.domain == "example.com"
+
+
+class TestDuplicateFields:
+    """Hardening #8 — duplicate required/optional fields must be rejected."""
+
+    def test_duplicate_nonce_rejected(self):
+        msg = _default_build()
+        # Inject a second Nonce line.
+        tampered = msg.replace(
+            "Nonce: abcdef1234567890abcdef1234567890",
+            "Nonce: abcdef1234567890abcdef1234567890\nNonce: zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz",
+        )
+        with pytest.raises(SiweParseError, match="Duplicate SIWE field"):
+            parse_siwe_message(tampered)
+
+    def test_duplicate_chain_id_rejected(self):
+        msg = _default_build()
+        tampered = msg.replace("Chain ID: 1", "Chain ID: 1\nChain ID: 137")
+        with pytest.raises(SiweParseError, match="Duplicate SIWE field"):
+            parse_siwe_message(tampered)
+
+    def test_duplicate_uri_rejected(self):
+        msg = _default_build()
+        tampered = msg.replace(
+            "URI: https://example.com/",
+            "URI: https://example.com/\nURI: https://phisher.example/",
+        )
+        with pytest.raises(SiweParseError, match="Duplicate SIWE field"):
+            parse_siwe_message(tampered)
+
+
+class TestMaxLength:
+    """Hardening #9 — oversized messages must be rejected before parsing."""
+
+    def test_rejects_oversized_message(self):
+        # Build a base message, then append ``Resources:`` block lines until
+        # the byte count blows past the cap. We want the size to trip the
+        # check before any structural rule can.
+        base = _default_build()
+        padding = "- https://example.com/abc\n" * ((MAX_SIWE_MESSAGE_LENGTH // 24) + 16)
+        oversized = base + "\nResources:\n" + padding
+        assert len(oversized) > MAX_SIWE_MESSAGE_LENGTH
+        with pytest.raises(SiweParseError, match="exceeds maximum length"):
+            parse_siwe_message(oversized)
+
+    def test_accepts_message_at_boundary(self):
+        # Pad a valid message with extra newlines right up to the limit.
+        msg = _default_build()
+        # Trailing newlines are ignored in the resource-parsing loop, so we
+        # can safely concatenate them without breaking the grammar.
+        padded = msg + "\n" * (MAX_SIWE_MESSAGE_LENGTH - len(msg) - 1)
+        assert len(padded) < MAX_SIWE_MESSAGE_LENGTH
+        parsed = parse_siwe_message(padded)
+        assert parsed.nonce == "abcdef1234567890abcdef1234567890"
+
+
+class TestStructuralRejections:
+    def test_rejects_missing_required_field(self):
+        msg = _default_build()
+        tampered = "\n".join(line for line in msg.split("\n") if not line.startswith("Nonce:"))
+        with pytest.raises(SiweParseError, match="Missing required"):
+            parse_siwe_message(tampered)
+
+    def test_rejects_short_nonce_in_builder(self):
+        issued = datetime(2026, 4, 16, 12, 0, 0, tzinfo=timezone.utc)
+        with pytest.raises(ValueError, match="Nonce must be at least"):
+            build_siwe_message(
+                domain="example.com",
+                address=_TEST_ADDRESS,
+                uri="https://example.com/",
+                chain_id=1,
+                nonce="short",
+                issued_at=issued,
+            )
+
+    def test_rejects_bad_address(self):
+        issued = datetime(2026, 4, 16, 12, 0, 0, tzinfo=timezone.utc)
+        with pytest.raises(ValueError, match="Invalid Ethereum address"):
+            build_siwe_message(
+                domain="example.com",
+                address="not-an-address",
+                uri="https://example.com/",
+                chain_id=1,
+                nonce="abcdef1234567890abcdef1234567890",
+                issued_at=issued,
+            )
+
+    def test_rejects_bad_chain_id(self):
+        msg = _default_build().replace("Chain ID: 1", "Chain ID: foo")
+        with pytest.raises(SiweParseError, match="Chain ID must be an integer"):
+            parse_siwe_message(msg)
+
+    def test_rejects_unknown_field(self):
+        msg = _default_build()
+        tampered = msg + "\nX-Custom: surprise"
+        with pytest.raises(SiweParseError, match="Unknown SIWE field"):
+            parse_siwe_message(tampered)
+
+    def test_rejects_empty_input(self):
+        with pytest.raises(SiweParseError, match="non-empty"):
+            parse_siwe_message("")
+
+    def test_rejects_too_few_lines(self):
+        with pytest.raises(SiweParseError, match="too short"):
+            parse_siwe_message("just one line")

--- a/blockauth/utils/tests/test_wallet_login_hardening.py
+++ b/blockauth/utils/tests/test_wallet_login_hardening.py
@@ -1,0 +1,190 @@
+"""Tests for the upstream port's hardening items not exercised elsewhere.
+
+Covers:
+
+* #3 — startup validation for ``WALLET_LOGIN_EXPECTED_DOMAINS`` in non-DEBUG.
+* #10 — throttle scoping per (IP, wallet_address, scope).
+* #11 — ``prune_wallet_nonces`` management command.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from io import StringIO
+
+import pytest
+from django.core.cache import cache
+from django.core.exceptions import ImproperlyConfigured
+from django.core.management import call_command
+from django.utils import timezone
+
+from blockauth.apps import validate_wallet_login_settings
+from blockauth.models.wallet_login_nonce import WalletLoginNonce
+
+# =============================================================================
+# Hardening #3 — startup validation
+# =============================================================================
+
+
+class TestStartupValidation:
+    def test_debug_true_is_permissive(self, settings):
+        settings.DEBUG = True
+        settings.WALLET_LOGIN_EXPECTED_DOMAINS = ()
+        # Must not raise.
+        validate_wallet_login_settings()
+
+    def test_empty_allowlist_in_production_raises(self, settings):
+        settings.DEBUG = False
+        settings.WALLET_LOGIN_EXPECTED_DOMAINS = ()
+        settings.WALLET_LOGIN_SKIP_STARTUP_VALIDATION = False
+        with pytest.raises(ImproperlyConfigured, match="non-empty"):
+            validate_wallet_login_settings()
+
+    def test_production_with_allowlist_is_accepted(self, settings):
+        settings.DEBUG = False
+        settings.WALLET_LOGIN_EXPECTED_DOMAINS = ("app.example.com",)
+        settings.WALLET_LOGIN_SKIP_STARTUP_VALIDATION = False
+        validate_wallet_login_settings()
+
+    def test_non_iterable_allowlist_raises(self, settings):
+        settings.DEBUG = False
+        settings.WALLET_LOGIN_EXPECTED_DOMAINS = "app.example.com"  # str, not tuple
+        settings.WALLET_LOGIN_SKIP_STARTUP_VALIDATION = False
+        with pytest.raises(ImproperlyConfigured, match="list, tuple or set"):
+            validate_wallet_login_settings()
+
+    def test_blank_entry_rejected(self, settings):
+        settings.DEBUG = False
+        settings.WALLET_LOGIN_EXPECTED_DOMAINS = ("app.example.com", "")
+        settings.WALLET_LOGIN_SKIP_STARTUP_VALIDATION = False
+        with pytest.raises(ImproperlyConfigured, match="invalid entries"):
+            validate_wallet_login_settings()
+
+    def test_skip_flag_bypasses_check(self, settings):
+        settings.DEBUG = False
+        settings.WALLET_LOGIN_EXPECTED_DOMAINS = ()
+        settings.WALLET_LOGIN_SKIP_STARTUP_VALIDATION = True
+        validate_wallet_login_settings()
+
+
+# =============================================================================
+# Hardening #10 — throttle scoping
+# =============================================================================
+
+
+class _FakeRequest:
+    """Minimal stand-in for a DRF request used by the throttle."""
+
+    def __init__(self, *, ip: str, address: str | None):
+        self.META = {"REMOTE_ADDR": ip}
+        self.data: dict = {}
+        if address is not None:
+            self.data["address"] = address
+
+
+class TestWalletThrottleScoping:
+    @pytest.fixture(autouse=True)
+    def _clear_cache(self):
+        cache.clear()
+        yield
+        cache.clear()
+
+    def test_different_addresses_get_independent_buckets(self):
+        from blockauth.utils.rate_limiter import WalletChallengeThrottle
+
+        throttle = WalletChallengeThrottle(rate=(2, 60))
+        req_a = _FakeRequest(ip="198.51.100.7", address="0x" + "a" * 40)
+        req_b = _FakeRequest(ip="198.51.100.7", address="0x" + "b" * 40)
+
+        assert throttle.allow_request(req_a, None) is True
+        assert throttle.allow_request(req_a, None) is True
+        # Address-A bucket is now full — next request for A is denied.
+        assert throttle.allow_request(req_a, None) is False
+        # Address-B on the same IP is still allowed.
+        assert throttle.allow_request(req_b, None) is True
+
+    def test_challenge_and_login_scopes_are_independent(self):
+        from blockauth.utils.rate_limiter import (
+            WalletChallengeThrottle,
+            WalletLoginThrottle,
+        )
+
+        req = _FakeRequest(ip="198.51.100.7", address="0x" + "a" * 40)
+        challenge = WalletChallengeThrottle(rate=(1, 60))
+        login = WalletLoginThrottle(rate=(1, 60))
+
+        assert challenge.allow_request(req, None) is True
+        assert challenge.allow_request(req, None) is False
+        # Login endpoint has its own bucket.
+        assert login.allow_request(req, None) is True
+
+    def test_rejects_when_address_missing_but_ip_present(self):
+        """No address -> still gets a bucket keyed on IP + scope."""
+        from blockauth.utils.rate_limiter import WalletLoginThrottle
+
+        throttle = WalletLoginThrottle(rate=(1, 60))
+        req = _FakeRequest(ip="198.51.100.7", address=None)
+        assert throttle.allow_request(req, None) is True
+        assert throttle.allow_request(req, None) is False
+
+
+# =============================================================================
+# Hardening #11 — reaper management command
+# =============================================================================
+
+
+@pytest.mark.django_db
+class TestPruneWalletNonces:
+    def _create(self, *, nonce, expires_at, consumed_at=None):
+        now = timezone.now()
+        return WalletLoginNonce.objects.create(
+            address="0x" + "a" * 40,
+            nonce=nonce,
+            domain="example.com",
+            uri="https://example.com/",
+            chain_id=1,
+            issued_at=now,
+            expires_at=expires_at,
+            consumed_at=consumed_at,
+        )
+
+    def test_removes_expired_rows(self):
+        now = timezone.now()
+        self._create(nonce="expired_" + "a" * 24, expires_at=now - timedelta(seconds=1))
+        self._create(nonce="live_" + "b" * 28, expires_at=now + timedelta(minutes=5))
+
+        out = StringIO()
+        call_command("prune_wallet_nonces", stdout=out)
+        remaining = list(WalletLoginNonce.objects.values_list("nonce", flat=True))
+        assert len(remaining) == 1
+        assert remaining[0].startswith("live_")
+        assert "Deleted 1" in out.getvalue()
+
+    def test_removes_old_consumed_rows(self):
+        now = timezone.now()
+        # Still in TTL but consumed long ago — should be reaped.
+        self._create(
+            nonce="consumed_old_" + "a" * 16,
+            expires_at=now + timedelta(minutes=1),
+            consumed_at=now - timedelta(hours=2),
+        )
+        # Consumed recently — keep (caller may want to inspect it).
+        self._create(
+            nonce="consumed_new_" + "b" * 16,
+            expires_at=now + timedelta(minutes=1),
+            consumed_at=now - timedelta(minutes=1),
+        )
+
+        call_command("prune_wallet_nonces", "--older-than", "3600", stdout=StringIO())
+        remaining = list(WalletLoginNonce.objects.values_list("nonce", flat=True))
+        assert len(remaining) == 1
+        assert remaining[0].startswith("consumed_new_")
+
+    def test_dry_run_does_not_delete(self):
+        now = timezone.now()
+        self._create(nonce="expired_" + "a" * 24, expires_at=now - timedelta(seconds=1))
+
+        out = StringIO()
+        call_command("prune_wallet_nonces", "--dry-run", stdout=out)
+        assert WalletLoginNonce.objects.count() == 1
+        assert "dry-run" in out.getvalue()

--- a/blockauth/utils/tests/test_wallet_login_siwe.py
+++ b/blockauth/utils/tests/test_wallet_login_siwe.py
@@ -151,6 +151,30 @@ class TestSignatureVerify:
                 svc._verify_signature(address=_TEST_ADDRESS_LC, message=message, signature=sig)
         assert exc_info.value.code == "signature_internal_error"
 
+    def test_eth_keys_validation_error_surfaces_as_internal_error(self, svc, siwe_and_sig):
+        """Regression: ``eth_utils.ValidationError`` inherits from ``Exception``,
+        not ``ValueError`` / ``TypeError``. A narrow catch on those two leaked
+        the raw exception as a 500 instead of the neutral
+        ``signature_internal_error`` envelope that the sibling
+        ``recover_message`` block surfaces. This test pins the behaviour so
+        a future narrowing of the catch regresses loudly.
+        """
+        from eth_utils import ValidationError as EthUtilsValidationError
+
+        message, sig, _ = siwe_and_sig
+
+        with patch(
+            "blockauth.services.wallet_login_service.EthKeysSignature",
+            side_effect=EthUtilsValidationError("bad sig"),
+        ):
+            with pytest.raises(WalletLoginError) as exc_info:
+                svc._verify_signature(
+                    address=_TEST_ADDRESS_LC,
+                    message=message,
+                    signature=sig,
+                )
+        assert exc_info.value.code == "signature_internal_error"
+
 
 # =============================================================================
 # Service layer — challenge + verify lifecycle
@@ -590,3 +614,58 @@ class TestTriggerFanOut:
         # POST_LOGIN_TRIGGER must still have fired even though POST_SIGNUP
         # blew up -- the linker wraps each trigger in its own try/except.
         assert calls["post_login"] == 1
+
+
+# =============================================================================
+# LogRecord attribute-collision regression
+# =============================================================================
+
+
+@pytest.mark.django_db
+class TestLinkerLoggingDoesNotCollide:
+    """Regression: ``logger.info(extra={"created": ...})`` blows up because
+    ``created`` is a reserved ``LogRecord`` attribute (the record's creation
+    timestamp). Any handler that actually formats the record raises
+    ``KeyError: "Attempt to overwrite 'created' in LogRecord"``. The fix
+    renames the extra key to ``user_created``. This test wires a real
+    ``StreamHandler`` + ``Formatter`` onto the linker's logger and asserts
+    the successful-link path emits a record without raising.
+    """
+
+    def test_successful_link_emits_record_without_collision(self):
+        import io
+        import logging
+
+        from blockauth.services import wallet_user_linker as linker_mod
+        from blockauth.services.wallet_user_linker import WalletUserLinker
+
+        buf = io.StringIO()
+        handler = logging.StreamHandler(buf)
+        # The default Formatter calls ``LogRecord.getMessage`` and touches
+        # the reserved attribute names during ``%(created)s``-style interp
+        # when something attempts to overwrite them in ``extra=``. Use a
+        # format string that forces attribute access on ``created`` so we
+        # get the KeyError on pre-fix code. ``makeRecord`` itself also
+        # refuses to overwrite reserved attrs in ``extra`` on any modern
+        # Python, so even the default formatter is enough to trip the bug
+        # -- belt and braces.
+        handler.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(message)s"))
+
+        linker_logger = linker_mod.logger
+        prior_level = linker_logger.level
+        linker_logger.addHandler(handler)
+        linker_logger.setLevel(logging.INFO)
+        try:
+            linker = WalletUserLinker()
+            linked = linker.link(wallet_address=_TEST_ADDRESS_LC)
+            handler.flush()
+        finally:
+            linker_logger.removeHandler(handler)
+            linker_logger.setLevel(prior_level)
+
+        # Sanity: the happy path actually ran.
+        assert linked.user_id
+        # And the handler captured the line (non-empty ==> no raise during
+        # emit). On pre-fix code ``makeRecord`` raises before anything
+        # lands in the buffer.
+        assert "Wallet login linked to user" in buf.getvalue()

--- a/blockauth/utils/tests/test_wallet_login_siwe.py
+++ b/blockauth/utils/tests/test_wallet_login_siwe.py
@@ -1,0 +1,592 @@
+"""Tests for the SIWE-backed wallet login flow (issue #90).
+
+Covers:
+
+* Service-layer signature verification + malleability rejection.
+* Service-layer nonce lifecycle (replay, chain mismatch, address mismatch,
+  forged domain, unknown nonce, not-before).
+* HTTP endpoint round-trip (challenge -> sign -> login -> replay-rejected).
+* Hardening item #4 — ``WALLET_LOGIN_AUTO_CREATE=False`` no longer acts as
+  a registration oracle by default.
+
+The tests reuse a single deterministic test account so any stored
+signatures match the expected signer. The private key is fixed test junk
+and must never hit a real network.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from unittest.mock import patch
+
+import pytest
+from django.core.cache import cache
+from django.urls import reverse
+from django.utils import timezone as django_timezone
+from eth_account import Account
+from eth_account.messages import encode_defunct
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from blockauth.models.wallet_login_nonce import WalletLoginNonce
+from blockauth.services.wallet_login_service import (
+    _SECP256K1_N,
+    WalletLoginError,
+    WalletLoginService,
+    reset_wallet_login_service,
+)
+from blockauth.utils.siwe import build_siwe_message
+
+# Deterministic test wallet — not a real account.
+_TEST_PRIVATE_KEY = "0x" + "1" * 64
+_TEST_ACCOUNT = Account.from_key(_TEST_PRIVATE_KEY)
+_TEST_ADDRESS = _TEST_ACCOUNT.address  # EIP-55 checksummed
+_TEST_ADDRESS_LC = _TEST_ADDRESS.lower()
+
+
+def _sign(message: str) -> str:
+    """Return a 0x-prefixed 65-byte signature from the fixed test key."""
+    signed = _TEST_ACCOUNT.sign_message(encode_defunct(text=message))
+    sig_hex = signed.signature.hex()
+    return sig_hex if sig_hex.startswith("0x") else "0x" + sig_hex
+
+
+@pytest.fixture(autouse=True)
+def _override_domains(settings):
+    """Apply the SIWE allow-list for every test in this module."""
+    settings.WALLET_LOGIN_EXPECTED_DOMAINS = ("example.com",)
+    settings.WALLET_LOGIN_DEFAULT_CHAIN_ID = 1
+    settings.WALLET_LOGIN_NONCE_TTL_SECONDS = 300
+    reset_wallet_login_service()
+    yield
+    reset_wallet_login_service()
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache_between_tests():
+    cache.clear()
+    yield
+    cache.clear()
+
+
+@pytest.fixture
+def svc():
+    return WalletLoginService(expected_domains=("example.com",), default_chain_id=1)
+
+
+@pytest.fixture
+def siwe_and_sig():
+    """Build a valid SIWE plaintext + matching signature for the test wallet."""
+    issued = django_timezone.now().replace(microsecond=0)
+    msg = build_siwe_message(
+        domain="example.com",
+        address=_TEST_ADDRESS,
+        uri="https://example.com/",
+        chain_id=1,
+        nonce="abcdef1234567890abcdef1234567890",
+        issued_at=issued,
+        expiration_time=issued + timedelta(minutes=5),
+    )
+    return msg, _sign(msg), issued
+
+
+# =============================================================================
+# Service layer — signature verification & malleability
+# =============================================================================
+
+
+class TestSignatureVerify:
+    def test_happy_path(self, svc, siwe_and_sig):
+        message, sig, _ = siwe_and_sig
+        svc._verify_signature(address=_TEST_ADDRESS_LC, message=message, signature=sig)
+
+    def test_rejects_bad_length(self, svc, siwe_and_sig):
+        message, _sig, _ = siwe_and_sig
+        with pytest.raises(WalletLoginError) as exc_info:
+            svc._verify_signature(address=_TEST_ADDRESS_LC, message=message, signature="0x1234")
+        assert exc_info.value.code == "invalid_signature"
+
+    def test_rejects_non_hex(self, svc, siwe_and_sig):
+        message, _sig, _ = siwe_and_sig
+        with pytest.raises(WalletLoginError) as exc_info:
+            svc._verify_signature(
+                address=_TEST_ADDRESS_LC,
+                message=message,
+                signature="0x" + "z" * 130,
+            )
+        assert exc_info.value.code == "invalid_signature"
+
+    def test_rejects_malleable_high_s(self, svc, siwe_and_sig):
+        message, sig, _ = siwe_and_sig
+        sig_bytes = bytes.fromhex(sig[2:])
+        r = int.from_bytes(sig_bytes[0:32], "big")
+        s = int.from_bytes(sig_bytes[32:64], "big")
+        v = sig_bytes[64]
+        mal_s = _SECP256K1_N - s
+        new_v = 27 + ((v - 27) ^ 1) if v in (27, 28) else (v ^ 1)
+        mal_bytes = r.to_bytes(32, "big") + mal_s.to_bytes(32, "big") + bytes([new_v])
+        with pytest.raises(WalletLoginError) as exc_info:
+            svc._verify_signature(
+                address=_TEST_ADDRESS_LC,
+                message=message,
+                signature="0x" + mal_bytes.hex(),
+            )
+        assert exc_info.value.code == "malleable_signature"
+
+    def test_rejects_wrong_address(self, svc, siwe_and_sig):
+        message, sig, _ = siwe_and_sig
+        with pytest.raises(WalletLoginError) as exc_info:
+            svc._verify_signature(address="0x" + "0" * 40, message=message, signature=sig)
+        assert exc_info.value.code == "signature_mismatch"
+
+    def test_library_regression_surfaces_as_internal_error(self, svc, siwe_and_sig):
+        """Hardening #5 — unexpected exceptions must NOT look like bad input."""
+        message, sig, _ = siwe_and_sig
+
+        class _Boom(RuntimeError):
+            pass
+
+        with patch.object(svc._w3.eth.account, "recover_message", side_effect=_Boom("boom")):
+            with pytest.raises(WalletLoginError) as exc_info:
+                svc._verify_signature(address=_TEST_ADDRESS_LC, message=message, signature=sig)
+        assert exc_info.value.code == "signature_internal_error"
+
+
+# =============================================================================
+# Service layer — challenge + verify lifecycle
+# =============================================================================
+
+
+@pytest.mark.django_db
+class TestIssueChallenge:
+    def test_issues_unique_nonce_per_call(self, svc):
+        first = svc.issue_challenge(address=_TEST_ADDRESS_LC)
+        second = svc.issue_challenge(address=_TEST_ADDRESS_LC)
+        assert first.nonce != second.nonce
+        assert WalletLoginNonce.objects.count() == 2
+
+    def test_nonce_has_ttl(self, svc):
+        result = svc.issue_challenge(address=_TEST_ADDRESS_LC)
+        row = WalletLoginNonce.objects.get(nonce=result.nonce)
+        assert row.address == _TEST_ADDRESS_LC
+        assert row.domain == "example.com"
+        assert row.consumed_at is None
+        assert (row.expires_at - row.issued_at) == timedelta(minutes=5)
+
+    def test_rejects_bad_address(self, svc):
+        with pytest.raises(WalletLoginError) as exc_info:
+            svc.issue_challenge(address="not-an-address")
+        assert exc_info.value.code == "invalid_address"
+
+    def test_rejects_disallowed_domain(self, svc):
+        with pytest.raises(WalletLoginError) as exc_info:
+            svc.issue_challenge(address=_TEST_ADDRESS_LC, domain="phisher.example")
+        assert exc_info.value.code == "domain_not_allowed"
+
+
+@pytest.mark.django_db
+class TestVerifyLogin:
+    def test_happy_path_consumes_nonce(self, svc):
+        challenge = svc.issue_challenge(address=_TEST_ADDRESS_LC)
+        sig = _sign(challenge.message)
+        result = svc.verify_login(
+            wallet_address=_TEST_ADDRESS_LC,
+            message=challenge.message,
+            signature=sig,
+        )
+        assert result.address == _TEST_ADDRESS_LC
+        row = WalletLoginNonce.objects.get(pk=result.nonce_id)
+        assert row.consumed_at is not None
+
+    def test_replay_rejected_after_consumption(self, svc):
+        challenge = svc.issue_challenge(address=_TEST_ADDRESS_LC)
+        sig = _sign(challenge.message)
+        svc.verify_login(
+            wallet_address=_TEST_ADDRESS_LC,
+            message=challenge.message,
+            signature=sig,
+        )
+        with pytest.raises(WalletLoginError) as exc_info:
+            svc.verify_login(
+                wallet_address=_TEST_ADDRESS_LC,
+                message=challenge.message,
+                signature=sig,
+            )
+        assert exc_info.value.code == "nonce_invalid"
+
+    def test_rejects_expired_nonce(self, svc):
+        challenge = svc.issue_challenge(address=_TEST_ADDRESS_LC)
+        sig = _sign(challenge.message)
+        WalletLoginNonce.objects.filter(nonce=challenge.nonce).update(
+            expires_at=django_timezone.now() - timedelta(seconds=1)
+        )
+        with pytest.raises(WalletLoginError) as exc_info:
+            svc.verify_login(
+                wallet_address=_TEST_ADDRESS_LC,
+                message=challenge.message,
+                signature=sig,
+            )
+        # Either the plaintext expiration or the nonce row expiration may
+        # trip first depending on timing.
+        assert exc_info.value.code in {"expired", "nonce_expired"}
+
+    def test_rejects_domain_mismatch(self, svc):
+        """Client signs a message whose domain is not in the allow-list."""
+        issued = django_timezone.now()
+        rogue_msg = build_siwe_message(
+            domain="phisher.example",
+            address=_TEST_ADDRESS,
+            uri="https://phisher.example/",
+            chain_id=1,
+            nonce="abcdef1234567890abcdef1234567890",
+            issued_at=issued,
+            expiration_time=issued + timedelta(minutes=5),
+        )
+        with pytest.raises(WalletLoginError) as exc_info:
+            svc.verify_login(
+                wallet_address=_TEST_ADDRESS_LC,
+                message=rogue_msg,
+                signature=_sign(rogue_msg),
+            )
+        assert exc_info.value.code == "domain_mismatch"
+
+    def test_rejects_address_mismatch(self, svc):
+        challenge = svc.issue_challenge(address=_TEST_ADDRESS_LC)
+        sig = _sign(challenge.message)
+        with pytest.raises(WalletLoginError) as exc_info:
+            svc.verify_login(
+                wallet_address="0x" + "0" * 40,
+                message=challenge.message,
+                signature=sig,
+            )
+        assert exc_info.value.code == "address_mismatch"
+
+    def test_rejects_unknown_nonce(self, svc):
+        issued = django_timezone.now()
+        forged = build_siwe_message(
+            domain="example.com",
+            address=_TEST_ADDRESS,
+            uri="https://example.com/",
+            chain_id=1,
+            nonce="zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz",
+            issued_at=issued,
+            expiration_time=issued + timedelta(minutes=5),
+        )
+        with pytest.raises(WalletLoginError) as exc_info:
+            svc.verify_login(
+                wallet_address=_TEST_ADDRESS_LC,
+                message=forged,
+                signature=_sign(forged),
+            )
+        assert exc_info.value.code == "nonce_invalid"
+
+    def test_rejects_wrong_signature(self, svc):
+        challenge = svc.issue_challenge(address=_TEST_ADDRESS_LC)
+        other = Account.from_key("0x" + "2" * 64)
+        signed = other.sign_message(encode_defunct(text=challenge.message))
+        sig_hex = signed.signature.hex()
+        bad_sig = sig_hex if sig_hex.startswith("0x") else "0x" + sig_hex
+        with pytest.raises(WalletLoginError) as exc_info:
+            svc.verify_login(
+                wallet_address=_TEST_ADDRESS_LC,
+                message=challenge.message,
+                signature=bad_sig,
+            )
+        assert exc_info.value.code == "signature_mismatch"
+
+    def test_rejects_not_yet_valid(self, svc):
+        issued = django_timezone.now()
+        future_msg = build_siwe_message(
+            domain="example.com",
+            address=_TEST_ADDRESS,
+            uri="https://example.com/",
+            chain_id=1,
+            nonce="abcdef1234567890abcdef1234567890",
+            issued_at=issued,
+            not_before=issued + timedelta(minutes=10),
+            expiration_time=issued + timedelta(minutes=15),
+        )
+        with pytest.raises(WalletLoginError) as exc_info:
+            svc.verify_login(
+                wallet_address=_TEST_ADDRESS_LC,
+                message=future_msg,
+                signature=_sign(future_msg),
+            )
+        assert exc_info.value.code == "not_yet_valid"
+
+    def test_rejects_nonce_chain_mismatch(self, svc):
+        """Server minted a chain-1 nonce; signed message claims chain 137."""
+        challenge = svc.issue_challenge(address=_TEST_ADDRESS_LC, chain_id=1)
+        # Mint a parallel SIWE plaintext reusing the same nonce but a
+        # different chain_id. The SIWE parser is fine with that; the service
+        # should reject on nonce_chain_mismatch.
+        issued = django_timezone.now()
+        tampered = build_siwe_message(
+            domain="example.com",
+            address=_TEST_ADDRESS,
+            uri="https://example.com/",
+            chain_id=137,
+            nonce=challenge.nonce,
+            issued_at=issued,
+            expiration_time=issued + timedelta(minutes=5),
+        )
+        with pytest.raises(WalletLoginError) as exc_info:
+            svc.verify_login(
+                wallet_address=_TEST_ADDRESS_LC,
+                message=tampered,
+                signature=_sign(tampered),
+            )
+        assert exc_info.value.code == "nonce_chain_mismatch"
+
+
+# =============================================================================
+# HTTP round-trip
+# =============================================================================
+
+
+@pytest.mark.django_db
+class TestWalletLoginEndpoints:
+    def test_challenge_returns_signable_message(self):
+        client = APIClient()
+        url = reverse("wallet-login-challenge")
+        response = client.post(url, {"address": _TEST_ADDRESS_LC}, format="json")
+        assert response.status_code == status.HTTP_200_OK, response.content
+        body = response.json()
+        assert body["domain"] == "example.com"
+        assert body["chain_id"] == 1
+        assert body["nonce"]
+        assert body["message"].startswith("example.com wants you to sign in with your Ethereum account:")
+
+    def test_full_login_then_replay_rejected(self):
+        client = APIClient()
+        challenge_resp = client.post(
+            reverse("wallet-login-challenge"),
+            {"address": _TEST_ADDRESS_LC},
+            format="json",
+        )
+        assert challenge_resp.status_code == 200, challenge_resp.content
+        message = challenge_resp.json()["message"]
+        sig = _sign(message)
+
+        cache.clear()
+        login_resp = client.post(
+            reverse("wallet-login"),
+            {
+                "wallet_address": _TEST_ADDRESS_LC,
+                "message": message,
+                "signature": sig,
+            },
+            format="json",
+        )
+        assert login_resp.status_code == 200, login_resp.content
+        assert "access" in login_resp.json()
+        assert "refresh" in login_resp.json()
+
+        cache.clear()
+        replay = client.post(
+            reverse("wallet-login"),
+            {
+                "wallet_address": _TEST_ADDRESS_LC,
+                "message": message,
+                "signature": sig,
+            },
+            format="json",
+        )
+        assert replay.status_code == status.HTTP_401_UNAUTHORIZED, replay.content
+        assert replay.json()["error"]["code"] == "nonce_invalid"
+
+    def test_login_rejects_forged_domain(self):
+        client = APIClient()
+        issued = django_timezone.now()
+        rogue_msg = build_siwe_message(
+            domain="phisher.example",
+            address=_TEST_ADDRESS,
+            uri="https://phisher.example/",
+            chain_id=1,
+            nonce="abcdef1234567890abcdef1234567890",
+            issued_at=issued,
+            expiration_time=issued + timedelta(minutes=5),
+        )
+        resp = client.post(
+            reverse("wallet-login"),
+            {
+                "wallet_address": _TEST_ADDRESS_LC,
+                "message": rogue_msg,
+                "signature": _sign(rogue_msg),
+            },
+            format="json",
+        )
+        assert resp.status_code == status.HTTP_401_UNAUTHORIZED, resp.content
+        assert resp.json()["error"]["code"] == "domain_mismatch"
+
+    def test_login_rejects_unknown_wallet_with_generic_401(self, settings):
+        """Hardening #4 — the default no longer acts as a registration oracle."""
+        settings.WALLET_LOGIN_AUTO_CREATE = False
+        client = APIClient()
+        challenge_resp = client.post(
+            reverse("wallet-login-challenge"),
+            {"address": _TEST_ADDRESS_LC},
+            format="json",
+        )
+        message = challenge_resp.json()["message"]
+        sig = _sign(message)
+        cache.clear()
+        resp = client.post(
+            reverse("wallet-login"),
+            {
+                "wallet_address": _TEST_ADDRESS_LC,
+                "message": message,
+                "signature": sig,
+            },
+            format="json",
+        )
+        # Default hides registration status — 401 + generic code.
+        assert resp.status_code == status.HTTP_401_UNAUTHORIZED, resp.content
+        assert resp.json()["error"]["code"] == "login_failed"
+
+    def test_login_rejects_unknown_wallet_explicit_oracle_opt_in(self, settings):
+        """Deployments that opt in still get the distinct 403."""
+        settings.WALLET_LOGIN_AUTO_CREATE = False
+        settings.WALLET_LOGIN_EXPOSE_REGISTRATION_STATUS = True
+        client = APIClient()
+        challenge_resp = client.post(
+            reverse("wallet-login-challenge"),
+            {"address": _TEST_ADDRESS_LC},
+            format="json",
+        )
+        message = challenge_resp.json()["message"]
+        sig = _sign(message)
+        cache.clear()
+        resp = client.post(
+            reverse("wallet-login"),
+            {
+                "wallet_address": _TEST_ADDRESS_LC,
+                "message": message,
+                "signature": sig,
+            },
+            format="json",
+        )
+        assert resp.status_code == status.HTTP_403_FORBIDDEN, resp.content
+        assert resp.json()["error"]["code"] == "auto_create_disabled"
+
+    def test_login_existing_wallet_succeeds_with_autocreate_disabled(self, settings):
+        """A pre-existing user still logs in when auto-create is off."""
+        settings.WALLET_LOGIN_AUTO_CREATE = False
+        from tests.models import TestBlockUser
+
+        TestBlockUser.objects.create(wallet_address=_TEST_ADDRESS_LC, is_verified=False)
+        client = APIClient()
+        challenge_resp = client.post(
+            reverse("wallet-login-challenge"),
+            {"address": _TEST_ADDRESS_LC},
+            format="json",
+        )
+        message = challenge_resp.json()["message"]
+        sig = _sign(message)
+        cache.clear()
+        resp = client.post(
+            reverse("wallet-login"),
+            {
+                "wallet_address": _TEST_ADDRESS_LC,
+                "message": message,
+                "signature": sig,
+            },
+            format="json",
+        )
+        assert resp.status_code == 200, resp.content
+        assert "access" in resp.json()
+
+    def test_login_rejects_oversized_message(self):
+        """Hardening #9 — serializer caps message length."""
+        from blockauth.utils.siwe import MAX_SIWE_MESSAGE_LENGTH
+
+        client = APIClient()
+        huge = "x" * (MAX_SIWE_MESSAGE_LENGTH + 16)
+        resp = client.post(
+            reverse("wallet-login"),
+            {
+                "wallet_address": _TEST_ADDRESS_LC,
+                "message": huge,
+                "signature": "0x" + "ab" * 65,
+            },
+            format="json",
+        )
+        assert resp.status_code == status.HTTP_400_BAD_REQUEST
+
+
+# =============================================================================
+# Hardening #1 — auto-create race must not 500
+# =============================================================================
+
+
+@pytest.mark.django_db
+class TestAutoCreateRace:
+    """The linker must use get_or_create inside transaction.atomic."""
+
+    def test_second_concurrent_first_login_returns_existing_user(self):
+        """Simulate the losing side of the race by pre-creating the row.
+
+        If the linker used filter().first() + create() it would raise
+        IntegrityError (unique wallet_address). get_or_create returns the
+        existing row instead.
+        """
+        from blockauth.services.wallet_user_linker import WalletUserLinker
+        from tests.models import TestBlockUser
+
+        existing = TestBlockUser.objects.create(wallet_address=_TEST_ADDRESS_LC, is_verified=False)
+
+        linker = WalletUserLinker()
+        linked = linker.link(wallet_address=_TEST_ADDRESS_LC)
+        assert linked.user_id == str(existing.id)
+        assert linked.created is False
+
+
+# =============================================================================
+# Hardening #2 — trigger fan-out is post-commit and exception-safe
+# =============================================================================
+
+
+@pytest.mark.django_db(transaction=True)
+class TestTriggerFanOut:
+    """Use transaction=True so ``transaction.on_commit`` actually fires.
+
+    pytest-django's default ``django_db`` fixture wraps each test in a
+    rollback, which suppresses ``on_commit`` callbacks. The linker's
+    post-commit trigger dispatch needs a real commit to exercise.
+    """
+
+    def test_exception_in_post_signup_trigger_does_not_kill_response(self, settings):
+        """A raising POST_SIGNUP_TRIGGER must not break the login path."""
+        from blockauth.services.wallet_user_linker import WalletUserLinker
+
+        calls = {"post_login": 0, "post_signup": 0}
+
+        class RaisingSignup:
+            def trigger(self, context):
+                calls["post_signup"] += 1
+                raise RuntimeError("signup webhook exploded")
+
+        class CountingLogin:
+            def trigger(self, context):
+                calls["post_login"] += 1
+
+        from blockauth.services import wallet_user_linker as linker_mod
+
+        def _fake_get_config(key):
+            if key == "POST_SIGNUP_TRIGGER":
+                return RaisingSignup
+            if key == "POST_LOGIN_TRIGGER":
+                return CountingLogin
+            raise AttributeError(key)
+
+        with patch.object(linker_mod, "get_config", _fake_get_config):
+            linker = WalletUserLinker()
+            linked = linker.link(wallet_address=_TEST_ADDRESS_LC)
+
+        assert linked.created is True
+        # Signup trigger was invoked and raised — that must not roll back
+        # the user row or break the login fan-out.
+        assert calls["post_signup"] == 1
+        # POST_LOGIN_TRIGGER must still have fired even though POST_SIGNUP
+        # blew up -- the linker wraps each trigger in its own try/except.
+        assert calls["post_login"] == 1

--- a/blockauth/views/wallet_auth_views.py
+++ b/blockauth/views/wallet_auth_views.py
@@ -1,4 +1,21 @@
+"""Wallet authentication views.
+
+Includes:
+
+* :class:`WalletChallengeView` — ``POST /login/wallet/challenge/``, mints a
+  server-issued EIP-4361 SIWE challenge. Clients sign the returned
+  ``message`` verbatim with the wallet's private key.
+* :class:`WalletAuthLoginView` — ``POST /login/wallet/``, consumes the
+  nonce, verifies the signature, and issues JWTs. Response shape is
+  ``{"access", "refresh"}`` so clients only add the challenge round-trip.
+* :class:`WalletEmailAddView` / :class:`WalletLinkView` — unchanged from
+  pre-SIWE behavior.
+
+Background: issue #90 (upstream port of fabric-auth #401 / #402).
+"""
+
 import logging
+from typing import Union
 
 from drf_spectacular.utils import extend_schema
 from rest_framework import status
@@ -7,87 +24,214 @@ from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from blockauth.docs.wallet_auth_docs import wallet_email_add_docs, wallet_login_docs
+from blockauth.docs.wallet_auth_docs import wallet_email_add_docs
 from blockauth.enums import AuthenticationType
 from blockauth.models.otp import OTPSubject
 from blockauth.notification import send_otp
+from blockauth.serializers.wallet_auth_serializers import (
+    WalletChallengeRequestSerializer,
+    WalletChallengeResponseSerializer,
+    WalletLoginRequestSerializer,
+    WalletLoginResponseSerializer,
+)
 from blockauth.serializers.wallet_serializers import (
     WalletEmailAddSerializer,
     WalletLinkSerializer,
-    WalletLoginSerializer,
+)
+from blockauth.services.wallet_login_service import (
+    WalletLoginError,
+    get_wallet_login_service,
+)
+from blockauth.services.wallet_user_linker import (
+    WalletUserLinkError,
+    wallet_user_linker,
 )
 from blockauth.utils.config import get_block_auth_user_model, get_config
 from blockauth.utils.custom_exception import ValidationErrorWithCode, WalletConflictError
 from blockauth.utils.generics import model_to_json, sanitize_log_context
 from blockauth.utils.logger import blockauth_logger
-from blockauth.utils.rate_limiter import EnhancedThrottle
+from blockauth.utils.rate_limiter import (
+    EnhancedThrottle,
+    WalletChallengeThrottle,
+    WalletLoginThrottle,
+)
 
 logger = logging.getLogger(__name__)
 _User = get_block_auth_user_model()
 
 
-class WalletAuthLoginView(APIView):
-    """
-    API endpoint for Ethereum wallet login.
-    Accepts wallet address, message, and signature, and returns access/refresh tokens.
+# Error codes surfaced to clients. Each failure mode has a distinct code so
+# client devs can distinguish "bad nonce" from "bad signature" without
+# grepping error text.
+_AUTH_ERROR_STATUS_MAP = {
+    "invalid_address": status.HTTP_400_BAD_REQUEST,
+    "malformed_message": status.HTTP_400_BAD_REQUEST,
+    "address_mismatch": status.HTTP_400_BAD_REQUEST,
+    "unsupported_version": status.HTTP_400_BAD_REQUEST,
+    "domain_mismatch": status.HTTP_401_UNAUTHORIZED,
+    "domain_not_allowed": status.HTTP_400_BAD_REQUEST,
+    "not_yet_valid": status.HTTP_401_UNAUTHORIZED,
+    "expired": status.HTTP_401_UNAUTHORIZED,
+    "nonce_invalid": status.HTTP_401_UNAUTHORIZED,
+    "nonce_domain_mismatch": status.HTTP_401_UNAUTHORIZED,
+    "nonce_chain_mismatch": status.HTTP_401_UNAUTHORIZED,
+    "nonce_expired": status.HTTP_401_UNAUTHORIZED,
+    "malleable_signature": status.HTTP_400_BAD_REQUEST,
+    "invalid_signature": status.HTTP_400_BAD_REQUEST,
+    "signature_recovery_failed": status.HTTP_400_BAD_REQUEST,
+    "signature_mismatch": status.HTTP_401_UNAUTHORIZED,
+    # #5: a library regression in signature recovery is NOT a 400.
+    "signature_internal_error": status.HTTP_500_INTERNAL_SERVER_ERROR,
+    # #4: default wallet-not-registered surfaces as a generic 401 so the
+    # endpoint doesn't work as a registration oracle. A deployment that
+    # explicitly opts into the 403 via WALLET_LOGIN_EXPOSE_REGISTRATION_STATUS
+    # still gets the distinct code.
+    "login_failed": status.HTTP_401_UNAUTHORIZED,
+    "auto_create_disabled": status.HTTP_403_FORBIDDEN,
+}
+
+
+def _reject(error: Union[WalletLoginError, WalletUserLinkError]) -> Response:
+    """Shape a service-layer error into an HTTP response."""
+    http_status = _AUTH_ERROR_STATUS_MAP.get(error.code, status.HTTP_400_BAD_REQUEST)
+    return Response(
+        {"error": {"code": error.code, "message": error.message}},
+        status=http_status,
+    )
+
+
+class WalletChallengeView(APIView):
+    """``POST /login/wallet/challenge/`` — mint a SIWE plaintext for signing.
+
+    Public endpoint: the caller is by definition not yet authenticated.
+    Throttle scope is separate from ``/login/wallet/`` so one endpoint's
+    rate-limit bucket can't starve the other.
     """
 
     permission_classes = (AllowAny,)
-    authentication_classes = []
-    serializer_class = WalletLoginSerializer
-    login_throttle = EnhancedThrottle(rate=(10, 60), max_failures=5, cooldown_minutes=15)
+    authentication_classes: list = []
+    throttle_classes = [WalletChallengeThrottle]
 
-    @extend_schema(**wallet_login_docs)
+    @extend_schema(
+        operation_id="wallet-login-challenge",
+        summary="Wallet login — issue SIWE challenge",
+        description=(
+            "Returns an EIP-4361 plaintext that the caller must sign with "
+            "the private key controlling the supplied address. The server "
+            "records the embedded nonce so it can reject replays on the "
+            "subsequent `/login/wallet/` call. TTL defaults to 5 minutes; "
+            "the nonce is single-use."
+        ),
+        request=WalletChallengeRequestSerializer,
+        responses={200: WalletChallengeResponseSerializer},
+        tags=["Wallet"],
+    )
     def post(self, request):
-        if not self.login_throttle.allow_request(request, "wallet_login"):
-            reason = self.login_throttle.get_block_reason()
-            msg = (
-                "Too many failed login attempts. Please try again later."
-                if reason == "cooldown"
-                else "Rate limit exceeded. Please try again later."
-            )
-            return Response(data={"detail": msg}, status=status.HTTP_429_TOO_MANY_REQUESTS)
+        serializer = WalletChallengeRequestSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
 
-        serializer = self.serializer_class(data=request.data)
-        blockauth_logger.info("Wallet login attempt", sanitize_log_context(request.data))
+        service = get_wallet_login_service()
+        try:
+            result = service.issue_challenge(
+                address=serializer.validated_data["address"],
+                chain_id=serializer.validated_data.get("chain_id"),
+                domain=serializer.validated_data.get("domain"),
+                uri=serializer.validated_data.get("uri"),
+            )
+        except WalletLoginError as exc:
+            blockauth_logger.info(
+                "Wallet challenge rejected",
+                sanitize_log_context({"error_code": exc.code}),
+            )
+            return _reject(exc)
+
+        response_serializer = WalletChallengeResponseSerializer(
+            {
+                "message": result.message,
+                "nonce": result.nonce,
+                "domain": result.domain,
+                "chain_id": result.chain_id,
+                "uri": result.uri,
+                "issued_at": result.issued_at,
+                "expires_at": result.expires_at,
+            }
+        )
+        return Response(response_serializer.data, status=status.HTTP_200_OK)
+
+
+class WalletAuthLoginView(APIView):
+    """``POST /login/wallet/`` — SIWE-backed wallet authentication.
+
+    Flow:
+
+    1. Parse the signed SIWE plaintext and validate every mandatory EIP-4361
+       field (domain, URI, chain_id, nonce, issuedAt, expirationTime).
+    2. Look up and atomically consume the matching server-issued nonce row.
+    3. Verify the signature (with low-s malleability bound).
+    4. Delegate user lookup/creation + token issuance to the linker service.
+
+    The response shape ``{"access", "refresh"}`` is unchanged from the
+    previous wallet login implementation. Clients only need to add the
+    preceding ``/login/wallet/challenge/`` round-trip.
+    """
+
+    permission_classes = (AllowAny,)
+    authentication_classes: list = []
+    throttle_classes = [WalletLoginThrottle]
+
+    @extend_schema(
+        operation_id="wallet-login",
+        summary="Wallet login — verify signed SIWE challenge",
+        description=(
+            "Consumes a nonce issued by `/login/wallet/challenge/` and a "
+            "valid EIP-4361 signature to authenticate the wallet holder. "
+            "Returns the same `{access, refresh}` JWT pair as the other "
+            "login flows. Nonces are single-use and expire after the "
+            "configured TTL (default 5 minutes)."
+        ),
+        request=WalletLoginRequestSerializer,
+        responses={200: WalletLoginResponseSerializer},
+        tags=["Wallet"],
+    )
+    def post(self, request):
+        serializer = WalletLoginRequestSerializer(data=request.data)
+        try:
+            serializer.is_valid(raise_exception=True)
+        except ValidationError as exc:
+            raise ValidationErrorWithCode(detail=exc.detail)
+
+        service = get_wallet_login_service()
+        try:
+            verified = service.verify_login(
+                wallet_address=serializer.validated_data["wallet_address"],
+                message=serializer.validated_data["message"],
+                signature=serializer.validated_data["signature"],
+            )
+        except WalletLoginError as exc:
+            blockauth_logger.warning(
+                "Wallet login rejected",
+                sanitize_log_context({"error_code": exc.code}),
+            )
+            return _reject(exc)
 
         try:
-            # Validate input data
-            serializer.is_valid(raise_exception=True)
-
-            # Perform authentication (all business logic is in the serializer)
-            auth_result = serializer.authenticate_user()
-
-            # Log success
-            if auth_result["created"]:
-                blockauth_logger.success(
-                    "Wallet login: new user created",
-                    sanitize_log_context(request.data, {"user": auth_result["user"].id}),
-                )
-            else:
-                blockauth_logger.success(
-                    "Wallet login successful", sanitize_log_context(request.data, {"user": auth_result["user"].id})
-                )
-
-            self.login_throttle.record_success(request, "wallet_login")
-
-            # Return response
-            return Response(
-                data={"access": auth_result["access_token"], "refresh": auth_result["refresh_token"]},
-                status=status.HTTP_200_OK,
-            )
-
-        except ValidationError as e:
-            self.login_throttle.record_failure(request, "wallet_login")
+            linked = wallet_user_linker.link(wallet_address=verified.address)
+        except WalletUserLinkError as exc:
             blockauth_logger.warning(
-                "Wallet login validation failed", sanitize_log_context(request.data, {"errors": e.detail})
+                "Wallet login link rejected",
+                sanitize_log_context({"error_code": exc.code}),
             )
-            raise ValidationErrorWithCode(detail=e.detail)
-        except Exception as e:
-            self.login_throttle.record_failure(request, "wallet_login")
-            blockauth_logger.error("Wallet login failed", sanitize_log_context(request.data, {"error": str(e)}))
-            logger.error(f"Wallet login request failed: {e}", exc_info=True)
-            raise APIException()
+            return _reject(exc)
+
+        blockauth_logger.success(
+            "Wallet login successful",
+            sanitize_log_context({"user": linked.user_id, "created": linked.created}),
+        )
+
+        response_serializer = WalletLoginResponseSerializer(
+            {"access": linked.access_token, "refresh": linked.refresh_token}
+        )
+        return Response(response_serializer.data, status=status.HTTP_200_OK)
 
 
 class WalletEmailAddView(APIView):

--- a/conftest.py
+++ b/conftest.py
@@ -35,6 +35,12 @@ def pytest_configure():
         ROOT_URLCONF="blockauth.urls",
         SECRET_KEY="test-secret-key-not-for-production",
         DEFAULT_AUTO_FIELD="django.db.models.BigAutoField",
+        DEBUG=True,
+        # SIWE defaults for the test suite. Individual tests may override
+        # these via pytest-django's ``settings`` fixture.
+        WALLET_LOGIN_EXPECTED_DOMAINS=("example.com",),
+        WALLET_LOGIN_DEFAULT_CHAIN_ID=1,
+        WALLET_LOGIN_NONCE_TTL_SECONDS=300,
         BLOCK_AUTH_SETTINGS={
             "SECRET_KEY": "test-secret-key-not-for-production",
             "ALGORITHM": "HS256",

--- a/uv.lock
+++ b/uv.lock
@@ -345,7 +345,7 @@ dev = [
 requires-dist = [
     { name = "argon2-cffi", specifier = ">=23.0.0" },
     { name = "cryptography", specifier = ">=46.0.5" },
-    { name = "django", specifier = ">=5.0,<6.0" },
+    { name = "django", specifier = ">=5.0,<7.0" },
     { name = "django-ratelimit", specifier = ">=4.1,<5.0" },
     { name = "djangorestframework", specifier = ">=3.14,<4.0" },
     { name = "drf-spectacular", specifier = ">=0.27,<1.0" },


### PR DESCRIPTION
## Summary

Upstream port of [fabric-auth#402](https://github.com/BloclabsHQ/fabric-auth/pull/402)'s SIWE (EIP-4361) wallet login flow into auth-pack, plus the 11 hardening items from review of that implementation so every consumer inherits the fixes. Closes #90.

The client flow is now:

1. `POST /login/wallet/challenge/` — server mints a 128-bit nonce bound to the lowercased address, stores it with a TTL (default 5 minutes), and returns an EIP-4361 plaintext. The server owns every byte of what gets signed.
2. `POST /login/wallet/` — client posts `{wallet_address, message, signature}`. The server parses every mandatory EIP-4361 field (domain, URI, chain_id, nonce, issuedAt, expirationTime), consumes the matching nonce row atomically inside `SELECT ... FOR UPDATE`, rejects malleable high-s signatures, then hands off to the linker for user lookup/creation + JWT issuance. Response shape `{access, refresh}` is unchanged.

### What shipped

**SIWE flow**

- `blockauth/models/wallet_login_nonce.py` + `blockauth/migrations/0002_walletloginnonce.py` — single-use, TTL-bounded row with `expires_at` index.
- `blockauth/utils/siwe.py` — minimal EIP-4361 parser + builder. No new transitive deps.
- `blockauth/services/wallet_login_service.py` — nonce issuance, SIWE verification, low-s malleability bound.
- `blockauth/services/wallet_user_linker.py` — user lookup/create + token issuance + trigger fan-out.
- `blockauth/serializers/wallet_auth_serializers.py` — DRF wrappers for challenge + login request/response.
- `blockauth/views/wallet_auth_views.py` — `WalletChallengeView` + rewritten `WalletAuthLoginView`.
- `blockauth/urls.py` + `blockauth/constants/core.py` — `login/wallet/challenge/` route + URL name.

**Hardening items (all 11)**

1. **Auto-create race → no 500.** `WalletUserLinker.link` uses `get_or_create` inside `transaction.atomic()` so the losing side of a concurrent first-login returns the existing row. `blockauth/services/wallet_user_linker.py:80-95`.
2. **Sync trigger fan-out.** Triggers fire on `transaction.on_commit` wrapped in per-trigger `try/except logger.exception`. A raising `POST_SIGNUP_TRIGGER` no longer blocks the response or loses the broadcast. `blockauth/services/wallet_user_linker.py:172-216`.
3. **Domain allow-list startup validation.** `validate_wallet_login_settings()` in `blockauth/apps.py` refuses to boot a non-DEBUG deployment with an empty `WALLET_LOGIN_EXPECTED_DOMAINS`. `WALLET_LOGIN_SKIP_STARTUP_VALIDATION` opt-out for phased rollouts.
4. **Registration oracle.** Default `WALLET_LOGIN_AUTO_CREATE=False` response is now a generic 401/`login_failed`. `WALLET_LOGIN_EXPOSE_REGISTRATION_STATUS=True` opts into the distinct 403 for UX reasons. `blockauth/services/wallet_user_linker.py:96-112`.
5. **Narrow excepts.** Signature recovery catches only `(ValueError, TypeError)`; anything else surfaces as HTTP 500 `signature_internal_error` with `logger.exception`. `blockauth/services/wallet_login_service.py:326-368`.
6. **Silent ImportError fallback.** `_issue_tokens` emits `logger.warning` when `generate_auth_token_with_custom_claims` is unavailable instead of silently dropping custom claims.
7. **CRLF handling.** `blockauth/utils/siwe.py::_split_lines` normalizes `\r\n`/`\r`/`\n` before splitting.
8. **Duplicate-field rejection.** Repeated required/optional fields raise `SiweParseError("Duplicate SIWE field: ...")` instead of last-one-wins.
9. **Max message length.** `MAX_SIWE_MESSAGE_LENGTH = 4096` enforced by the parser; the DRF serializer caps `message` to match so oversized payloads never reach the parser.
10. **Throttle scoping.** `WalletLoginThrottle` / `WalletChallengeThrottle` scope buckets per (IP, wallet_address, scope); the challenge and login endpoints get independent buckets. Uses the existing XFF-aware `get_client_ip` so load-balancer IPs don't starve all legitimate users.
11. **Nonce reaper.** `python manage.py prune_wallet_nonces` deletes expired rows plus consumed rows older than `--older-than` seconds (default 3600). Batched, `--dry-run` supported, and safe for Celery Beat / cron.

## Acceptance criteria

- [x] `WalletLoginNonce` model + migration in auth-pack
- [x] `/login/wallet/challenge/` endpoint
- [x] `/login/wallet/` endpoint overrides the current view with SIWE validation
- [x] All 11 hardening items above addressed in the upstream port
- [x] Tests: 26 from fabric-auth#402 (parser + service + HTTP) plus new tests for items #1 (auto-create race), #2 (trigger fan-out), #4 (oracle + opt-in), #5 (library regression), #7 (CRLF), #8 (duplicate fields), #9 (max length), #10 (throttle scoping), #11 (reaper). Also `nonce_chain_mismatch` and `not_before`.
- [x] Startup validation for `WALLET_LOGIN_EXPECTED_DOMAINS` in non-DEBUG
- [x] Migration notes for consumers (CHANGELOG + below)
- [x] fabric-auth can remove its local override and rely on auth-pack once the release ships

## Test plan

- [x] `uv run pytest` — 423 passed (from a 365 baseline; 58 new tests). Final run:
  ```
  ====================== 423 passed, 179 warnings in 7.57s ======================
  ```
- [x] `uv run black --check` — clean on every file touched.
- [x] `uv run isort --check-only` — clean.
- [x] `uv run flake8` — no new non-E501 warnings (the E501 warnings match the rest of the codebase which is black-formatted at `line-length = 120`).
- [ ] Smoke the two endpoints end-to-end in a fabric-auth worktree against this branch before cutting a release.

## Rollout notes / breaking changes

- Run `python manage.py migrate` to apply `blockauth.0002_walletloginnonce`.
- Set `WALLET_LOGIN_EXPECTED_DOMAINS = ("app.example.com", ...)` in production Django settings. The startup check fails closed on `DEBUG=False` deployments without it.
- Update wallet-login clients to call `POST /login/wallet/challenge/` first, sign the returned `message` verbatim with the wallet's private key (`eth_account.sign_message(encode_defunct(text=message))`), and post `{wallet_address, message, signature}` to `POST /login/wallet/`. Response shape (`{access, refresh}`) is unchanged.
- Schedule `python manage.py prune_wallet_nonces` every 5–15 minutes (Celery Beat, cron, or systemd timer). The `expires_at` index keeps each sweep cheap.
- fabric-auth should bump `uv.lock` for blockauth and remove its `base/views/wallet_auth_views.py` SIWE override once the release tag lands.

### Out of scope (follow-ups)

- EIP-1271 (contract wallets). Current flow is EOA only, same as the previous behavior. Requires on-chain `isValidSignature` via an RPC provider that blockauth doesn't own — separate issue.
- Wiki rewrite of auth-pack's `Security-Model` page — the existing section still documents the pre-SIWE flow. File a doc-only follow-up.

Refs: #90, BloclabsHQ/fabric-auth#401, BloclabsHQ/fabric-auth#402.

Closes #90