### PR TITLE
feat: return user payload from basic, passwordless, and wallet login (v0.6.0)

### DIFF
--- a/blockauth/__init__.py
+++ b/blockauth/__init__.py
@@ -28,7 +28,7 @@ Static utilities (no storage needed):
     backup_codes = TOTPService.generate_backup_codes()
 """
 
-__version__ = "0.5.0"
+__version__ = "0.6.0"
 
 # =============================================================================
 # Direct imports (Django-independent, no AppRegistryNotReady errors)

--- a/blockauth/docs/auth_docs.py
+++ b/blockauth/docs/auth_docs.py
@@ -8,11 +8,13 @@ Separated from business logic for better maintainability and organization.
 from drf_spectacular.utils import OpenApiExample, OpenApiResponse
 
 from blockauth.serializers.user_account_serializers import (
+    BasicLoginResponseSerializer,
     BasicLoginSerializer,
     EmailChangeConfirmationSerializer,
     EmailChangeRequestSerializer,
     PasswordChangeSerializer,
     PasswordlessLoginConfirmationSerializer,
+    PasswordlessLoginResponseSerializer,
     PasswordlessLoginSerializer,
     PasswordResetConfirmationEmailSerializer,
     PasswordResetRequestSerializer,
@@ -430,41 +432,26 @@ basic_login_docs = {
         ),
     ],
     "responses": {
+        # Issue #97: response serializer is the source of truth -- the hand-
+        # rolled schema that lived here previously described a ``user`` field
+        # that the code didn't actually return, so generated clients were
+        # broken. Point drf-spectacular at the real serializer to keep the
+        # spec honest.
         200: OpenApiResponse(
             description="Login successful",
-            response={
-                "type": "object",
-                "properties": {
-                    "access": {
-                        "type": "string",
-                        "description": "JWT access token for API authentication",
-                        "format": "jwt",
-                    },
-                    "refresh": {
-                        "type": "string",
-                        "description": "JWT refresh token for token renewal",
-                        "format": "jwt",
-                    },
-                    "user": {
-                        "type": "object",
-                        "properties": {
-                            "id": {"type": "integer", "description": "User ID"},
-                            "email": {"type": "string", "format": "email", "description": "User email address"},
-                            "phone_number": {"type": "string", "description": "User phone number"},
-                            "is_verified": {"type": "boolean", "description": "Email verification status"},
-                        },
-                        "required": ["id", "is_verified"],
-                    },
-                },
-                "required": ["access", "refresh"],
-            },
+            response=BasicLoginResponseSerializer,
             examples=[
                 OpenApiExample(
                     "Success",
                     value={
                         "access": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
                         "refresh": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
-                        "user": {"id": 123, "email": "user@example.com", "is_verified": True},
+                        "user": {
+                            "id": "8f3e8f4c-1c2d-4a3b-bd8b-4a0f8f5b1a21",
+                            "email": "user@example.com",
+                            "is_verified": True,
+                            "wallet_address": None,
+                        },
                     },
                     status_codes=[200],
                 )

--- a/blockauth/docs/auth_docs.py
+++ b/blockauth/docs/auth_docs.py
@@ -640,41 +640,23 @@ passwordless_confirm_docs = {
         ),
     ],
     "responses": {
+        # Issue #97: point at the real response serializer so the OpenAPI
+        # spec stops drifting from the runtime shape.
         200: OpenApiResponse(
             description="Login successful",
-            response={
-                "type": "object",
-                "properties": {
-                    "access": {
-                        "type": "string",
-                        "description": "JWT access token for API authentication",
-                        "format": "jwt",
-                    },
-                    "refresh": {
-                        "type": "string",
-                        "description": "JWT refresh token for token renewal",
-                        "format": "jwt",
-                    },
-                    "user": {
-                        "type": "object",
-                        "properties": {
-                            "id": {"type": "integer", "description": "User ID"},
-                            "email": {"type": "string", "format": "email", "description": "User email address"},
-                            "phone_number": {"type": "string", "description": "User phone number"},
-                            "is_verified": {"type": "boolean", "description": "Email verification status"},
-                        },
-                        "required": ["id", "is_verified"],
-                    },
-                },
-                "required": ["access", "refresh"],
-            },
+            response=PasswordlessLoginResponseSerializer,
             examples=[
                 OpenApiExample(
                     "Success",
                     value={
                         "access": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
                         "refresh": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
-                        "user": {"id": 123, "email": "user@example.com", "is_verified": True},
+                        "user": {
+                            "id": "8f3e8f4c-1c2d-4a3b-bd8b-4a0f8f5b1a21",
+                            "email": "user@example.com",
+                            "is_verified": True,
+                            "wallet_address": None,
+                        },
                     },
                     status_codes=[200],
                 )

--- a/blockauth/serializers/user_account_serializers.py
+++ b/blockauth/serializers/user_account_serializers.py
@@ -256,3 +256,67 @@ class EmailChangeConfirmationSerializer(serializers.Serializer):
 
 class RefreshTokenSerializer(serializers.Serializer):
     refresh_token = serializers.CharField(help_text="Refresh token to get new access token", required=True)
+
+
+"""shared login response serializers (issue #97)
+
+These serializers describe the ``{access, refresh, user}`` response shape
+used by basic-login, passwordless-login, and wallet-login. Keeping them in
+one place means the OpenAPI spec stays consistent across all three endpoints
+and clients can share a single generated type.
+
+``email`` and ``wallet_address`` are both nullable because:
+
+* wallet-first accounts are created with no email on first SIWE login,
+* basic / passwordless accounts have no wallet until the user runs the
+  ``wallet/link/`` flow.
+"""
+
+
+class LoginUserSerializer(serializers.Serializer):
+    """User payload embedded in every login response.
+
+    Shared by ``BasicLoginResponseSerializer``,
+    ``PasswordlessLoginResponseSerializer``, and
+    ``WalletLoginResponseSerializer`` so the three endpoints stay in lock-step.
+    Do not add anything here that isn't safe to surface to the client --
+    this object goes into the success response of an unauthenticated call.
+    """
+
+    id = serializers.UUIDField(help_text="User UUID")
+    email = serializers.CharField(
+        allow_null=True,
+        required=False,
+        help_text="Email address (null for wallet-first accounts)",
+    )
+    is_verified = serializers.BooleanField(help_text="Whether the account is verified")
+    wallet_address = serializers.CharField(
+        allow_null=True,
+        required=False,
+        help_text="Ethereum wallet address (null for accounts without a linked wallet)",
+    )
+
+
+class BasicLoginResponseSerializer(serializers.Serializer):
+    """Response body for ``POST /login/basic/`` (issue #97).
+
+    The ``user`` field gives clients parity with wallet-login so they can
+    hydrate profile state without a follow-up ``GET /me/`` round-trip.
+    """
+
+    access = serializers.CharField(help_text="JWT access token")
+    refresh = serializers.CharField(help_text="JWT refresh token")
+    user = LoginUserSerializer(help_text="Authenticated user profile")
+
+
+class PasswordlessLoginResponseSerializer(serializers.Serializer):
+    """Response body for ``POST /login/passwordless/confirm/`` (issue #97).
+
+    Same shape as :class:`BasicLoginResponseSerializer`; kept as a distinct
+    class so drf-spectacular can tag the schema separately per endpoint and
+    so future divergence (e.g. passwordless-only flags) is cheap.
+    """
+
+    access = serializers.CharField(help_text="JWT access token")
+    refresh = serializers.CharField(help_text="JWT refresh token")
+    user = LoginUserSerializer(help_text="Authenticated user profile")

--- a/blockauth/serializers/wallet_auth_serializers.py
+++ b/blockauth/serializers/wallet_auth_serializers.py
@@ -9,6 +9,7 @@ default URLconf.
 
 from rest_framework import serializers
 
+from blockauth.serializers.user_account_serializers import LoginUserSerializer
 from blockauth.utils.siwe import MAX_SIWE_MESSAGE_LENGTH
 
 
@@ -81,26 +82,14 @@ class WalletLoginRequestSerializer(serializers.Serializer):
     )
 
 
-class WalletLoginUserSerializer(serializers.Serializer):
-    """User payload nested inside the wallet-login response.
-
-    Matches the shape described in issue #97 so clients get parity with
-    basic-login without a second ``GET /me/`` round-trip.  ``email`` is
-    nullable because wallet-first Creators may not have one yet.
-    """
-
-    id = serializers.UUIDField(help_text="User UUID")
-    email = serializers.EmailField(
-        allow_null=True,
-        required=False,
-        help_text="Email address (null for wallet-first accounts)",
-    )
-    is_verified = serializers.BooleanField(help_text="Whether the account is verified")
-    wallet_address = serializers.CharField(
-        allow_null=True,
-        required=False,
-        help_text="Ethereum wallet address",
-    )
+# Backwards-compat alias. The wallet-login response used to embed a
+# ``WalletLoginUserSerializer`` declared here. Issue #97 generalised the
+# payload to basic-login and passwordless-login, at which point the
+# serializer was promoted to the shared ``LoginUserSerializer`` in
+# ``user_account_serializers``. Keeping the alias avoids breaking any
+# external consumer that imported the old name before the rename was
+# released; remove in a future major bump.
+WalletLoginUserSerializer = LoginUserSerializer
 
 
 class WalletLoginResponseSerializer(serializers.Serializer):
@@ -108,4 +97,4 @@ class WalletLoginResponseSerializer(serializers.Serializer):
 
     access = serializers.CharField(help_text="JWT access token")
     refresh = serializers.CharField(help_text="JWT refresh token")
-    user = WalletLoginUserSerializer(help_text="Authenticated user profile")
+    user = LoginUserSerializer(help_text="Authenticated user profile")

--- a/blockauth/serializers/wallet_auth_serializers.py
+++ b/blockauth/serializers/wallet_auth_serializers.py
@@ -81,8 +81,31 @@ class WalletLoginRequestSerializer(serializers.Serializer):
     )
 
 
+class WalletLoginUserSerializer(serializers.Serializer):
+    """User payload nested inside the wallet-login response.
+
+    Matches the shape described in issue #97 so clients get parity with
+    basic-login without a second ``GET /me/`` round-trip.  ``email`` is
+    nullable because wallet-first Creators may not have one yet.
+    """
+
+    id = serializers.UUIDField(help_text="User UUID")
+    email = serializers.EmailField(
+        allow_null=True,
+        required=False,
+        help_text="Email address (null for wallet-first accounts)",
+    )
+    is_verified = serializers.BooleanField(help_text="Whether the account is verified")
+    wallet_address = serializers.CharField(
+        allow_null=True,
+        required=False,
+        help_text="Ethereum wallet address",
+    )
+
+
 class WalletLoginResponseSerializer(serializers.Serializer):
     """Response body for ``POST /login/wallet/``."""
 
     access = serializers.CharField(help_text="JWT access token")
     refresh = serializers.CharField(help_text="JWT refresh token")
+    user = WalletLoginUserSerializer(help_text="Authenticated user profile")

--- a/blockauth/services/wallet_user_linker.py
+++ b/blockauth/services/wallet_user_linker.py
@@ -34,7 +34,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import Tuple
+from typing import Any, Tuple
 
 from django.conf import settings
 from django.db import transaction
@@ -59,13 +59,20 @@ class WalletUserLinkError(Exception):
 
 @dataclass(frozen=True)
 class LinkedUser:
-    """Output of :meth:`WalletUserLinker.link`."""
+    """Output of :meth:`WalletUserLinker.link`.
+
+    ``user`` carries the Django model instance so the caller can serialise
+    a user payload into the HTTP response without an extra DB round-trip.
+    The field is typed ``Any`` to avoid importing the concrete user model
+    at class-definition time (it varies per deployment).
+    """
 
     user_id: str
     email: str
     access_token: str
     refresh_token: str
     created: bool
+    user: Any = None
 
 
 class WalletUserLinker:
@@ -161,6 +168,7 @@ class WalletUserLinker:
             access_token=access_token,
             refresh_token=refresh_token,
             created=created,
+            user=user,
         )
 
     # =========================================================================

--- a/blockauth/utils/tests/test_wallet_login_siwe.py
+++ b/blockauth/utils/tests/test_wallet_login_siwe.py
@@ -403,8 +403,18 @@ class TestWalletLoginEndpoints:
             format="json",
         )
         assert login_resp.status_code == 200, login_resp.content
-        assert "access" in login_resp.json()
-        assert "refresh" in login_resp.json()
+        body = login_resp.json()
+        assert "access" in body
+        assert "refresh" in body
+        # Issue #97: wallet login now returns user payload
+        assert "user" in body
+        user_payload = body["user"]
+        assert "id" in user_payload
+        assert "is_verified" in user_payload
+        assert "wallet_address" in user_payload
+        assert user_payload["wallet_address"] == _TEST_ADDRESS_LC
+        # email may be null for wallet-first accounts
+        assert "email" in user_payload
 
         cache.clear()
         replay = client.post(
@@ -518,7 +528,11 @@ class TestWalletLoginEndpoints:
             format="json",
         )
         assert resp.status_code == 200, resp.content
-        assert "access" in resp.json()
+        body = resp.json()
+        assert "access" in body
+        # Issue #97: user payload present for existing wallet too
+        assert "user" in body
+        assert body["user"]["wallet_address"] == _TEST_ADDRESS_LC
 
     def test_login_rejects_oversized_message(self):
         """Hardening #9 — serializer caps message length."""

--- a/blockauth/views/basic_auth_views.py
+++ b/blockauth/views/basic_auth_views.py
@@ -26,11 +26,13 @@ from blockauth.enums import AuthenticationType
 from blockauth.models.otp import OTP, OTPSubject
 from blockauth.notification import NotificationEvent, send_otp
 from blockauth.serializers.user_account_serializers import (
+    BasicLoginResponseSerializer,
     BasicLoginSerializer,
     EmailChangeConfirmationSerializer,
     EmailChangeRequestSerializer,
     PasswordChangeSerializer,
     PasswordlessLoginConfirmationSerializer,
+    PasswordlessLoginResponseSerializer,
     PasswordlessLoginSerializer,
     PasswordResetConfirmationEmailSerializer,
     PasswordResetRequestSerializer,
@@ -297,7 +299,23 @@ class BasicAuthLoginView(APIView):
                 access_token, refresh_token = generate_auth_token(token_class=AUTH_TOKEN_CLASS(), user_id=str(user.id))
             self.login_throttle.record_success(request, "basic_login")
             blockauth_logger.success("Basic login successful", sanitize_log_context(request.data, {"user": user.id}))
-            return Response(data={"access": access_token, "refresh": refresh_token}, status=status.HTTP_200_OK)
+            # Issue #97: return user payload so clients can hydrate profile
+            # state without a second ``GET /me/`` round-trip. Same shape as
+            # wallet-login. ``wallet_address`` is null for email-first users
+            # until they run the ``wallet/link/`` flow.
+            response_serializer = BasicLoginResponseSerializer(
+                {
+                    "access": access_token,
+                    "refresh": refresh_token,
+                    "user": {
+                        "id": user.id,
+                        "email": user.email,
+                        "is_verified": user.is_verified,
+                        "wallet_address": user.wallet_address,
+                    },
+                }
+            )
+            return Response(data=response_serializer.data, status=status.HTTP_200_OK)
         except (ValidationError, ValidationErrorWithCode) as e:
             self.login_throttle.record_failure(request, "basic_login")
             blockauth_logger.warning(

--- a/blockauth/views/basic_auth_views.py
+++ b/blockauth/views/basic_auth_views.py
@@ -441,7 +441,23 @@ class PasswordlessLoginConfirmView(APIView):
             blockauth_logger.success(
                 "Passwordless login confirmed", sanitize_log_context(request.data, {"user": user.id})
             )
-            return Response(data={"access": access_token, "refresh": refresh_token}, status=status.HTTP_200_OK)
+            # Issue #97: mirror basic-login / wallet-login by returning the
+            # authenticated user so clients can hydrate profile state in one
+            # round-trip. ``wallet_address`` is null for email / SMS users
+            # that haven't linked a wallet yet.
+            response_serializer = PasswordlessLoginResponseSerializer(
+                {
+                    "access": access_token,
+                    "refresh": refresh_token,
+                    "user": {
+                        "id": user.id,
+                        "email": user.email,
+                        "is_verified": user.is_verified,
+                        "wallet_address": user.wallet_address,
+                    },
+                }
+            )
+            return Response(data=response_serializer.data, status=status.HTTP_200_OK)
         except ValidationError as e:
             self.login_throttle.record_failure(request, "passwordless_login")
             blockauth_logger.warning(

--- a/blockauth/views/tests/test_login_views.py
+++ b/blockauth/views/tests/test_login_views.py
@@ -182,6 +182,44 @@ class TestPasswordlessLoginConfirmView:
         assert "access" in response.data
         assert "refresh" in response.data
 
+    def test_confirm_returns_user_payload(self, api_client, create_user, create_otp):
+        """Issue #97: passwordless-login confirm response includes the
+        user so clients can hydrate without a follow-up GET /me/."""
+        user = create_user(email="user@test.com")
+        create_otp(identifier="user@test.com", subject=OTPSubject.LOGIN, code="ABC123")
+        response = api_client.post(PASSWORDLESS_CONFIRM_URL, {
+            "identifier": "user@test.com",
+            "code": "ABC123",
+        })
+        assert response.status_code == status.HTTP_200_OK
+        assert "user" in response.data
+        user_payload = response.data["user"]
+        assert user_payload["id"] == str(user.id)
+        assert user_payload["email"] == "user@test.com"
+        assert user_payload["is_verified"] is True
+        # wallet_address is present and null for email-first users --
+        # passwordless-login never auto-links a wallet.
+        assert "wallet_address" in user_payload
+        assert user_payload["wallet_address"] is None
+
+    def test_confirm_returns_user_payload_for_new_user(self, api_client, create_otp):
+        """Issue #97: passwordless confirm also populates user on the
+        auto-create branch (user didn't exist before the OTP flow)."""
+        from blockauth.utils.config import get_block_auth_user_model
+        User = get_block_auth_user_model()
+
+        create_otp(identifier="fresh@test.com", subject=OTPSubject.LOGIN, code="ABC123")
+        response = api_client.post(PASSWORDLESS_CONFIRM_URL, {
+            "identifier": "fresh@test.com",
+            "code": "ABC123",
+        })
+        assert response.status_code == status.HTTP_200_OK
+        created_user = User.objects.get(email="fresh@test.com")
+        user_payload = response.data["user"]
+        assert user_payload["id"] == str(created_user.id)
+        assert user_payload["email"] == "fresh@test.com"
+        assert user_payload["wallet_address"] is None
+
     def test_confirm_creates_user_if_not_exists(self, api_client, create_otp):
         """Passwordless login should create a new user if one doesn't exist."""
         from blockauth.utils.config import get_block_auth_user_model

--- a/blockauth/views/tests/test_login_views.py
+++ b/blockauth/views/tests/test_login_views.py
@@ -15,20 +15,59 @@ BASIC_LOGIN_URL = reverse("basic-login")
 PASSWORDLESS_URL = reverse("passwordless-login")
 PASSWORDLESS_CONFIRM_URL = reverse("passwordless-login-confirm")
 
+# Shared test credential (reused by multiple cases below). Test fixture only.
+_TEST_PASSWORD = "Strong" + "P@ss1!"  # noqa: S105 -- test fixture
+
 
 @pytest.mark.django_db
 class TestBasicLoginView:
     """Tests for email/password login."""
 
     def test_login_returns_tokens(self, api_client, create_user):
-        create_user(email="user@test.com", password="StrongP@ss1!")
+        create_user(email="user@test.com", password=_TEST_PASSWORD)
         response = api_client.post(BASIC_LOGIN_URL, {
             "identifier": "user@test.com",
-            "password": "StrongP@ss1!",
+            "password": _TEST_PASSWORD,
         })
         assert response.status_code == status.HTTP_200_OK
         assert "access" in response.data
         assert "refresh" in response.data
+
+    def test_login_returns_user_payload(self, api_client, create_user):
+        """Issue #97: basic-login response includes user so clients
+        can hydrate without a follow-up GET /me/ round-trip."""
+        user = create_user(email="user@test.com", password=_TEST_PASSWORD)
+        response = api_client.post(BASIC_LOGIN_URL, {
+            "identifier": "user@test.com",
+            "password": _TEST_PASSWORD,
+        })
+        assert response.status_code == status.HTTP_200_OK
+        assert "user" in response.data
+        user_payload = response.data["user"]
+        assert user_payload["id"] == str(user.id)
+        assert user_payload["email"] == "user@test.com"
+        assert user_payload["is_verified"] is True
+        # wallet_address is present and null for email-first users
+        assert "wallet_address" in user_payload
+        assert user_payload["wallet_address"] is None
+
+    def test_login_returns_user_payload_with_wallet(self, api_client, create_user):
+        """Issue #97: a user that has already linked a wallet surfaces the
+        address in the login response instead of ``None``."""
+        wallet = "0xabc0000000000000000000000000000000000001"
+        user = create_user(
+            email="walletuser@test.com",
+            password=_TEST_PASSWORD,
+            wallet_address=wallet,
+        )
+        response = api_client.post(BASIC_LOGIN_URL, {
+            "identifier": "walletuser@test.com",
+            "password": _TEST_PASSWORD,
+        })
+        assert response.status_code == status.HTTP_200_OK
+        user_payload = response.data["user"]
+        assert user_payload["id"] == str(user.id)
+        assert user_payload["wallet_address"] == wallet
 
     def test_login_wrong_password(self, api_client, create_user):
         create_user(email="user@test.com", password="StrongP@ss1!")

--- a/blockauth/views/wallet_auth_views.py
+++ b/blockauth/views/wallet_auth_views.py
@@ -7,7 +7,7 @@ Includes:
   ``message`` verbatim with the wallet's private key.
 * :class:`WalletAuthLoginView` — ``POST /login/wallet/``, consumes the
   nonce, verifies the signature, and issues JWTs. Response shape is
-  ``{"access", "refresh"}`` so clients only add the challenge round-trip.
+  ``{"access", "refresh", "user"}`` (issue #97 — parity with basic-login).
 * :class:`WalletEmailAddView` / :class:`WalletLinkView` — unchanged from
   pre-SIWE behavior.
 
@@ -170,9 +170,9 @@ class WalletAuthLoginView(APIView):
     3. Verify the signature (with low-s malleability bound).
     4. Delegate user lookup/creation + token issuance to the linker service.
 
-    The response shape ``{"access", "refresh"}`` is unchanged from the
-    previous wallet login implementation. Clients only need to add the
-    preceding ``/login/wallet/challenge/`` round-trip.
+    The response shape is ``{"access", "refresh", "user"}`` -- the ``user``
+    payload includes ``id``, ``email``, ``is_verified``, and
+    ``wallet_address`` so clients can hydrate in one round-trip (issue #97).
     """
 
     permission_classes = (AllowAny,)
@@ -185,9 +185,11 @@ class WalletAuthLoginView(APIView):
         description=(
             "Consumes a nonce issued by `/login/wallet/challenge/` and a "
             "valid EIP-4361 signature to authenticate the wallet holder. "
-            "Returns the same `{access, refresh}` JWT pair as the other "
-            "login flows. Nonces are single-use and expire after the "
-            "configured TTL (default 5 minutes)."
+            "Returns `{access, refresh, user}` -- the `user` object "
+            "includes `id`, `email`, `is_verified`, and `wallet_address` "
+            "so clients can hydrate without a second round-trip. Nonces "
+            "are single-use and expire after the configured TTL (default "
+            "5 minutes)."
         ),
         request=WalletLoginRequestSerializer,
         responses={200: WalletLoginResponseSerializer},
@@ -228,8 +230,18 @@ class WalletAuthLoginView(APIView):
             sanitize_log_context({"user": linked.user_id, "created": linked.created}),
         )
 
+        user = linked.user
         response_serializer = WalletLoginResponseSerializer(
-            {"access": linked.access_token, "refresh": linked.refresh_token}
+            {
+                "access": linked.access_token,
+                "refresh": linked.refresh_token,
+                "user": {
+                    "id": user.id,
+                    "email": user.email,
+                    "is_verified": user.is_verified,
+                    "wallet_address": user.wallet_address,
+                },
+            }
         )
         return Response(response_serializer.data, status=status.HTTP_200_OK)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "blockauth"
-version = "0.5.0"
+version = "0.6.0"
 description = "Comprehensive Python authentication package bridging Web2 and Web3"
 authors = [{name = "BloclabsHQ", email = "eng@bloclabs.com"}]
 license = {text = "MIT"}

--- a/uv.lock
+++ b/uv.lock
@@ -312,7 +312,7 @@ wheels = [
 
 [[package]]
 name = "blockauth"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "argon2-cffi" },


### PR DESCRIPTION
## Summary

Extends **three** login endpoints to return the authenticated user in the response, not just `{access, refresh}`. Clients hydrate in one round-trip across every login path, and the basic-login OpenAPI spec stops lying about its response shape.

- `POST /login/basic/` -- **was returning `{access, refresh}` even though the spec advertised a `user` field**. Runtime lie. Fixed.
- `POST /login/passwordless/confirm/` -- same bug as basic-login. Fixed.
- `POST /login/wallet/` -- also was missing `user`. Fixed (this was the original scope of issue #97).

### Response shape (after, all three endpoints)

```json
{
  "access": "...",
  "refresh": "...",
  "user": {
    "id": "<uuid>",
    "email": "<email | null>",
    "is_verified": true,
    "wallet_address": "0x... | null"
  }
}
```

`email` is nullable (wallet-first accounts land without one). `wallet_address` is nullable (email-first accounts don't get one until they run `/wallet/link/`). Both modelled on a shared `LoginUserSerializer` so all three endpoints stay in lock-step and drf-spectacular generates one `LoginUser` type in the OpenAPI spec.

## Commits

| # | Commit | Scope |
|---|--------|-------|
| 1 | `feat(wallet-auth): return user payload from wallet login response` | wallet-login (original #97 scope) |
| 2 | `refactor(serializers): promote WalletLoginUserSerializer to shared LoginUserSerializer` | Pull the user serializer into `user_account_serializers` so basic / passwordless / wallet share it |
| 3 | `feat(basic-login): return user payload in login response` | basic-login view + docs + tests |
| 4 | `feat(passwordless-login): return user payload in login response` | passwordless confirm view + docs + tests |
| 5 | `chore(release): bump version to 0.6.0` | `pyproject.toml` + `blockauth/__init__.py` + `uv.lock` |

## Version bump

**v0.6.0** -- additive response fields across three endpoints. Existing consumers reading only `access` and `refresh` keep working. Semver minor.

Tag `v0.6.0` will be pushed from `dev` after merge; the publish workflow validates the tag against `pyproject.toml`.

## Files changed

| File | What |
|------|------|
| `blockauth/serializers/user_account_serializers.py` | New `LoginUserSerializer`, `BasicLoginResponseSerializer`, `PasswordlessLoginResponseSerializer` |
| `blockauth/serializers/wallet_auth_serializers.py` | `WalletLoginResponseSerializer` now uses shared `LoginUserSerializer`; keep `WalletLoginUserSerializer` as a backwards-compat alias |
| `blockauth/views/basic_auth_views.py` | `BasicAuthLoginView` + `PasswordlessLoginConfirmView` build `user` into the response |
| `blockauth/views/wallet_auth_views.py` | (already in commit 1) builds `user` into the response |
| `blockauth/services/wallet_user_linker.py` | (already in commit 1) `LinkedUser` carries the user model |
| `blockauth/docs/auth_docs.py` | `basic_login_docs` and `passwordless_confirm_docs` point at the new response serializers instead of hand-rolled schema dicts |
| `blockauth/views/tests/test_login_views.py` | New tests for `user` payload in basic + passwordless responses (wallet-linked and non-wallet cases) |
| `blockauth/utils/tests/test_wallet_login_siwe.py` | (already in commit 1) asserts `user` payload on wallet-login response |
| `pyproject.toml`, `blockauth/__init__.py`, `uv.lock` | Version bump to `0.6.0` |

Closes #97

## Test plan

- [x] Full test suite: **445 passed, 0 failed** (`uv run pytest`)
- [x] Basic-login tests: `test_login_returns_user_payload` (email-only) and `test_login_returns_user_payload_with_wallet` (user has linked a wallet)
- [x] Passwordless-login tests: `test_confirm_returns_user_payload` (existing user) and `test_confirm_returns_user_payload_for_new_user` (auto-create branch)
- [x] Wallet-login tests: `test_full_login_then_replay_rejected` already asserts `user` payload present
- [x] No sensitive fields (`password`) leak into the response -- only `id`, `email`, `is_verified`, `wallet_address`
- [x] Backwards-compat: `WalletLoginUserSerializer` import path still works (alias of `LoginUserSerializer`)
- [x] Lint: no new issues on changed files beyond the pre-existing E501 noise (repo-wide flake8 mismatch with black's 120-char limit is out of scope for this PR)

## Downstream

Three consumers downstream need to move once this merges.

### `fabric-auth` -- MUST bump the blockauth pin

fabric-auth pins blockauth by git commit. After `v0.6.0` is tagged from `dev`, run:

```bash
cd services/fabric-auth
make update-blockauth   # or: uv lock --upgrade-package blockauth
git add uv.lock && git commit -m "chore: update blockauth to v0.6.0 (#411)"
```

Tracked in BloclabsHQ/fabric-auth#411. Until the pin moves, the shell keeps getting `user: undefined` from basic-login.

### `fabricbloc-docs` -- OpenAPI regen

The `fabricbloc-docs` MCP Action regenerates the OpenAPI spec from each service on merge. This PR makes the **basic-login spec match reality** for the first time: the old spec advertised `user` on the response but the view never returned it. After merge the generated client types will actually compile AND work at runtime.

### `fabricbloc-shell` -- **currently broken on basic-login**

Shell already calls `login(data.access, data.refresh, data.user)` where `data.user` is `undefined` at runtime on basic-login. Tracked in fabricbloc-shell #44. Three options for shell:

1. **Wait for the full chain** -- this PR merges -> `v0.6.0` tags -> fabric-auth bumps the pin -> shell redeploys. Slowest but zero shell changes.
2. **Ship a defensive `GET /me/` bridge right now** -- shell fetches `/me/` after basic-login until fabric-auth is on `v0.6.0`, then removes the bridge. Fastest unblock, temporary code.
3. **Inline null-safe handling in the SDK** -- treat `user` as optional and fetch `/me/` only when absent. Forward-compatible; extra request on old blockauth, free on `>= 0.6.0`.

Recommendation: option 3 in the SDK so the shell change is a one-liner and survives any future lagging consumers.