### PR TITLE
fix(apps): skip startup validation for offline management commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — pre-1
 - With `WALLET_LOGIN_AUTO_CREATE=False` the endpoint no longer acts as a registration oracle -- unknown and known wallets both return a generic 401. Deployments that need the distinct 403 can opt in via `WALLET_LOGIN_EXPOSE_REGISTRATION_STATUS=True` (#90, hardening #4).
 - Narrow exception handling in signature verification. A library regression surfaces as `signature_internal_error` (mapped to HTTP 500) with `logger.exception`, rather than masquerading as a 400 from bad input (#90, hardening #5).
 - Token-issuance fallback now warns on `ImportError` instead of silently dropping custom claims (#90, hardening #6).
+- Startup validation no longer fires during offline management commands. Docker builds that run `python manage.py collectstatic` / `migrate` / `check` / etc. no longer fail on a non-DEBUG deployment with an empty `WALLET_LOGIN_EXPECTED_DOMAINS`. The check still fires for `runserver` and for WSGI/ASGI boots (gunicorn, uvicorn, daphne), so a misconfigured deployment still refuses to serve traffic (#93).
 
 ### Migration notes
 

--- a/blockauth/apps.py
+++ b/blockauth/apps.py
@@ -5,11 +5,64 @@ first wallet login request -- we want a non-DEBUG deployment with an empty
 ``WALLET_LOGIN_EXPECTED_DOMAINS`` list to fail to boot, not to silently
 accept SIWE challenges against a host extracted from the dev URL
 (hardening #3 in issue #90).
+
+The validation is also guarded by a ``sys.argv`` check so it only fires for
+commands that actually serve traffic (``runserver``, or a WSGI/ASGI server
+booting through ``django.setup()``). Management commands that trigger
+``ready()`` during a Docker build or a deploy (``collectstatic``,
+``migrate``, ``check``, ...) don't need the allow-list -- forcing every
+consumer's Dockerfile to set ``WALLET_LOGIN_SKIP_STARTUP_VALIDATION=true``
+just to build a static-asset layer was a silent landmine every new consumer
+tripped over (issue #93).
 """
+
+import sys
 
 from django.apps import AppConfig
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
+
+# Management commands that run ``django.setup()`` but don't serve HTTP
+# traffic. The SIWE allow-list check doesn't need to fire for any of these:
+# they either run during a Docker build (``collectstatic``), a deploy step
+# (``migrate``), CI (``check``, ``test``), ops inspection (``shell``,
+# ``dbshell``, ``showmigrations``, ``diffsettings``), i18n build
+# (``compilemessages``, ``makemessages``), data IO (``dumpdata``,
+# ``loaddata``, ``flush``, ``clearsessions``), or user admin
+# (``createsuperuser``, ``changepassword``).
+#
+# ``runserver`` / ``runserver_plus`` are deliberately absent -- they bind a
+# port and must validate. WSGI/ASGI servers (``gunicorn``, ``uvicorn``,
+# ``daphne``) don't run through manage.py so their ``sys.argv[1]`` is not
+# in this set either, which is the desired fail-closed behavior.
+_OFFLINE_MANAGEMENT_COMMANDS = frozenset(
+    {
+        "check",
+        "changepassword",
+        "clearsessions",
+        "collectstatic",
+        "compilemessages",
+        "createsuperuser",
+        "dbshell",
+        "diffsettings",
+        "dumpdata",
+        "flush",
+        "help",
+        "loaddata",
+        "makemessages",
+        "makemigrations",
+        "migrate",
+        "sendtestemail",
+        "shell",
+        "shell_plus",
+        "showmigrations",
+        "sqlflush",
+        "sqlmigrate",
+        "sqlsequencereset",
+        "test",
+        "version",
+    }
+)
 
 
 class BlockAuthConfig(AppConfig):
@@ -40,6 +93,15 @@ def validate_wallet_login_settings() -> None:
     # feature flag) silence the check without turning DEBUG on. Prefer to
     # leave it off in real production.
     if getattr(settings, "WALLET_LOGIN_SKIP_STARTUP_VALIDATION", False):
+        return
+
+    # #93: when running an offline management command (``collectstatic``,
+    # ``migrate``, ...), the check would crash a Docker build that hadn't
+    # yet wired the allow-list. Those commands don't serve traffic, so
+    # there's nothing to protect. We keep firing for ``runserver`` and for
+    # WSGI/ASGI boots (no ``manage.py <cmd>`` argv).
+    command = sys.argv[1] if len(sys.argv) > 1 else ""
+    if command in _OFFLINE_MANAGEMENT_COMMANDS:
         return
 
     domains = getattr(settings, "WALLET_LOGIN_EXPECTED_DOMAINS", ())

--- a/blockauth/utils/tests/test_wallet_login_hardening.py
+++ b/blockauth/utils/tests/test_wallet_login_hardening.py
@@ -66,6 +66,76 @@ class TestStartupValidation:
         settings.WALLET_LOGIN_SKIP_STARTUP_VALIDATION = True
         validate_wallet_login_settings()
 
+    # ---- #93: offline management commands must not fire the check ----------
+    #
+    # ``ready()`` runs on every ``django.setup()`` including ``collectstatic``
+    # inside a Dockerfile, which would otherwise block every consumer build
+    # until they set ``WALLET_LOGIN_SKIP_STARTUP_VALIDATION`` in every RUN
+    # step. The guard whitelists offline commands so the check only fires
+    # for serving boots (``runserver``, gunicorn, uvicorn, ...).
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "collectstatic",
+            "migrate",
+            "makemigrations",
+            "check",
+            "test",
+            "shell",
+            "dbshell",
+            "showmigrations",
+            "compilemessages",
+            "loaddata",
+            "createsuperuser",
+            "flush",
+        ],
+    )
+    def test_offline_command_skips_check(self, settings, monkeypatch, command):
+        settings.DEBUG = False
+        settings.WALLET_LOGIN_EXPECTED_DOMAINS = ()
+        settings.WALLET_LOGIN_SKIP_STARTUP_VALIDATION = False
+        monkeypatch.setattr("sys.argv", ["manage.py", command])
+        # Must not raise.
+        validate_wallet_login_settings()
+
+    def test_runserver_still_validates(self, settings, monkeypatch):
+        """``runserver`` binds a port, so the check must fire."""
+        settings.DEBUG = False
+        settings.WALLET_LOGIN_EXPECTED_DOMAINS = ()
+        settings.WALLET_LOGIN_SKIP_STARTUP_VALIDATION = False
+        monkeypatch.setattr("sys.argv", ["manage.py", "runserver"])
+        with pytest.raises(ImproperlyConfigured, match="non-empty"):
+            validate_wallet_login_settings()
+
+    def test_wsgi_boot_still_validates(self, settings, monkeypatch):
+        """gunicorn/uvicorn never go through manage.py; argv[1] is not a
+        Django command so the guard falls through and the check fires.
+        """
+        settings.DEBUG = False
+        settings.WALLET_LOGIN_EXPECTED_DOMAINS = ()
+        settings.WALLET_LOGIN_SKIP_STARTUP_VALIDATION = False
+        monkeypatch.setattr("sys.argv", ["gunicorn", "myapp.wsgi:application"])
+        with pytest.raises(ImproperlyConfigured, match="non-empty"):
+            validate_wallet_login_settings()
+
+    def test_argv_with_no_command_still_validates(self, settings, monkeypatch):
+        """No subcommand -> treat as serving boot (fail closed)."""
+        settings.DEBUG = False
+        settings.WALLET_LOGIN_EXPECTED_DOMAINS = ()
+        settings.WALLET_LOGIN_SKIP_STARTUP_VALIDATION = False
+        monkeypatch.setattr("sys.argv", ["manage.py"])
+        with pytest.raises(ImproperlyConfigured, match="non-empty"):
+            validate_wallet_login_settings()
+
+    def test_offline_command_with_allowlist_still_accepted(self, settings, monkeypatch):
+        """Sanity: a valid allow-list shouldn't regress the offline path."""
+        settings.DEBUG = False
+        settings.WALLET_LOGIN_EXPECTED_DOMAINS = ("app.example.com",)
+        settings.WALLET_LOGIN_SKIP_STARTUP_VALIDATION = False
+        monkeypatch.setattr("sys.argv", ["manage.py", "migrate"])
+        validate_wallet_login_settings()
+
 
 # =============================================================================
 # Hardening #10 — throttle scoping


### PR DESCRIPTION
## Summary

- `validate_wallet_login_settings()` in `BlockAuthConfig.ready()` now skips for offline management commands (`collectstatic`, `migrate`, `check`, etc.) via a `sys.argv` guard
- 24-command `_OFFLINE_MANAGEMENT_COMMANDS` frozenset — `runserver` and WSGI/ASGI boots (gunicorn, uvicorn, daphne) still validate
- 16 new tests covering offline-command skip, runserver enforcement, WSGI enforcement, and empty-argv fail-closed behavior

Closes #93
Related: #90, #91

## Test plan
- [x] `test_offline_command_skips_check` — 12 parametrized offline commands pass without raise
- [x] `test_runserver_still_validates` — `runserver` triggers `ImproperlyConfigured`
- [x] `test_wsgi_boot_still_validates` — gunicorn argv triggers `ImproperlyConfigured`
- [x] `test_argv_with_no_command_still_validates` — bare `manage.py` triggers `ImproperlyConfigured`
- [x] `test_offline_command_with_allowlist_still_accepted` — no regression with valid config
- [x] Full suite: 441 passed