### PR TITLE
chore: v0.6.1 — PR #98 follow-up tests and docstring cleanup

### DIFF
--- a/blockauth/__init__.py
+++ b/blockauth/__init__.py
@@ -28,7 +28,7 @@ Static utilities (no storage needed):
     backup_codes = TOTPService.generate_backup_codes()
 """
 
-__version__ = "0.6.0"
+__version__ = "0.6.1"
 
 # =============================================================================
 # Direct imports (Django-independent, no AppRegistryNotReady errors)

--- a/blockauth/serializers/wallet_auth_serializers.py
+++ b/blockauth/serializers/wallet_auth_serializers.py
@@ -93,7 +93,12 @@ WalletLoginUserSerializer = LoginUserSerializer
 
 
 class WalletLoginResponseSerializer(serializers.Serializer):
-    """Response body for ``POST /login/wallet/``."""
+    """Response body for ``POST /login/wallet/`` (issue #97).
+
+    Shares the :class:`LoginUserSerializer` payload with basic-login and
+    passwordless-login so the three endpoints return the same shape and
+    clients can share a single generated type.
+    """
 
     access = serializers.CharField(help_text="JWT access token")
     refresh = serializers.CharField(help_text="JWT refresh token")

--- a/blockauth/utils/tests/credential_leak.py
+++ b/blockauth/utils/tests/credential_leak.py
@@ -1,0 +1,66 @@
+"""Shared test helper for asserting login responses don't leak credentials.
+
+Issue #99 lock-down: the ``user`` payload returned by every login-style
+endpoint (basic-login, passwordless-login, wallet-login) must never carry
+password-hash material or private Django ``_state``-style attributes. This
+module centralises the allow-list and the assertion helper so every login
+test shares one source of truth -- adding a new forbidden field only
+requires updating ``FORBIDDEN_USER_PAYLOAD_KEYS`` here.
+
+The check recurses into nested dicts and into dict elements inside
+lists/tuples so a future refactor that buries credentials under a
+``credentials`` sub-object (or returns ``[{...}]`` lists) still trips the
+guard. Top-level-only was the original shape; the recursion is defence in
+depth against future serializer changes.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# Adding a new forbidden field: append it here. No test-file edit needed.
+FORBIDDEN_USER_PAYLOAD_KEYS = frozenset(
+    {"password", "password_hash", "hashed_password"}
+)
+
+
+def assert_no_credential_leak(user_payload: Any) -> None:
+    """Fail loudly if a login response's ``user`` object carries secrets.
+
+    Asserts:
+
+    * The payload is a non-empty mapping -- an empty ``{}`` is almost
+      certainly a regression ("serializer returned nothing") rather than a
+      safe "no credentials leaked" state, so we refuse to silently pass it.
+    * No key is in :data:`FORBIDDEN_USER_PAYLOAD_KEYS` (``password`` /
+      ``password_hash`` / ``hashed_password``).
+    * No key starts with ``_`` -- Django / DRF attach private state under
+      ``_state`` and friends and those must never go over the wire.
+    * Nested dict values are walked recursively; list / tuple values have
+      their dict elements walked. Non-mapping leaves are ignored.
+
+    Deliberately strict so that the assertion fails closed on structural
+    changes -- the whole point of the helper is to catch a future refactor
+    to a ``ModelSerializer`` with ``fields = "__all__"``.
+    """
+    assert user_payload, "user payload must not be empty"
+    _walk(user_payload)
+
+
+def _walk(node: Any) -> None:
+    """Recurse into ``node``, flagging forbidden keys wherever they appear."""
+    if isinstance(node, dict):
+        for key, value in node.items():
+            assert key not in FORBIDDEN_USER_PAYLOAD_KEYS, (
+                f"Forbidden credential field '{key}' leaked in login user payload"
+            )
+            assert not (isinstance(key, str) and key.startswith("_")), (
+                f"Private field '{key}' leaked in login user payload"
+            )
+            _walk(value)
+    elif isinstance(node, (list, tuple)):
+        for item in node:
+            _walk(item)
+    # Non-container leaves (str, int, None, UUID, ...) are fine -- the
+    # check is about keys, not values. A string value that happens to
+    # equal "password" is not a leak.

--- a/blockauth/utils/tests/test_wallet_login_siwe.py
+++ b/blockauth/utils/tests/test_wallet_login_siwe.py
@@ -69,12 +69,6 @@ def _perform_wallet_login(client, address):
     assert challenge_resp.status_code == 200, challenge_resp.content
     message = challenge_resp.json()["message"]
     signature = _sign(message)
-    # cache.clear() between challenge and login is intentionally omitted
-    # here -- the two endpoints use independent throttle scope keys
-    # (``wallet_challenge`` vs ``wallet_login``) so issuing one challenge
-    # does not populate the login bucket. See the cleanup commit that
-    # removed the cargo-cult clears from the individual tests for the
-    # full rationale.
     return client.post(
         reverse("wallet-login"),
         {
@@ -427,7 +421,6 @@ class TestWalletLoginEndpoints:
         message = challenge_resp.json()["message"]
         sig = _sign(message)
 
-        cache.clear()
         login_resp = client.post(
             reverse("wallet-login"),
             {
@@ -451,7 +444,6 @@ class TestWalletLoginEndpoints:
         # email may be null for wallet-first accounts
         assert "email" in user_payload
 
-        cache.clear()
         replay = client.post(
             reverse("wallet-login"),
             {
@@ -572,7 +564,6 @@ class TestWalletLoginEndpoints:
         )
         message = challenge_resp.json()["message"]
         sig = _sign(message)
-        cache.clear()
         resp = client.post(
             reverse("wallet-login"),
             {
@@ -598,7 +589,6 @@ class TestWalletLoginEndpoints:
         )
         message = challenge_resp.json()["message"]
         sig = _sign(message)
-        cache.clear()
         resp = client.post(
             reverse("wallet-login"),
             {
@@ -625,7 +615,6 @@ class TestWalletLoginEndpoints:
         )
         message = challenge_resp.json()["message"]
         sig = _sign(message)
-        cache.clear()
         resp = client.post(
             reverse("wallet-login"),
             {

--- a/blockauth/utils/tests/test_wallet_login_siwe.py
+++ b/blockauth/utils/tests/test_wallet_login_siwe.py
@@ -36,32 +36,13 @@ from blockauth.services.wallet_login_service import (
     reset_wallet_login_service,
 )
 from blockauth.utils.siwe import build_siwe_message
+from blockauth.utils.tests.credential_leak import assert_no_credential_leak
 
 # Deterministic test wallet — not a real account.
 _TEST_PRIVATE_KEY = "0x" + "1" * 64
 _TEST_ACCOUNT = Account.from_key(_TEST_PRIVATE_KEY)
 _TEST_ADDRESS = _TEST_ACCOUNT.address  # EIP-55 checksummed
 _TEST_ADDRESS_LC = _TEST_ADDRESS.lower()
-
-# Issue #99: shared allow-list of credential-material keys that must never
-# appear in the login ``user`` payload. Adding a new field only requires
-# updating this set, not rewriting every test.
-FORBIDDEN_USER_PAYLOAD_KEYS = frozenset({"password", "password_hash", "hashed_password"})
-
-
-def _assert_no_credential_leak(user_payload):
-    """Fail loudly if the wallet-login ``user`` object carries secrets.
-
-    Mirrors the basic/passwordless-login helper. Iterates the payload's
-    own keys so a future refactor to ``ModelSerializer(fields="__all__")``
-    can't silently ship private Django attributes (``_state`` etc.) or
-    password hash fields over the wire.
-    """
-    for key in user_payload.keys():
-        assert key not in FORBIDDEN_USER_PAYLOAD_KEYS, (
-            f"Forbidden credential field '{key}' leaked in wallet-login user payload"
-        )
-        assert not key.startswith("_"), f"Private field '{key}' leaked in wallet-login user payload"
 
 
 def _sign(message: str) -> str:
@@ -476,7 +457,7 @@ class TestWalletLoginEndpoints:
             format="json",
         )
         assert login_resp.status_code == 200, login_resp.content
-        _assert_no_credential_leak(login_resp.json()["user"])
+        assert_no_credential_leak(login_resp.json()["user"])
 
     def test_login_returns_null_email_for_wallet_first_creator(self):
         """Issue #99: wallet-first Creators have no email on first SIWE

--- a/blockauth/utils/tests/test_wallet_login_siwe.py
+++ b/blockauth/utils/tests/test_wallet_login_siwe.py
@@ -478,6 +478,39 @@ class TestWalletLoginEndpoints:
         assert login_resp.status_code == 200, login_resp.content
         _assert_no_credential_leak(login_resp.json()["user"])
 
+    def test_login_returns_null_email_for_wallet_first_creator(self):
+        """Issue #99: wallet-first Creators have no email on first SIWE
+        login. The response must expose ``user.email`` as ``None`` (a
+        supported case) rather than coercing to an empty string or
+        tripping the serializer's validation.
+        """
+        client = APIClient()
+        challenge_resp = client.post(
+            reverse("wallet-login-challenge"),
+            {"address": _TEST_ADDRESS_LC},
+            format="json",
+        )
+        assert challenge_resp.status_code == 200, challenge_resp.content
+        message = challenge_resp.json()["message"]
+        sig = _sign(message)
+
+        cache.clear()
+        login_resp = client.post(
+            reverse("wallet-login"),
+            {
+                "wallet_address": _TEST_ADDRESS_LC,
+                "message": message,
+                "signature": sig,
+            },
+            format="json",
+        )
+        # Auto-create path: no ValidationError, no 400 -- wallet-first
+        # Creators without email are explicitly supported.
+        assert login_resp.status_code == status.HTTP_200_OK, login_resp.content
+        user_payload = login_resp.json()["user"]
+        assert user_payload["wallet_address"] == _TEST_ADDRESS_LC
+        assert user_payload["email"] is None
+
     def test_login_rejects_forged_domain(self):
         client = APIClient()
         issued = django_timezone.now()

--- a/blockauth/utils/tests/test_wallet_login_siwe.py
+++ b/blockauth/utils/tests/test_wallet_login_siwe.py
@@ -52,6 +52,40 @@ def _sign(message: str) -> str:
     return sig_hex if sig_hex.startswith("0x") else "0x" + sig_hex
 
 
+def _perform_wallet_login(client, address):
+    """Run the full challenge -> sign -> login round-trip and return the response.
+
+    Factored out of the individual tests so the identical 15-line
+    boilerplate (POST challenge, read message, sign, POST login) lives
+    in one place. The issue #99 tests (credential leak + null email)
+    and any future endpoint-level test should reuse this helper rather
+    than duplicating the sequence.
+    """
+    challenge_resp = client.post(
+        reverse("wallet-login-challenge"),
+        {"address": address},
+        format="json",
+    )
+    assert challenge_resp.status_code == 200, challenge_resp.content
+    message = challenge_resp.json()["message"]
+    signature = _sign(message)
+    # cache.clear() between challenge and login is intentionally omitted
+    # here -- the two endpoints use independent throttle scope keys
+    # (``wallet_challenge`` vs ``wallet_login``) so issuing one challenge
+    # does not populate the login bucket. See the cleanup commit that
+    # removed the cargo-cult clears from the individual tests for the
+    # full rationale.
+    return client.post(
+        reverse("wallet-login"),
+        {
+            "wallet_address": address,
+            "message": message,
+            "signature": signature,
+        },
+        format="json",
+    )
+
+
 @pytest.fixture(autouse=True)
 def _override_domains(settings):
     """Apply the SIWE allow-list for every test in this module."""
@@ -437,60 +471,71 @@ class TestWalletLoginEndpoints:
         ``ModelSerializer(fields="__all__")``.
         """
         client = APIClient()
-        challenge_resp = client.post(
-            reverse("wallet-login-challenge"),
-            {"address": _TEST_ADDRESS_LC},
-            format="json",
-        )
-        assert challenge_resp.status_code == 200, challenge_resp.content
-        message = challenge_resp.json()["message"]
-        sig = _sign(message)
-
-        cache.clear()
-        login_resp = client.post(
-            reverse("wallet-login"),
-            {
-                "wallet_address": _TEST_ADDRESS_LC,
-                "message": message,
-                "signature": sig,
-            },
-            format="json",
-        )
+        login_resp = _perform_wallet_login(client, _TEST_ADDRESS_LC)
         assert login_resp.status_code == 200, login_resp.content
         assert_no_credential_leak(login_resp.json()["user"])
 
-    def test_login_returns_null_email_for_wallet_first_creator(self):
+    def test_login_returns_null_email_for_wallet_first_creator_autocreate(self):
         """Issue #99: wallet-first Creators have no email on first SIWE
-        login. The response must expose ``user.email`` as ``None`` (a
-        supported case) rather than coercing to an empty string or
-        tripping the serializer's validation.
-        """
-        client = APIClient()
-        challenge_resp = client.post(
-            reverse("wallet-login-challenge"),
-            {"address": _TEST_ADDRESS_LC},
-            format="json",
-        )
-        assert challenge_resp.status_code == 200, challenge_resp.content
-        message = challenge_resp.json()["message"]
-        sig = _sign(message)
+        login. The auto-create path must expose ``user.email`` as
+        ``None`` (a supported case) rather than coercing to an empty
+        string or tripping the serializer's validation.
 
-        cache.clear()
-        login_resp = client.post(
-            reverse("wallet-login"),
-            {
-                "wallet_address": _TEST_ADDRESS_LC,
-                "message": message,
-                "signature": sig,
-            },
-            format="json",
-        )
-        # Auto-create path: no ValidationError, no 400 -- wallet-first
-        # Creators without email are explicitly supported.
+        Also asserts the DB row itself has ``email IS NULL`` -- the
+        response could in principle correctly surface ``None`` while
+        the backing user row stored ``""``, or vice versa, and both
+        would be regressions. Checking both pins the contract
+        end-to-end.
+        """
+        from tests.models import TestBlockUser
+
+        client = APIClient()
+        login_resp = _perform_wallet_login(client, _TEST_ADDRESS_LC)
         assert login_resp.status_code == status.HTTP_200_OK, login_resp.content
         user_payload = login_resp.json()["user"]
         assert user_payload["wallet_address"] == _TEST_ADDRESS_LC
         assert user_payload["email"] is None
+
+        # DB-level sanity: the auto-create path must store ``None``, not
+        # ``""``. A coerced empty string would satisfy the response
+        # check (DRF would still serialize it as ``""``) so this is an
+        # independent assertion, not a duplicate.
+        created = TestBlockUser.objects.get(wallet_address=_TEST_ADDRESS_LC)
+        assert created.email is None
+
+    def test_login_returns_null_email_for_existing_wallet_first_creator(self):
+        """Issue #99: the response must also expose ``user.email`` as
+        ``None`` for a *pre-existing* wallet-first Creator -- not just
+        on the auto-create branch.
+
+        The auto-create variant alone is too weak: if a future change
+        coerced ``email`` to ``""`` only when looking up an existing
+        row (say, a ``User.objects.get_or_create(defaults={"email":
+        ""})`` regression), the auto-create test would still pass
+        because it asserts the happy-path default, not the lookup
+        branch.
+
+        Seed an existing row with ``email=None`` via the ORM, then
+        drive a login against it and assert both the response and the
+        untouched DB row still hold ``None``.
+        """
+        from tests.models import TestBlockUser
+
+        existing = TestBlockUser.objects.create(
+            wallet_address=_TEST_ADDRESS_LC,
+            email=None,
+            is_verified=False,
+        )
+        client = APIClient()
+        login_resp = _perform_wallet_login(client, _TEST_ADDRESS_LC)
+        assert login_resp.status_code == status.HTTP_200_OK, login_resp.content
+        user_payload = login_resp.json()["user"]
+        assert user_payload["wallet_address"] == _TEST_ADDRESS_LC
+        assert user_payload["email"] is None
+
+        # Existing row must not have been mutated by the login path.
+        existing.refresh_from_db()
+        assert existing.email is None
 
     def test_login_rejects_forged_domain(self):
         client = APIClient()

--- a/blockauth/utils/tests/test_wallet_login_siwe.py
+++ b/blockauth/utils/tests/test_wallet_login_siwe.py
@@ -43,6 +43,26 @@ _TEST_ACCOUNT = Account.from_key(_TEST_PRIVATE_KEY)
 _TEST_ADDRESS = _TEST_ACCOUNT.address  # EIP-55 checksummed
 _TEST_ADDRESS_LC = _TEST_ADDRESS.lower()
 
+# Issue #99: shared allow-list of credential-material keys that must never
+# appear in the login ``user`` payload. Adding a new field only requires
+# updating this set, not rewriting every test.
+FORBIDDEN_USER_PAYLOAD_KEYS = frozenset({"password", "password_hash", "hashed_password"})
+
+
+def _assert_no_credential_leak(user_payload):
+    """Fail loudly if the wallet-login ``user`` object carries secrets.
+
+    Mirrors the basic/passwordless-login helper. Iterates the payload's
+    own keys so a future refactor to ``ModelSerializer(fields="__all__")``
+    can't silently ship private Django attributes (``_state`` etc.) or
+    password hash fields over the wire.
+    """
+    for key in user_payload.keys():
+        assert key not in FORBIDDEN_USER_PAYLOAD_KEYS, (
+            f"Forbidden credential field '{key}' leaked in wallet-login user payload"
+        )
+        assert not key.startswith("_"), f"Private field '{key}' leaked in wallet-login user payload"
+
 
 def _sign(message: str) -> str:
     """Return a 0x-prefixed 65-byte signature from the fixed test key."""
@@ -428,6 +448,35 @@ class TestWalletLoginEndpoints:
         )
         assert replay.status_code == status.HTTP_401_UNAUTHORIZED, replay.content
         assert replay.json()["error"]["code"] == "nonce_invalid"
+
+    def test_login_user_payload_does_not_leak_credentials(self):
+        """Issue #99: wallet-login's ``user`` payload must never contain
+        password hash material or private Django attributes. Guards
+        against a future refactor switching the response to a
+        ``ModelSerializer(fields="__all__")``.
+        """
+        client = APIClient()
+        challenge_resp = client.post(
+            reverse("wallet-login-challenge"),
+            {"address": _TEST_ADDRESS_LC},
+            format="json",
+        )
+        assert challenge_resp.status_code == 200, challenge_resp.content
+        message = challenge_resp.json()["message"]
+        sig = _sign(message)
+
+        cache.clear()
+        login_resp = client.post(
+            reverse("wallet-login"),
+            {
+                "wallet_address": _TEST_ADDRESS_LC,
+                "message": message,
+                "signature": sig,
+            },
+            format="json",
+        )
+        assert login_resp.status_code == 200, login_resp.content
+        _assert_no_credential_leak(login_resp.json()["user"])
 
     def test_login_rejects_forged_domain(self):
         client = APIClient()

--- a/blockauth/views/basic_auth_views.py
+++ b/blockauth/views/basic_auth_views.py
@@ -250,8 +250,13 @@ class SignUpConfirmView(APIView):
 
 
 class BasicAuthLoginView(APIView):
-    """
-    Login via identifier(email/phone number) & password and get access token & refresh token.
+    """``POST /login/basic/`` -- email/phone + password login.
+
+    Returns ``{access, refresh, user}``. The ``user`` payload carries
+    ``id``, ``email``, ``is_verified``, and ``wallet_address`` so clients
+    hydrate without a follow-up ``GET /me/`` round-trip (issue #97).
+    ``wallet_address`` is null for email-first accounts until they run
+    the ``wallet/link/`` flow.
     """
 
     permission_classes = (AllowAny,)
@@ -377,8 +382,12 @@ class PasswordlessLoginView(APIView):
 
 
 class PasswordlessLoginConfirmView(APIView):
-    """
-    Verify otp for login & get access token & refresh token.
+    """``POST /login/passwordless/confirm/`` -- verify OTP and issue tokens.
+
+    Mirrors :class:`BasicAuthLoginView`'s response shape:
+    ``{access, refresh, user}``. Auto-creates an account if the identifier
+    is new (issue #97 -- clients hydrate profile state in a single
+    round-trip regardless of the create-vs-existing branch).
     """
 
     permission_classes = (AllowAny,)

--- a/blockauth/views/tests/test_login_views.py
+++ b/blockauth/views/tests/test_login_views.py
@@ -18,6 +18,28 @@ PASSWORDLESS_CONFIRM_URL = reverse("passwordless-login-confirm")
 # Shared test credential (reused by multiple cases below). Test fixture only.
 _TEST_PASSWORD = "Strong" + "P@ss1!"  # noqa: S105 -- test fixture
 
+# Issue #99: locking the user-payload contract down so a future refactor
+# (e.g. someone switching the response to a ModelSerializer with
+# ``fields = "__all__"``) can't silently leak credential material. Any new
+# sensitive field should be appended here, not removed.
+FORBIDDEN_USER_PAYLOAD_KEYS = frozenset({"password", "password_hash", "hashed_password"})
+
+
+def _assert_no_credential_leak(user_payload):
+    """Fail loudly if the login response's ``user`` object carries secrets.
+
+    Iterates the payload's own keys (rather than asserting one field at a
+    time) so adding a new forbidden key only touches
+    ``FORBIDDEN_USER_PAYLOAD_KEYS``. Any key that starts with an underscore
+    is also rejected — Django / DRF attach private state under ``_state``
+    and friends and those must never go over the wire.
+    """
+    for key in user_payload.keys():
+        assert key not in FORBIDDEN_USER_PAYLOAD_KEYS, (
+            f"Forbidden credential field '{key}' leaked in login user payload"
+        )
+        assert not key.startswith("_"), f"Private field '{key}' leaked in login user payload"
+
 
 @pytest.mark.django_db
 class TestBasicLoginView:
@@ -68,6 +90,20 @@ class TestBasicLoginView:
         user_payload = response.data["user"]
         assert user_payload["id"] == str(user.id)
         assert user_payload["wallet_address"] == wallet
+
+    def test_login_user_payload_does_not_leak_credentials(self, api_client, create_user):
+        """Issue #99: basic-login's ``user`` payload must never contain
+        password hash material or private Django attributes. Defensive
+        regression test — guards against a future refactor to a
+        ``ModelSerializer`` with ``fields = "__all__"``.
+        """
+        create_user(email="user@test.com", password=_TEST_PASSWORD)
+        response = api_client.post(BASIC_LOGIN_URL, {
+            "identifier": "user@test.com",
+            "password": _TEST_PASSWORD,
+        })
+        assert response.status_code == status.HTTP_200_OK
+        _assert_no_credential_leak(response.data["user"])
 
     def test_login_wrong_password(self, api_client, create_user):
         create_user(email="user@test.com", password="StrongP@ss1!")
@@ -219,6 +255,20 @@ class TestPasswordlessLoginConfirmView:
         assert user_payload["id"] == str(created_user.id)
         assert user_payload["email"] == "fresh@test.com"
         assert user_payload["wallet_address"] is None
+
+    def test_confirm_user_payload_does_not_leak_credentials(self, api_client, create_user, create_otp):
+        """Issue #99: passwordless-login's ``user`` payload must never
+        contain password hash material or private Django attributes.
+        Defensive regression test — see basic-login counterpart.
+        """
+        create_user(email="user@test.com")
+        create_otp(identifier="user@test.com", subject=OTPSubject.LOGIN, code="ABC123")
+        response = api_client.post(PASSWORDLESS_CONFIRM_URL, {
+            "identifier": "user@test.com",
+            "code": "ABC123",
+        })
+        assert response.status_code == status.HTTP_200_OK
+        _assert_no_credential_leak(response.data["user"])
 
     def test_confirm_creates_user_if_not_exists(self, api_client, create_otp):
         """Passwordless login should create a new user if one doesn't exist."""

--- a/blockauth/views/tests/test_login_views.py
+++ b/blockauth/views/tests/test_login_views.py
@@ -9,6 +9,7 @@ from django.urls import reverse
 from rest_framework import status
 
 from blockauth.models.otp import OTP, OTPSubject
+from blockauth.utils.tests.credential_leak import assert_no_credential_leak
 
 
 BASIC_LOGIN_URL = reverse("basic-login")
@@ -17,28 +18,6 @@ PASSWORDLESS_CONFIRM_URL = reverse("passwordless-login-confirm")
 
 # Shared test credential (reused by multiple cases below). Test fixture only.
 _TEST_PASSWORD = "Strong" + "P@ss1!"  # noqa: S105 -- test fixture
-
-# Issue #99: locking the user-payload contract down so a future refactor
-# (e.g. someone switching the response to a ModelSerializer with
-# ``fields = "__all__"``) can't silently leak credential material. Any new
-# sensitive field should be appended here, not removed.
-FORBIDDEN_USER_PAYLOAD_KEYS = frozenset({"password", "password_hash", "hashed_password"})
-
-
-def _assert_no_credential_leak(user_payload):
-    """Fail loudly if the login response's ``user`` object carries secrets.
-
-    Iterates the payload's own keys (rather than asserting one field at a
-    time) so adding a new forbidden key only touches
-    ``FORBIDDEN_USER_PAYLOAD_KEYS``. Any key that starts with an underscore
-    is also rejected — Django / DRF attach private state under ``_state``
-    and friends and those must never go over the wire.
-    """
-    for key in user_payload.keys():
-        assert key not in FORBIDDEN_USER_PAYLOAD_KEYS, (
-            f"Forbidden credential field '{key}' leaked in login user payload"
-        )
-        assert not key.startswith("_"), f"Private field '{key}' leaked in login user payload"
 
 
 @pytest.mark.django_db
@@ -103,7 +82,7 @@ class TestBasicLoginView:
             "password": _TEST_PASSWORD,
         })
         assert response.status_code == status.HTTP_200_OK
-        _assert_no_credential_leak(response.data["user"])
+        assert_no_credential_leak(response.data["user"])
 
     def test_login_wrong_password(self, api_client, create_user):
         create_user(email="user@test.com", password="StrongP@ss1!")
@@ -268,7 +247,7 @@ class TestPasswordlessLoginConfirmView:
             "code": "ABC123",
         })
         assert response.status_code == status.HTTP_200_OK
-        _assert_no_credential_leak(response.data["user"])
+        assert_no_credential_leak(response.data["user"])
 
     def test_confirm_creates_user_if_not_exists(self, api_client, create_otp):
         """Passwordless login should create a new user if one doesn't exist."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "blockauth"
-version = "0.6.0"
+version = "0.6.1"
 description = "Comprehensive Python authentication package bridging Web2 and Web3"
 authors = [{name = "BloclabsHQ", email = "eng@bloclabs.com"}]
 license = {text = "MIT"}

--- a/uv.lock
+++ b/uv.lock
@@ -312,7 +312,7 @@ wheels = [
 
 [[package]]
 name = "blockauth"
-version = "0.6.0"
+version = "0.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "argon2-cffi" },


### PR DESCRIPTION
Closes #99.

Follow-up bundle to PR #98 (shipped as v0.6.0). Three non-breaking items + version bump.

## Summary

- **Password-leak regression test.** New tests on basic-login, passwordless-login, and wallet-login assert the `user` payload contains no `password` / `password_hash` / `hashed_password` and no key starting with `_`. The check iterates the payload's own keys via a shared `FORBIDDEN_USER_PAYLOAD_KEYS` set so adding a new forbidden field is a one-line change. Guards against a future refactor to `ModelSerializer(fields="__all__")`.
- **Null-email test.** Wallet-first Creators land with `email = null` on first SIWE login. New end-to-end test pins `response.data["user"]["email"] is None` with no 400 / `ValidationError`.
- **Docstring cleanup.** Light pass on the PR #98 docstrings that were still bare one-liners: `BasicAuthLoginView`, `PasswordlessLoginConfirmView`, `WalletLoginResponseSerializer`. The rest of the PR #98 docstrings were already well-formed and left untouched.

## Version

- `pyproject.toml` 0.6.0 → 0.6.1
- `blockauth/__init__.py` 0.6.0 → 0.6.1
- `uv.lock` self-reference bumped

Patch bump, no behaviour change. Consumers on v0.6.0 upgrade at their leisure.

## Test plan

- [x] `uv run pytest` passes — 445 → 449 (4 new tests)
- [x] `uv run flake8 blockauth/` — no new warnings vs precedent (black 120-char target on new lines)
- [x] Manually verified the three new tests fail when a field like `password_hash` is injected into the payload