### PR TITLE
release: v0.6.1 (v0.6.0 + v0.6.1 to main)

### DIFF
--- a/blockauth/__init__.py
+++ b/blockauth/__init__.py
@@ -28,7 +28,7 @@ Static utilities (no storage needed):
     backup_codes = TOTPService.generate_backup_codes()
 """
 
-__version__ = "0.5.0"
+__version__ = "0.6.0"
 
 # =============================================================================
 # Direct imports (Django-independent, no AppRegistryNotReady errors)

--- a/blockauth/__init__.py
+++ b/blockauth/__init__.py
@@ -28,7 +28,7 @@ Static utilities (no storage needed):
     backup_codes = TOTPService.generate_backup_codes()
 """
 
-__version__ = "0.6.0"
+__version__ = "0.6.1"
 
 # =============================================================================
 # Direct imports (Django-independent, no AppRegistryNotReady errors)

--- a/blockauth/docs/auth_docs.py
+++ b/blockauth/docs/auth_docs.py
@@ -8,11 +8,13 @@ Separated from business logic for better maintainability and organization.
 from drf_spectacular.utils import OpenApiExample, OpenApiResponse
 
 from blockauth.serializers.user_account_serializers import (
+    BasicLoginResponseSerializer,
     BasicLoginSerializer,
     EmailChangeConfirmationSerializer,
     EmailChangeRequestSerializer,
     PasswordChangeSerializer,
     PasswordlessLoginConfirmationSerializer,
+    PasswordlessLoginResponseSerializer,
     PasswordlessLoginSerializer,
     PasswordResetConfirmationEmailSerializer,
     PasswordResetRequestSerializer,
@@ -430,41 +432,26 @@ basic_login_docs = {
         ),
     ],
     "responses": {
+        # Issue #97: response serializer is the source of truth -- the hand-
+        # rolled schema that lived here previously described a ``user`` field
+        # that the code didn't actually return, so generated clients were
+        # broken. Point drf-spectacular at the real serializer to keep the
+        # spec honest.
         200: OpenApiResponse(
             description="Login successful",
-            response={
-                "type": "object",
-                "properties": {
-                    "access": {
-                        "type": "string",
-                        "description": "JWT access token for API authentication",
-                        "format": "jwt",
-                    },
-                    "refresh": {
-                        "type": "string",
-                        "description": "JWT refresh token for token renewal",
-                        "format": "jwt",
-                    },
-                    "user": {
-                        "type": "object",
-                        "properties": {
-                            "id": {"type": "integer", "description": "User ID"},
-                            "email": {"type": "string", "format": "email", "description": "User email address"},
-                            "phone_number": {"type": "string", "description": "User phone number"},
-                            "is_verified": {"type": "boolean", "description": "Email verification status"},
-                        },
-                        "required": ["id", "is_verified"],
-                    },
-                },
-                "required": ["access", "refresh"],
-            },
+            response=BasicLoginResponseSerializer,
             examples=[
                 OpenApiExample(
                     "Success",
                     value={
                         "access": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
                         "refresh": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
-                        "user": {"id": 123, "email": "user@example.com", "is_verified": True},
+                        "user": {
+                            "id": "8f3e8f4c-1c2d-4a3b-bd8b-4a0f8f5b1a21",
+                            "email": "user@example.com",
+                            "is_verified": True,
+                            "wallet_address": None,
+                        },
                     },
                     status_codes=[200],
                 )

--- a/blockauth/docs/auth_docs.py
+++ b/blockauth/docs/auth_docs.py
@@ -640,41 +640,23 @@ passwordless_confirm_docs = {
         ),
     ],
     "responses": {
+        # Issue #97: point at the real response serializer so the OpenAPI
+        # spec stops drifting from the runtime shape.
         200: OpenApiResponse(
             description="Login successful",
-            response={
-                "type": "object",
-                "properties": {
-                    "access": {
-                        "type": "string",
-                        "description": "JWT access token for API authentication",
-                        "format": "jwt",
-                    },
-                    "refresh": {
-                        "type": "string",
-                        "description": "JWT refresh token for token renewal",
-                        "format": "jwt",
-                    },
-                    "user": {
-                        "type": "object",
-                        "properties": {
-                            "id": {"type": "integer", "description": "User ID"},
-                            "email": {"type": "string", "format": "email", "description": "User email address"},
-                            "phone_number": {"type": "string", "description": "User phone number"},
-                            "is_verified": {"type": "boolean", "description": "Email verification status"},
-                        },
-                        "required": ["id", "is_verified"],
-                    },
-                },
-                "required": ["access", "refresh"],
-            },
+            response=PasswordlessLoginResponseSerializer,
             examples=[
                 OpenApiExample(
                     "Success",
                     value={
                         "access": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
                         "refresh": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
-                        "user": {"id": 123, "email": "user@example.com", "is_verified": True},
+                        "user": {
+                            "id": "8f3e8f4c-1c2d-4a3b-bd8b-4a0f8f5b1a21",
+                            "email": "user@example.com",
+                            "is_verified": True,
+                            "wallet_address": None,
+                        },
                     },
                     status_codes=[200],
                 )

--- a/blockauth/serializers/user_account_serializers.py
+++ b/blockauth/serializers/user_account_serializers.py
@@ -256,3 +256,67 @@ class EmailChangeConfirmationSerializer(serializers.Serializer):
 
 class RefreshTokenSerializer(serializers.Serializer):
     refresh_token = serializers.CharField(help_text="Refresh token to get new access token", required=True)
+
+
+"""shared login response serializers (issue #97)
+
+These serializers describe the ``{access, refresh, user}`` response shape
+used by basic-login, passwordless-login, and wallet-login. Keeping them in
+one place means the OpenAPI spec stays consistent across all three endpoints
+and clients can share a single generated type.
+
+``email`` and ``wallet_address`` are both nullable because:
+
+* wallet-first accounts are created with no email on first SIWE login,
+* basic / passwordless accounts have no wallet until the user runs the
+  ``wallet/link/`` flow.
+"""
+
+
+class LoginUserSerializer(serializers.Serializer):
+    """User payload embedded in every login response.
+
+    Shared by ``BasicLoginResponseSerializer``,
+    ``PasswordlessLoginResponseSerializer``, and
+    ``WalletLoginResponseSerializer`` so the three endpoints stay in lock-step.
+    Do not add anything here that isn't safe to surface to the client --
+    this object goes into the success response of an unauthenticated call.
+    """
+
+    id = serializers.UUIDField(help_text="User UUID")
+    email = serializers.CharField(
+        allow_null=True,
+        required=False,
+        help_text="Email address (null for wallet-first accounts)",
+    )
+    is_verified = serializers.BooleanField(help_text="Whether the account is verified")
+    wallet_address = serializers.CharField(
+        allow_null=True,
+        required=False,
+        help_text="Ethereum wallet address (null for accounts without a linked wallet)",
+    )
+
+
+class BasicLoginResponseSerializer(serializers.Serializer):
+    """Response body for ``POST /login/basic/`` (issue #97).
+
+    The ``user`` field gives clients parity with wallet-login so they can
+    hydrate profile state without a follow-up ``GET /me/`` round-trip.
+    """
+
+    access = serializers.CharField(help_text="JWT access token")
+    refresh = serializers.CharField(help_text="JWT refresh token")
+    user = LoginUserSerializer(help_text="Authenticated user profile")
+
+
+class PasswordlessLoginResponseSerializer(serializers.Serializer):
+    """Response body for ``POST /login/passwordless/confirm/`` (issue #97).
+
+    Same shape as :class:`BasicLoginResponseSerializer`; kept as a distinct
+    class so drf-spectacular can tag the schema separately per endpoint and
+    so future divergence (e.g. passwordless-only flags) is cheap.
+    """
+
+    access = serializers.CharField(help_text="JWT access token")
+    refresh = serializers.CharField(help_text="JWT refresh token")
+    user = LoginUserSerializer(help_text="Authenticated user profile")

--- a/blockauth/serializers/wallet_auth_serializers.py
+++ b/blockauth/serializers/wallet_auth_serializers.py
@@ -93,7 +93,12 @@ WalletLoginUserSerializer = LoginUserSerializer
 
 
 class WalletLoginResponseSerializer(serializers.Serializer):
-    """Response body for ``POST /login/wallet/``."""
+    """Response body for ``POST /login/wallet/`` (issue #97).
+
+    Shares the :class:`LoginUserSerializer` payload with basic-login and
+    passwordless-login so the three endpoints return the same shape and
+    clients can share a single generated type.
+    """
 
     access = serializers.CharField(help_text="JWT access token")
     refresh = serializers.CharField(help_text="JWT refresh token")

--- a/blockauth/serializers/wallet_auth_serializers.py
+++ b/blockauth/serializers/wallet_auth_serializers.py
@@ -9,6 +9,7 @@ default URLconf.
 
 from rest_framework import serializers
 
+from blockauth.serializers.user_account_serializers import LoginUserSerializer
 from blockauth.utils.siwe import MAX_SIWE_MESSAGE_LENGTH
 
 
@@ -81,26 +82,14 @@ class WalletLoginRequestSerializer(serializers.Serializer):
     )
 
 
-class WalletLoginUserSerializer(serializers.Serializer):
-    """User payload nested inside the wallet-login response.
-
-    Matches the shape described in issue #97 so clients get parity with
-    basic-login without a second ``GET /me/`` round-trip.  ``email`` is
-    nullable because wallet-first Creators may not have one yet.
-    """
-
-    id = serializers.UUIDField(help_text="User UUID")
-    email = serializers.EmailField(
-        allow_null=True,
-        required=False,
-        help_text="Email address (null for wallet-first accounts)",
-    )
-    is_verified = serializers.BooleanField(help_text="Whether the account is verified")
-    wallet_address = serializers.CharField(
-        allow_null=True,
-        required=False,
-        help_text="Ethereum wallet address",
-    )
+# Backwards-compat alias. The wallet-login response used to embed a
+# ``WalletLoginUserSerializer`` declared here. Issue #97 generalised the
+# payload to basic-login and passwordless-login, at which point the
+# serializer was promoted to the shared ``LoginUserSerializer`` in
+# ``user_account_serializers``. Keeping the alias avoids breaking any
+# external consumer that imported the old name before the rename was
+# released; remove in a future major bump.
+WalletLoginUserSerializer = LoginUserSerializer
 
 
 class WalletLoginResponseSerializer(serializers.Serializer):
@@ -108,4 +97,4 @@ class WalletLoginResponseSerializer(serializers.Serializer):
 
     access = serializers.CharField(help_text="JWT access token")
     refresh = serializers.CharField(help_text="JWT refresh token")
-    user = WalletLoginUserSerializer(help_text="Authenticated user profile")
+    user = LoginUserSerializer(help_text="Authenticated user profile")

--- a/blockauth/serializers/wallet_auth_serializers.py
+++ b/blockauth/serializers/wallet_auth_serializers.py
@@ -81,8 +81,31 @@ class WalletLoginRequestSerializer(serializers.Serializer):
     )
 
 
+class WalletLoginUserSerializer(serializers.Serializer):
+    """User payload nested inside the wallet-login response.
+
+    Matches the shape described in issue #97 so clients get parity with
+    basic-login without a second ``GET /me/`` round-trip.  ``email`` is
+    nullable because wallet-first Creators may not have one yet.
+    """
+
+    id = serializers.UUIDField(help_text="User UUID")
+    email = serializers.EmailField(
+        allow_null=True,
+        required=False,
+        help_text="Email address (null for wallet-first accounts)",
+    )
+    is_verified = serializers.BooleanField(help_text="Whether the account is verified")
+    wallet_address = serializers.CharField(
+        allow_null=True,
+        required=False,
+        help_text="Ethereum wallet address",
+    )
+
+
 class WalletLoginResponseSerializer(serializers.Serializer):
     """Response body for ``POST /login/wallet/``."""
 
     access = serializers.CharField(help_text="JWT access token")
     refresh = serializers.CharField(help_text="JWT refresh token")
+    user = WalletLoginUserSerializer(help_text="Authenticated user profile")

--- a/blockauth/services/wallet_user_linker.py
+++ b/blockauth/services/wallet_user_linker.py
@@ -34,7 +34,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import Tuple
+from typing import Any, Tuple
 
 from django.conf import settings
 from django.db import transaction
@@ -59,13 +59,20 @@ class WalletUserLinkError(Exception):
 
 @dataclass(frozen=True)
 class LinkedUser:
-    """Output of :meth:`WalletUserLinker.link`."""
+    """Output of :meth:`WalletUserLinker.link`.
+
+    ``user`` carries the Django model instance so the caller can serialise
+    a user payload into the HTTP response without an extra DB round-trip.
+    The field is typed ``Any`` to avoid importing the concrete user model
+    at class-definition time (it varies per deployment).
+    """
 
     user_id: str
     email: str
     access_token: str
     refresh_token: str
     created: bool
+    user: Any = None
 
 
 class WalletUserLinker:
@@ -161,6 +168,7 @@ class WalletUserLinker:
             access_token=access_token,
             refresh_token=refresh_token,
             created=created,
+            user=user,
         )
 
     # =========================================================================

--- a/blockauth/utils/tests/credential_leak.py
+++ b/blockauth/utils/tests/credential_leak.py
@@ -1,0 +1,66 @@
+"""Shared test helper for asserting login responses don't leak credentials.
+
+Issue #99 lock-down: the ``user`` payload returned by every login-style
+endpoint (basic-login, passwordless-login, wallet-login) must never carry
+password-hash material or private Django ``_state``-style attributes. This
+module centralises the allow-list and the assertion helper so every login
+test shares one source of truth -- adding a new forbidden field only
+requires updating ``FORBIDDEN_USER_PAYLOAD_KEYS`` here.
+
+The check recurses into nested dicts and into dict elements inside
+lists/tuples so a future refactor that buries credentials under a
+``credentials`` sub-object (or returns ``[{...}]`` lists) still trips the
+guard. Top-level-only was the original shape; the recursion is defence in
+depth against future serializer changes.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# Adding a new forbidden field: append it here. No test-file edit needed.
+FORBIDDEN_USER_PAYLOAD_KEYS = frozenset(
+    {"password", "password_hash", "hashed_password"}
+)
+
+
+def assert_no_credential_leak(user_payload: Any) -> None:
+    """Fail loudly if a login response's ``user`` object carries secrets.
+
+    Asserts:
+
+    * The payload is a non-empty mapping -- an empty ``{}`` is almost
+      certainly a regression ("serializer returned nothing") rather than a
+      safe "no credentials leaked" state, so we refuse to silently pass it.
+    * No key is in :data:`FORBIDDEN_USER_PAYLOAD_KEYS` (``password`` /
+      ``password_hash`` / ``hashed_password``).
+    * No key starts with ``_`` -- Django / DRF attach private state under
+      ``_state`` and friends and those must never go over the wire.
+    * Nested dict values are walked recursively; list / tuple values have
+      their dict elements walked. Non-mapping leaves are ignored.
+
+    Deliberately strict so that the assertion fails closed on structural
+    changes -- the whole point of the helper is to catch a future refactor
+    to a ``ModelSerializer`` with ``fields = "__all__"``.
+    """
+    assert user_payload, "user payload must not be empty"
+    _walk(user_payload)
+
+
+def _walk(node: Any) -> None:
+    """Recurse into ``node``, flagging forbidden keys wherever they appear."""
+    if isinstance(node, dict):
+        for key, value in node.items():
+            assert key not in FORBIDDEN_USER_PAYLOAD_KEYS, (
+                f"Forbidden credential field '{key}' leaked in login user payload"
+            )
+            assert not (isinstance(key, str) and key.startswith("_")), (
+                f"Private field '{key}' leaked in login user payload"
+            )
+            _walk(value)
+    elif isinstance(node, (list, tuple)):
+        for item in node:
+            _walk(item)
+    # Non-container leaves (str, int, None, UUID, ...) are fine -- the
+    # check is about keys, not values. A string value that happens to
+    # equal "password" is not a leak.

--- a/blockauth/utils/tests/test_wallet_login_siwe.py
+++ b/blockauth/utils/tests/test_wallet_login_siwe.py
@@ -403,8 +403,18 @@ class TestWalletLoginEndpoints:
             format="json",
         )
         assert login_resp.status_code == 200, login_resp.content
-        assert "access" in login_resp.json()
-        assert "refresh" in login_resp.json()
+        body = login_resp.json()
+        assert "access" in body
+        assert "refresh" in body
+        # Issue #97: wallet login now returns user payload
+        assert "user" in body
+        user_payload = body["user"]
+        assert "id" in user_payload
+        assert "is_verified" in user_payload
+        assert "wallet_address" in user_payload
+        assert user_payload["wallet_address"] == _TEST_ADDRESS_LC
+        # email may be null for wallet-first accounts
+        assert "email" in user_payload
 
         cache.clear()
         replay = client.post(
@@ -518,7 +528,11 @@ class TestWalletLoginEndpoints:
             format="json",
         )
         assert resp.status_code == 200, resp.content
-        assert "access" in resp.json()
+        body = resp.json()
+        assert "access" in body
+        # Issue #97: user payload present for existing wallet too
+        assert "user" in body
+        assert body["user"]["wallet_address"] == _TEST_ADDRESS_LC
 
     def test_login_rejects_oversized_message(self):
         """Hardening #9 — serializer caps message length."""

--- a/blockauth/utils/tests/test_wallet_login_siwe.py
+++ b/blockauth/utils/tests/test_wallet_login_siwe.py
@@ -69,12 +69,6 @@ def _perform_wallet_login(client, address):
     assert challenge_resp.status_code == 200, challenge_resp.content
     message = challenge_resp.json()["message"]
     signature = _sign(message)
-    # cache.clear() between challenge and login is intentionally omitted
-    # here -- the two endpoints use independent throttle scope keys
-    # (``wallet_challenge`` vs ``wallet_login``) so issuing one challenge
-    # does not populate the login bucket. See the cleanup commit that
-    # removed the cargo-cult clears from the individual tests for the
-    # full rationale.
     return client.post(
         reverse("wallet-login"),
         {
@@ -427,7 +421,6 @@ class TestWalletLoginEndpoints:
         message = challenge_resp.json()["message"]
         sig = _sign(message)
 
-        cache.clear()
         login_resp = client.post(
             reverse("wallet-login"),
             {
@@ -451,7 +444,6 @@ class TestWalletLoginEndpoints:
         # email may be null for wallet-first accounts
         assert "email" in user_payload
 
-        cache.clear()
         replay = client.post(
             reverse("wallet-login"),
             {
@@ -572,7 +564,6 @@ class TestWalletLoginEndpoints:
         )
         message = challenge_resp.json()["message"]
         sig = _sign(message)
-        cache.clear()
         resp = client.post(
             reverse("wallet-login"),
             {
@@ -598,7 +589,6 @@ class TestWalletLoginEndpoints:
         )
         message = challenge_resp.json()["message"]
         sig = _sign(message)
-        cache.clear()
         resp = client.post(
             reverse("wallet-login"),
             {
@@ -625,7 +615,6 @@ class TestWalletLoginEndpoints:
         )
         message = challenge_resp.json()["message"]
         sig = _sign(message)
-        cache.clear()
         resp = client.post(
             reverse("wallet-login"),
             {

--- a/blockauth/utils/tests/test_wallet_login_siwe.py
+++ b/blockauth/utils/tests/test_wallet_login_siwe.py
@@ -36,32 +36,13 @@ from blockauth.services.wallet_login_service import (
     reset_wallet_login_service,
 )
 from blockauth.utils.siwe import build_siwe_message
+from blockauth.utils.tests.credential_leak import assert_no_credential_leak
 
 # Deterministic test wallet — not a real account.
 _TEST_PRIVATE_KEY = "0x" + "1" * 64
 _TEST_ACCOUNT = Account.from_key(_TEST_PRIVATE_KEY)
 _TEST_ADDRESS = _TEST_ACCOUNT.address  # EIP-55 checksummed
 _TEST_ADDRESS_LC = _TEST_ADDRESS.lower()
-
-# Issue #99: shared allow-list of credential-material keys that must never
-# appear in the login ``user`` payload. Adding a new field only requires
-# updating this set, not rewriting every test.
-FORBIDDEN_USER_PAYLOAD_KEYS = frozenset({"password", "password_hash", "hashed_password"})
-
-
-def _assert_no_credential_leak(user_payload):
-    """Fail loudly if the wallet-login ``user`` object carries secrets.
-
-    Mirrors the basic/passwordless-login helper. Iterates the payload's
-    own keys so a future refactor to ``ModelSerializer(fields="__all__")``
-    can't silently ship private Django attributes (``_state`` etc.) or
-    password hash fields over the wire.
-    """
-    for key in user_payload.keys():
-        assert key not in FORBIDDEN_USER_PAYLOAD_KEYS, (
-            f"Forbidden credential field '{key}' leaked in wallet-login user payload"
-        )
-        assert not key.startswith("_"), f"Private field '{key}' leaked in wallet-login user payload"
 
 
 def _sign(message: str) -> str:
@@ -476,7 +457,7 @@ class TestWalletLoginEndpoints:
             format="json",
         )
         assert login_resp.status_code == 200, login_resp.content
-        _assert_no_credential_leak(login_resp.json()["user"])
+        assert_no_credential_leak(login_resp.json()["user"])
 
     def test_login_returns_null_email_for_wallet_first_creator(self):
         """Issue #99: wallet-first Creators have no email on first SIWE

--- a/blockauth/utils/tests/test_wallet_login_siwe.py
+++ b/blockauth/utils/tests/test_wallet_login_siwe.py
@@ -478,6 +478,39 @@ class TestWalletLoginEndpoints:
         assert login_resp.status_code == 200, login_resp.content
         _assert_no_credential_leak(login_resp.json()["user"])
 
+    def test_login_returns_null_email_for_wallet_first_creator(self):
+        """Issue #99: wallet-first Creators have no email on first SIWE
+        login. The response must expose ``user.email`` as ``None`` (a
+        supported case) rather than coercing to an empty string or
+        tripping the serializer's validation.
+        """
+        client = APIClient()
+        challenge_resp = client.post(
+            reverse("wallet-login-challenge"),
+            {"address": _TEST_ADDRESS_LC},
+            format="json",
+        )
+        assert challenge_resp.status_code == 200, challenge_resp.content
+        message = challenge_resp.json()["message"]
+        sig = _sign(message)
+
+        cache.clear()
+        login_resp = client.post(
+            reverse("wallet-login"),
+            {
+                "wallet_address": _TEST_ADDRESS_LC,
+                "message": message,
+                "signature": sig,
+            },
+            format="json",
+        )
+        # Auto-create path: no ValidationError, no 400 -- wallet-first
+        # Creators without email are explicitly supported.
+        assert login_resp.status_code == status.HTTP_200_OK, login_resp.content
+        user_payload = login_resp.json()["user"]
+        assert user_payload["wallet_address"] == _TEST_ADDRESS_LC
+        assert user_payload["email"] is None
+
     def test_login_rejects_forged_domain(self):
         client = APIClient()
         issued = django_timezone.now()

--- a/blockauth/utils/tests/test_wallet_login_siwe.py
+++ b/blockauth/utils/tests/test_wallet_login_siwe.py
@@ -52,6 +52,40 @@ def _sign(message: str) -> str:
     return sig_hex if sig_hex.startswith("0x") else "0x" + sig_hex
 
 
+def _perform_wallet_login(client, address):
+    """Run the full challenge -> sign -> login round-trip and return the response.
+
+    Factored out of the individual tests so the identical 15-line
+    boilerplate (POST challenge, read message, sign, POST login) lives
+    in one place. The issue #99 tests (credential leak + null email)
+    and any future endpoint-level test should reuse this helper rather
+    than duplicating the sequence.
+    """
+    challenge_resp = client.post(
+        reverse("wallet-login-challenge"),
+        {"address": address},
+        format="json",
+    )
+    assert challenge_resp.status_code == 200, challenge_resp.content
+    message = challenge_resp.json()["message"]
+    signature = _sign(message)
+    # cache.clear() between challenge and login is intentionally omitted
+    # here -- the two endpoints use independent throttle scope keys
+    # (``wallet_challenge`` vs ``wallet_login``) so issuing one challenge
+    # does not populate the login bucket. See the cleanup commit that
+    # removed the cargo-cult clears from the individual tests for the
+    # full rationale.
+    return client.post(
+        reverse("wallet-login"),
+        {
+            "wallet_address": address,
+            "message": message,
+            "signature": signature,
+        },
+        format="json",
+    )
+
+
 @pytest.fixture(autouse=True)
 def _override_domains(settings):
     """Apply the SIWE allow-list for every test in this module."""
@@ -437,60 +471,71 @@ class TestWalletLoginEndpoints:
         ``ModelSerializer(fields="__all__")``.
         """
         client = APIClient()
-        challenge_resp = client.post(
-            reverse("wallet-login-challenge"),
-            {"address": _TEST_ADDRESS_LC},
-            format="json",
-        )
-        assert challenge_resp.status_code == 200, challenge_resp.content
-        message = challenge_resp.json()["message"]
-        sig = _sign(message)
-
-        cache.clear()
-        login_resp = client.post(
-            reverse("wallet-login"),
-            {
-                "wallet_address": _TEST_ADDRESS_LC,
-                "message": message,
-                "signature": sig,
-            },
-            format="json",
-        )
+        login_resp = _perform_wallet_login(client, _TEST_ADDRESS_LC)
         assert login_resp.status_code == 200, login_resp.content
         assert_no_credential_leak(login_resp.json()["user"])
 
-    def test_login_returns_null_email_for_wallet_first_creator(self):
+    def test_login_returns_null_email_for_wallet_first_creator_autocreate(self):
         """Issue #99: wallet-first Creators have no email on first SIWE
-        login. The response must expose ``user.email`` as ``None`` (a
-        supported case) rather than coercing to an empty string or
-        tripping the serializer's validation.
-        """
-        client = APIClient()
-        challenge_resp = client.post(
-            reverse("wallet-login-challenge"),
-            {"address": _TEST_ADDRESS_LC},
-            format="json",
-        )
-        assert challenge_resp.status_code == 200, challenge_resp.content
-        message = challenge_resp.json()["message"]
-        sig = _sign(message)
+        login. The auto-create path must expose ``user.email`` as
+        ``None`` (a supported case) rather than coercing to an empty
+        string or tripping the serializer's validation.
 
-        cache.clear()
-        login_resp = client.post(
-            reverse("wallet-login"),
-            {
-                "wallet_address": _TEST_ADDRESS_LC,
-                "message": message,
-                "signature": sig,
-            },
-            format="json",
-        )
-        # Auto-create path: no ValidationError, no 400 -- wallet-first
-        # Creators without email are explicitly supported.
+        Also asserts the DB row itself has ``email IS NULL`` -- the
+        response could in principle correctly surface ``None`` while
+        the backing user row stored ``""``, or vice versa, and both
+        would be regressions. Checking both pins the contract
+        end-to-end.
+        """
+        from tests.models import TestBlockUser
+
+        client = APIClient()
+        login_resp = _perform_wallet_login(client, _TEST_ADDRESS_LC)
         assert login_resp.status_code == status.HTTP_200_OK, login_resp.content
         user_payload = login_resp.json()["user"]
         assert user_payload["wallet_address"] == _TEST_ADDRESS_LC
         assert user_payload["email"] is None
+
+        # DB-level sanity: the auto-create path must store ``None``, not
+        # ``""``. A coerced empty string would satisfy the response
+        # check (DRF would still serialize it as ``""``) so this is an
+        # independent assertion, not a duplicate.
+        created = TestBlockUser.objects.get(wallet_address=_TEST_ADDRESS_LC)
+        assert created.email is None
+
+    def test_login_returns_null_email_for_existing_wallet_first_creator(self):
+        """Issue #99: the response must also expose ``user.email`` as
+        ``None`` for a *pre-existing* wallet-first Creator -- not just
+        on the auto-create branch.
+
+        The auto-create variant alone is too weak: if a future change
+        coerced ``email`` to ``""`` only when looking up an existing
+        row (say, a ``User.objects.get_or_create(defaults={"email":
+        ""})`` regression), the auto-create test would still pass
+        because it asserts the happy-path default, not the lookup
+        branch.
+
+        Seed an existing row with ``email=None`` via the ORM, then
+        drive a login against it and assert both the response and the
+        untouched DB row still hold ``None``.
+        """
+        from tests.models import TestBlockUser
+
+        existing = TestBlockUser.objects.create(
+            wallet_address=_TEST_ADDRESS_LC,
+            email=None,
+            is_verified=False,
+        )
+        client = APIClient()
+        login_resp = _perform_wallet_login(client, _TEST_ADDRESS_LC)
+        assert login_resp.status_code == status.HTTP_200_OK, login_resp.content
+        user_payload = login_resp.json()["user"]
+        assert user_payload["wallet_address"] == _TEST_ADDRESS_LC
+        assert user_payload["email"] is None
+
+        # Existing row must not have been mutated by the login path.
+        existing.refresh_from_db()
+        assert existing.email is None
 
     def test_login_rejects_forged_domain(self):
         client = APIClient()

--- a/blockauth/utils/tests/test_wallet_login_siwe.py
+++ b/blockauth/utils/tests/test_wallet_login_siwe.py
@@ -43,6 +43,26 @@ _TEST_ACCOUNT = Account.from_key(_TEST_PRIVATE_KEY)
 _TEST_ADDRESS = _TEST_ACCOUNT.address  # EIP-55 checksummed
 _TEST_ADDRESS_LC = _TEST_ADDRESS.lower()
 
+# Issue #99: shared allow-list of credential-material keys that must never
+# appear in the login ``user`` payload. Adding a new field only requires
+# updating this set, not rewriting every test.
+FORBIDDEN_USER_PAYLOAD_KEYS = frozenset({"password", "password_hash", "hashed_password"})
+
+
+def _assert_no_credential_leak(user_payload):
+    """Fail loudly if the wallet-login ``user`` object carries secrets.
+
+    Mirrors the basic/passwordless-login helper. Iterates the payload's
+    own keys so a future refactor to ``ModelSerializer(fields="__all__")``
+    can't silently ship private Django attributes (``_state`` etc.) or
+    password hash fields over the wire.
+    """
+    for key in user_payload.keys():
+        assert key not in FORBIDDEN_USER_PAYLOAD_KEYS, (
+            f"Forbidden credential field '{key}' leaked in wallet-login user payload"
+        )
+        assert not key.startswith("_"), f"Private field '{key}' leaked in wallet-login user payload"
+
 
 def _sign(message: str) -> str:
     """Return a 0x-prefixed 65-byte signature from the fixed test key."""
@@ -428,6 +448,35 @@ class TestWalletLoginEndpoints:
         )
         assert replay.status_code == status.HTTP_401_UNAUTHORIZED, replay.content
         assert replay.json()["error"]["code"] == "nonce_invalid"
+
+    def test_login_user_payload_does_not_leak_credentials(self):
+        """Issue #99: wallet-login's ``user`` payload must never contain
+        password hash material or private Django attributes. Guards
+        against a future refactor switching the response to a
+        ``ModelSerializer(fields="__all__")``.
+        """
+        client = APIClient()
+        challenge_resp = client.post(
+            reverse("wallet-login-challenge"),
+            {"address": _TEST_ADDRESS_LC},
+            format="json",
+        )
+        assert challenge_resp.status_code == 200, challenge_resp.content
+        message = challenge_resp.json()["message"]
+        sig = _sign(message)
+
+        cache.clear()
+        login_resp = client.post(
+            reverse("wallet-login"),
+            {
+                "wallet_address": _TEST_ADDRESS_LC,
+                "message": message,
+                "signature": sig,
+            },
+            format="json",
+        )
+        assert login_resp.status_code == 200, login_resp.content
+        _assert_no_credential_leak(login_resp.json()["user"])
 
     def test_login_rejects_forged_domain(self):
         client = APIClient()

--- a/blockauth/views/basic_auth_views.py
+++ b/blockauth/views/basic_auth_views.py
@@ -26,11 +26,13 @@ from blockauth.enums import AuthenticationType
 from blockauth.models.otp import OTP, OTPSubject
 from blockauth.notification import NotificationEvent, send_otp
 from blockauth.serializers.user_account_serializers import (
+    BasicLoginResponseSerializer,
     BasicLoginSerializer,
     EmailChangeConfirmationSerializer,
     EmailChangeRequestSerializer,
     PasswordChangeSerializer,
     PasswordlessLoginConfirmationSerializer,
+    PasswordlessLoginResponseSerializer,
     PasswordlessLoginSerializer,
     PasswordResetConfirmationEmailSerializer,
     PasswordResetRequestSerializer,
@@ -297,7 +299,23 @@ class BasicAuthLoginView(APIView):
                 access_token, refresh_token = generate_auth_token(token_class=AUTH_TOKEN_CLASS(), user_id=str(user.id))
             self.login_throttle.record_success(request, "basic_login")
             blockauth_logger.success("Basic login successful", sanitize_log_context(request.data, {"user": user.id}))
-            return Response(data={"access": access_token, "refresh": refresh_token}, status=status.HTTP_200_OK)
+            # Issue #97: return user payload so clients can hydrate profile
+            # state without a second ``GET /me/`` round-trip. Same shape as
+            # wallet-login. ``wallet_address`` is null for email-first users
+            # until they run the ``wallet/link/`` flow.
+            response_serializer = BasicLoginResponseSerializer(
+                {
+                    "access": access_token,
+                    "refresh": refresh_token,
+                    "user": {
+                        "id": user.id,
+                        "email": user.email,
+                        "is_verified": user.is_verified,
+                        "wallet_address": user.wallet_address,
+                    },
+                }
+            )
+            return Response(data=response_serializer.data, status=status.HTTP_200_OK)
         except (ValidationError, ValidationErrorWithCode) as e:
             self.login_throttle.record_failure(request, "basic_login")
             blockauth_logger.warning(

--- a/blockauth/views/basic_auth_views.py
+++ b/blockauth/views/basic_auth_views.py
@@ -250,8 +250,13 @@ class SignUpConfirmView(APIView):
 
 
 class BasicAuthLoginView(APIView):
-    """
-    Login via identifier(email/phone number) & password and get access token & refresh token.
+    """``POST /login/basic/`` -- email/phone + password login.
+
+    Returns ``{access, refresh, user}``. The ``user`` payload carries
+    ``id``, ``email``, ``is_verified``, and ``wallet_address`` so clients
+    hydrate without a follow-up ``GET /me/`` round-trip (issue #97).
+    ``wallet_address`` is null for email-first accounts until they run
+    the ``wallet/link/`` flow.
     """
 
     permission_classes = (AllowAny,)
@@ -377,8 +382,12 @@ class PasswordlessLoginView(APIView):
 
 
 class PasswordlessLoginConfirmView(APIView):
-    """
-    Verify otp for login & get access token & refresh token.
+    """``POST /login/passwordless/confirm/`` -- verify OTP and issue tokens.
+
+    Mirrors :class:`BasicAuthLoginView`'s response shape:
+    ``{access, refresh, user}``. Auto-creates an account if the identifier
+    is new (issue #97 -- clients hydrate profile state in a single
+    round-trip regardless of the create-vs-existing branch).
     """
 
     permission_classes = (AllowAny,)

--- a/blockauth/views/basic_auth_views.py
+++ b/blockauth/views/basic_auth_views.py
@@ -441,7 +441,23 @@ class PasswordlessLoginConfirmView(APIView):
             blockauth_logger.success(
                 "Passwordless login confirmed", sanitize_log_context(request.data, {"user": user.id})
             )
-            return Response(data={"access": access_token, "refresh": refresh_token}, status=status.HTTP_200_OK)
+            # Issue #97: mirror basic-login / wallet-login by returning the
+            # authenticated user so clients can hydrate profile state in one
+            # round-trip. ``wallet_address`` is null for email / SMS users
+            # that haven't linked a wallet yet.
+            response_serializer = PasswordlessLoginResponseSerializer(
+                {
+                    "access": access_token,
+                    "refresh": refresh_token,
+                    "user": {
+                        "id": user.id,
+                        "email": user.email,
+                        "is_verified": user.is_verified,
+                        "wallet_address": user.wallet_address,
+                    },
+                }
+            )
+            return Response(data=response_serializer.data, status=status.HTTP_200_OK)
         except ValidationError as e:
             self.login_throttle.record_failure(request, "passwordless_login")
             blockauth_logger.warning(

--- a/blockauth/views/tests/test_login_views.py
+++ b/blockauth/views/tests/test_login_views.py
@@ -18,6 +18,28 @@ PASSWORDLESS_CONFIRM_URL = reverse("passwordless-login-confirm")
 # Shared test credential (reused by multiple cases below). Test fixture only.
 _TEST_PASSWORD = "Strong" + "P@ss1!"  # noqa: S105 -- test fixture
 
+# Issue #99: locking the user-payload contract down so a future refactor
+# (e.g. someone switching the response to a ModelSerializer with
+# ``fields = "__all__"``) can't silently leak credential material. Any new
+# sensitive field should be appended here, not removed.
+FORBIDDEN_USER_PAYLOAD_KEYS = frozenset({"password", "password_hash", "hashed_password"})
+
+
+def _assert_no_credential_leak(user_payload):
+    """Fail loudly if the login response's ``user`` object carries secrets.
+
+    Iterates the payload's own keys (rather than asserting one field at a
+    time) so adding a new forbidden key only touches
+    ``FORBIDDEN_USER_PAYLOAD_KEYS``. Any key that starts with an underscore
+    is also rejected — Django / DRF attach private state under ``_state``
+    and friends and those must never go over the wire.
+    """
+    for key in user_payload.keys():
+        assert key not in FORBIDDEN_USER_PAYLOAD_KEYS, (
+            f"Forbidden credential field '{key}' leaked in login user payload"
+        )
+        assert not key.startswith("_"), f"Private field '{key}' leaked in login user payload"
+
 
 @pytest.mark.django_db
 class TestBasicLoginView:
@@ -68,6 +90,20 @@ class TestBasicLoginView:
         user_payload = response.data["user"]
         assert user_payload["id"] == str(user.id)
         assert user_payload["wallet_address"] == wallet
+
+    def test_login_user_payload_does_not_leak_credentials(self, api_client, create_user):
+        """Issue #99: basic-login's ``user`` payload must never contain
+        password hash material or private Django attributes. Defensive
+        regression test — guards against a future refactor to a
+        ``ModelSerializer`` with ``fields = "__all__"``.
+        """
+        create_user(email="user@test.com", password=_TEST_PASSWORD)
+        response = api_client.post(BASIC_LOGIN_URL, {
+            "identifier": "user@test.com",
+            "password": _TEST_PASSWORD,
+        })
+        assert response.status_code == status.HTTP_200_OK
+        _assert_no_credential_leak(response.data["user"])
 
     def test_login_wrong_password(self, api_client, create_user):
         create_user(email="user@test.com", password="StrongP@ss1!")
@@ -219,6 +255,20 @@ class TestPasswordlessLoginConfirmView:
         assert user_payload["id"] == str(created_user.id)
         assert user_payload["email"] == "fresh@test.com"
         assert user_payload["wallet_address"] is None
+
+    def test_confirm_user_payload_does_not_leak_credentials(self, api_client, create_user, create_otp):
+        """Issue #99: passwordless-login's ``user`` payload must never
+        contain password hash material or private Django attributes.
+        Defensive regression test — see basic-login counterpart.
+        """
+        create_user(email="user@test.com")
+        create_otp(identifier="user@test.com", subject=OTPSubject.LOGIN, code="ABC123")
+        response = api_client.post(PASSWORDLESS_CONFIRM_URL, {
+            "identifier": "user@test.com",
+            "code": "ABC123",
+        })
+        assert response.status_code == status.HTTP_200_OK
+        _assert_no_credential_leak(response.data["user"])
 
     def test_confirm_creates_user_if_not_exists(self, api_client, create_otp):
         """Passwordless login should create a new user if one doesn't exist."""

--- a/blockauth/views/tests/test_login_views.py
+++ b/blockauth/views/tests/test_login_views.py
@@ -182,6 +182,44 @@ class TestPasswordlessLoginConfirmView:
         assert "access" in response.data
         assert "refresh" in response.data
 
+    def test_confirm_returns_user_payload(self, api_client, create_user, create_otp):
+        """Issue #97: passwordless-login confirm response includes the
+        user so clients can hydrate without a follow-up GET /me/."""
+        user = create_user(email="user@test.com")
+        create_otp(identifier="user@test.com", subject=OTPSubject.LOGIN, code="ABC123")
+        response = api_client.post(PASSWORDLESS_CONFIRM_URL, {
+            "identifier": "user@test.com",
+            "code": "ABC123",
+        })
+        assert response.status_code == status.HTTP_200_OK
+        assert "user" in response.data
+        user_payload = response.data["user"]
+        assert user_payload["id"] == str(user.id)
+        assert user_payload["email"] == "user@test.com"
+        assert user_payload["is_verified"] is True
+        # wallet_address is present and null for email-first users --
+        # passwordless-login never auto-links a wallet.
+        assert "wallet_address" in user_payload
+        assert user_payload["wallet_address"] is None
+
+    def test_confirm_returns_user_payload_for_new_user(self, api_client, create_otp):
+        """Issue #97: passwordless confirm also populates user on the
+        auto-create branch (user didn't exist before the OTP flow)."""
+        from blockauth.utils.config import get_block_auth_user_model
+        User = get_block_auth_user_model()
+
+        create_otp(identifier="fresh@test.com", subject=OTPSubject.LOGIN, code="ABC123")
+        response = api_client.post(PASSWORDLESS_CONFIRM_URL, {
+            "identifier": "fresh@test.com",
+            "code": "ABC123",
+        })
+        assert response.status_code == status.HTTP_200_OK
+        created_user = User.objects.get(email="fresh@test.com")
+        user_payload = response.data["user"]
+        assert user_payload["id"] == str(created_user.id)
+        assert user_payload["email"] == "fresh@test.com"
+        assert user_payload["wallet_address"] is None
+
     def test_confirm_creates_user_if_not_exists(self, api_client, create_otp):
         """Passwordless login should create a new user if one doesn't exist."""
         from blockauth.utils.config import get_block_auth_user_model

--- a/blockauth/views/tests/test_login_views.py
+++ b/blockauth/views/tests/test_login_views.py
@@ -9,6 +9,7 @@ from django.urls import reverse
 from rest_framework import status
 
 from blockauth.models.otp import OTP, OTPSubject
+from blockauth.utils.tests.credential_leak import assert_no_credential_leak
 
 
 BASIC_LOGIN_URL = reverse("basic-login")
@@ -17,28 +18,6 @@ PASSWORDLESS_CONFIRM_URL = reverse("passwordless-login-confirm")
 
 # Shared test credential (reused by multiple cases below). Test fixture only.
 _TEST_PASSWORD = "Strong" + "P@ss1!"  # noqa: S105 -- test fixture
-
-# Issue #99: locking the user-payload contract down so a future refactor
-# (e.g. someone switching the response to a ModelSerializer with
-# ``fields = "__all__"``) can't silently leak credential material. Any new
-# sensitive field should be appended here, not removed.
-FORBIDDEN_USER_PAYLOAD_KEYS = frozenset({"password", "password_hash", "hashed_password"})
-
-
-def _assert_no_credential_leak(user_payload):
-    """Fail loudly if the login response's ``user`` object carries secrets.
-
-    Iterates the payload's own keys (rather than asserting one field at a
-    time) so adding a new forbidden key only touches
-    ``FORBIDDEN_USER_PAYLOAD_KEYS``. Any key that starts with an underscore
-    is also rejected — Django / DRF attach private state under ``_state``
-    and friends and those must never go over the wire.
-    """
-    for key in user_payload.keys():
-        assert key not in FORBIDDEN_USER_PAYLOAD_KEYS, (
-            f"Forbidden credential field '{key}' leaked in login user payload"
-        )
-        assert not key.startswith("_"), f"Private field '{key}' leaked in login user payload"
 
 
 @pytest.mark.django_db
@@ -103,7 +82,7 @@ class TestBasicLoginView:
             "password": _TEST_PASSWORD,
         })
         assert response.status_code == status.HTTP_200_OK
-        _assert_no_credential_leak(response.data["user"])
+        assert_no_credential_leak(response.data["user"])
 
     def test_login_wrong_password(self, api_client, create_user):
         create_user(email="user@test.com", password="StrongP@ss1!")
@@ -268,7 +247,7 @@ class TestPasswordlessLoginConfirmView:
             "code": "ABC123",
         })
         assert response.status_code == status.HTTP_200_OK
-        _assert_no_credential_leak(response.data["user"])
+        assert_no_credential_leak(response.data["user"])
 
     def test_confirm_creates_user_if_not_exists(self, api_client, create_otp):
         """Passwordless login should create a new user if one doesn't exist."""

--- a/blockauth/views/tests/test_login_views.py
+++ b/blockauth/views/tests/test_login_views.py
@@ -15,20 +15,59 @@ BASIC_LOGIN_URL = reverse("basic-login")
 PASSWORDLESS_URL = reverse("passwordless-login")
 PASSWORDLESS_CONFIRM_URL = reverse("passwordless-login-confirm")
 
+# Shared test credential (reused by multiple cases below). Test fixture only.
+_TEST_PASSWORD = "Strong" + "P@ss1!"  # noqa: S105 -- test fixture
+
 
 @pytest.mark.django_db
 class TestBasicLoginView:
     """Tests for email/password login."""
 
     def test_login_returns_tokens(self, api_client, create_user):
-        create_user(email="user@test.com", password="StrongP@ss1!")
+        create_user(email="user@test.com", password=_TEST_PASSWORD)
         response = api_client.post(BASIC_LOGIN_URL, {
             "identifier": "user@test.com",
-            "password": "StrongP@ss1!",
+            "password": _TEST_PASSWORD,
         })
         assert response.status_code == status.HTTP_200_OK
         assert "access" in response.data
         assert "refresh" in response.data
+
+    def test_login_returns_user_payload(self, api_client, create_user):
+        """Issue #97: basic-login response includes user so clients
+        can hydrate without a follow-up GET /me/ round-trip."""
+        user = create_user(email="user@test.com", password=_TEST_PASSWORD)
+        response = api_client.post(BASIC_LOGIN_URL, {
+            "identifier": "user@test.com",
+            "password": _TEST_PASSWORD,
+        })
+        assert response.status_code == status.HTTP_200_OK
+        assert "user" in response.data
+        user_payload = response.data["user"]
+        assert user_payload["id"] == str(user.id)
+        assert user_payload["email"] == "user@test.com"
+        assert user_payload["is_verified"] is True
+        # wallet_address is present and null for email-first users
+        assert "wallet_address" in user_payload
+        assert user_payload["wallet_address"] is None
+
+    def test_login_returns_user_payload_with_wallet(self, api_client, create_user):
+        """Issue #97: a user that has already linked a wallet surfaces the
+        address in the login response instead of ``None``."""
+        wallet = "0xabc0000000000000000000000000000000000001"
+        user = create_user(
+            email="walletuser@test.com",
+            password=_TEST_PASSWORD,
+            wallet_address=wallet,
+        )
+        response = api_client.post(BASIC_LOGIN_URL, {
+            "identifier": "walletuser@test.com",
+            "password": _TEST_PASSWORD,
+        })
+        assert response.status_code == status.HTTP_200_OK
+        user_payload = response.data["user"]
+        assert user_payload["id"] == str(user.id)
+        assert user_payload["wallet_address"] == wallet
 
     def test_login_wrong_password(self, api_client, create_user):
         create_user(email="user@test.com", password="StrongP@ss1!")

--- a/blockauth/views/wallet_auth_views.py
+++ b/blockauth/views/wallet_auth_views.py
@@ -7,7 +7,7 @@ Includes:
   ``message`` verbatim with the wallet's private key.
 * :class:`WalletAuthLoginView` — ``POST /login/wallet/``, consumes the
   nonce, verifies the signature, and issues JWTs. Response shape is
-  ``{"access", "refresh"}`` so clients only add the challenge round-trip.
+  ``{"access", "refresh", "user"}`` (issue #97 — parity with basic-login).
 * :class:`WalletEmailAddView` / :class:`WalletLinkView` — unchanged from
   pre-SIWE behavior.
 
@@ -170,9 +170,9 @@ class WalletAuthLoginView(APIView):
     3. Verify the signature (with low-s malleability bound).
     4. Delegate user lookup/creation + token issuance to the linker service.
 
-    The response shape ``{"access", "refresh"}`` is unchanged from the
-    previous wallet login implementation. Clients only need to add the
-    preceding ``/login/wallet/challenge/`` round-trip.
+    The response shape is ``{"access", "refresh", "user"}`` -- the ``user``
+    payload includes ``id``, ``email``, ``is_verified``, and
+    ``wallet_address`` so clients can hydrate in one round-trip (issue #97).
     """
 
     permission_classes = (AllowAny,)
@@ -185,9 +185,11 @@ class WalletAuthLoginView(APIView):
         description=(
             "Consumes a nonce issued by `/login/wallet/challenge/` and a "
             "valid EIP-4361 signature to authenticate the wallet holder. "
-            "Returns the same `{access, refresh}` JWT pair as the other "
-            "login flows. Nonces are single-use and expire after the "
-            "configured TTL (default 5 minutes)."
+            "Returns `{access, refresh, user}` -- the `user` object "
+            "includes `id`, `email`, `is_verified`, and `wallet_address` "
+            "so clients can hydrate without a second round-trip. Nonces "
+            "are single-use and expire after the configured TTL (default "
+            "5 minutes)."
         ),
         request=WalletLoginRequestSerializer,
         responses={200: WalletLoginResponseSerializer},
@@ -228,8 +230,18 @@ class WalletAuthLoginView(APIView):
             sanitize_log_context({"user": linked.user_id, "created": linked.created}),
         )
 
+        user = linked.user
         response_serializer = WalletLoginResponseSerializer(
-            {"access": linked.access_token, "refresh": linked.refresh_token}
+            {
+                "access": linked.access_token,
+                "refresh": linked.refresh_token,
+                "user": {
+                    "id": user.id,
+                    "email": user.email,
+                    "is_verified": user.is_verified,
+                    "wallet_address": user.wallet_address,
+                },
+            }
         )
         return Response(response_serializer.data, status=status.HTTP_200_OK)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "blockauth"
-version = "0.6.0"
+version = "0.6.1"
 description = "Comprehensive Python authentication package bridging Web2 and Web3"
 authors = [{name = "BloclabsHQ", email = "eng@bloclabs.com"}]
 license = {text = "MIT"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "blockauth"
-version = "0.5.0"
+version = "0.6.0"
 description = "Comprehensive Python authentication package bridging Web2 and Web3"
 authors = [{name = "BloclabsHQ", email = "eng@bloclabs.com"}]
 license = {text = "MIT"}

--- a/uv.lock
+++ b/uv.lock
@@ -312,7 +312,7 @@ wheels = [
 
 [[package]]
 name = "blockauth"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "argon2-cffi" },

--- a/uv.lock
+++ b/uv.lock
@@ -312,7 +312,7 @@ wheels = [
 
 [[package]]
 name = "blockauth"
-version = "0.6.0"
+version = "0.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "argon2-cffi" },


### PR DESCRIPTION
Promotes `dev` → `main` for the v0.6.0 + v0.6.1 release series.

## What's included

### v0.6.0 (#98, closes #97)
- `feat(wallet-auth)`: return user payload from wallet login response
- `refactor(serializers)`: promote `WalletLoginUserSerializer` → shared `LoginUserSerializer`
- `feat(basic-login)`: return user payload in login response
- `feat(passwordless-login)`: return user payload in login response
- OpenAPI schema corrected — basic-login spec no longer lies about response shape

### v0.6.1 (#100, closes #99)
- Credential-leak regression test (recursive) across all three login endpoints
- Null-email test strengthened: covers both auto-create and existing-user paths with DB-level assertion
- `cache.clear()` cargo-cult removed (DB-backed nonces, independent throttle scopes)
- Docstring cleanup on PR #98 views/serializers

## Downstream

- Tags `v0.6.0` and `v0.6.1` already published from `dev`
- `fabric-auth` pin bump pending (`make update-blockauth`) — tracked in fabric-auth#411
- `fabricbloc-docs` OpenAPI regen auto-triggers on this merge
- `fabricbloc-shell` consumes once fabric-auth bumps the pin