### PR TITLE
fix: ValidationErrorWithCode is a real DRF ValidationError (#101) — 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — pre-1
   - Response body for DRF's default exception handler changes from `{"detail": {"error_code": "4000", "detail": {field: message}}}` to `{field: [message]}`. The top-level code is no longer in the body when using DRF's default handler.
   - Custom exception handlers that branch on `isinstance(exc, ValidationError)` now pick up `ValidationErrorWithCode` automatically and can iterate `exc.detail` as a DRF-native field map.
   - Per-field multi-message behavior changes: the old code joined multiple error messages per field into a single space-separated string. The new class preserves DRF's list of `ErrorDetail` so per-error codes and messages are iterable individually.
+  - Scalar per-field `detail` values (e.g. `{"email": "msg"}`) are normalized into `[ErrorDetail("msg")]` on `__init__` so `.detail` always matches the `{field: [ErrorDetail, ...]}` shape. Caller-supplied `code=` now propagates to both `.error_code` and per-field wrapping so top-level and per-field codes stay consistent. Tuple per-field values and nested-serializer detail dicts are accepted when deriving `.error_code` (tuples alongside lists; nested dicts recurse to the deepest leaf).
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,23 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — pre-1
 
 ## [Unreleased]
 
+### Added
+
+### Changed
+
+### Fixed
+
+---
+
+## [0.7.0] - 2026-04-17
+
 ### Breaking Changes
 
 - **Wallet login now requires a server-issued SIWE (EIP-4361) challenge** (#90). Clients must call `POST /login/wallet/challenge/` to obtain a signed plaintext before calling `POST /login/wallet/`. The login response shape (`{access, refresh}`) is unchanged, and the error envelope is now `{"error": {"code": "...", "message": "..."}}` with distinct string codes (e.g. `invalid_signature`, `nonce_invalid`, `domain_mismatch`) for each failure mode. Consumers that were passing raw JSON-body payloads to the old endpoint must migrate to the two-round-trip flow. See the "Migration notes" section below.
+- **`ValidationErrorWithCode` now subclasses DRF's `ValidationError`** (#101). `.detail` is a DRF-native `{field: [ErrorDetail, ...]}` map; the top-level error code moves from `.detail["error_code"]` to the `.error_code` attribute on the exception instance.
+  - Response body for DRF's default exception handler changes from `{"detail": {"error_code": "4000", "detail": {field: message}}}` to `{field: [message]}`. The top-level code is no longer in the body when using DRF's default handler.
+  - Custom exception handlers that branch on `isinstance(exc, ValidationError)` now pick up `ValidationErrorWithCode` automatically and can iterate `exc.detail` as a DRF-native field map.
+  - Per-field multi-message behavior changes: the old code joined multiple error messages per field into a single space-separated string. The new class preserves DRF's list of `ErrorDetail` so per-error codes and messages are iterable individually.
 
 ### Added
 
@@ -42,6 +56,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — pre-1
 - Set `WALLET_LOGIN_EXPECTED_DOMAINS` in production Django settings (the hard-failing startup check fires on `DEBUG=False` deployments without one).
 - Update wallet-login clients to call `POST /login/wallet/challenge/` first, sign the returned `message` verbatim with the wallet's private key, and post `{wallet_address, message, signature}` to `POST /login/wallet/`.
 - Schedule `python manage.py prune_wallet_nonces` every 5–15 minutes (Celery Beat, cron, or systemd timer).
+- If your service uses a custom DRF `EXCEPTION_HANDLER` that special-cases `ValidationErrorWithCode` by reading `exc.detail["error_code"]` or `exc.detail["detail"]`, switch to reading `exc.error_code` and iterating `exc.detail` as a standard DRF field map. If your service relies on DRF's default handler and was parsing the legacy envelope, switch to the DRF-native `{field: [message]}` shape (#101).
 
 ---
 

--- a/blockauth/__init__.py
+++ b/blockauth/__init__.py
@@ -28,7 +28,7 @@ Static utilities (no storage needed):
     backup_codes = TOTPService.generate_backup_codes()
 """
 
-__version__ = "0.6.1"
+__version__ = "0.7.0"
 
 # =============================================================================
 # Direct imports (Django-independent, no AppRegistryNotReady errors)

--- a/blockauth/utils/custom_exception.py
+++ b/blockauth/utils/custom_exception.py
@@ -1,4 +1,4 @@
-from rest_framework.exceptions import APIException
+from rest_framework.exceptions import APIException, ValidationError
 
 
 class WalletConflictError(APIException):
@@ -9,27 +9,31 @@ class WalletConflictError(APIException):
     default_code = "WALLET_IN_USE"
 
 
-class ValidationErrorWithCode(APIException):
-    status_code = 400
+class ValidationErrorWithCode(ValidationError):
+    """DRF ``ValidationError`` with a top-level error-code attribute for legacy envelopes.
+
+    ``.detail`` is DRF-native ``{field: [ErrorDetail, ...]}`` — untransformed.
+    ``.error_code`` carries a single top-level code (convenience for handlers
+    that want to tag the whole response, not just individual fields).
+
+    Subclassing ``ValidationError`` means ``isinstance(exc, ValidationError)``
+    checks in downstream exception handlers pick this up automatically and
+    can iterate ``.detail`` as a standard DRF field map.
+    """
+
     default_code = "4000"
 
     def __init__(self, detail=None, code=None):
-        errors = list(detail.values())[0]
-        error_code = errors[0].code if isinstance(errors, list) else errors.code
-
-        if code is None:
-            code = self.default_code if error_code == "required" else error_code
         if detail is None:
-            detail = {"non_field_errors": "A validation error occurred. Please check your input and try again."}
+            detail = {"non_field_errors": ["A validation error occurred. Please check your input and try again."]}
+        self.error_code = code if code is not None else self._derive_error_code(detail)
+        super().__init__(detail, code=None)
 
-        transformed_detail = self.transform_errors(detail)
-        super().__init__({"error_code": code, "detail": transformed_detail})
-
-    def transform_errors(self, errors):
-        transformed = {}
-        for field, messages in errors.items():
-            if isinstance(messages, list):
-                transformed[field] = " ".join(messages)  # Join multiple errors
-            else:
-                transformed[field] = str(messages)  # Convert non-list errors
-        return transformed
+    @staticmethod
+    def _derive_error_code(detail):
+        if not isinstance(detail, dict) or not detail:
+            return ValidationErrorWithCode.default_code
+        first_field = next(iter(detail.values()))
+        first_err = first_field[0] if isinstance(first_field, list) and first_field else first_field
+        err_code = getattr(first_err, "code", None)
+        return ValidationErrorWithCode.default_code if err_code in (None, "required") else err_code

--- a/blockauth/utils/custom_exception.py
+++ b/blockauth/utils/custom_exception.py
@@ -19,6 +19,10 @@ class ValidationErrorWithCode(ValidationError):
     Subclassing ``ValidationError`` means ``isinstance(exc, ValidationError)``
     checks in downstream exception handlers pick this up automatically and
     can iterate ``.detail`` as a standard DRF field map.
+
+    When a caller passes ``code=``, it is both stored on ``.error_code`` and
+    propagated to DRF's per-field wrapping so scalar ``detail`` values get
+    the same code at every level.
     """
 
     default_code = "4000"
@@ -26,14 +30,23 @@ class ValidationErrorWithCode(ValidationError):
     def __init__(self, detail=None, code=None):
         if detail is None:
             detail = {"non_field_errors": ["A validation error occurred. Please check your input and try again."]}
+        if isinstance(detail, dict):
+            detail = {k: v if isinstance(v, (list, tuple, dict)) else [v] for k, v in detail.items()}
         self.error_code = code if code is not None else self._derive_error_code(detail)
-        super().__init__(detail, code=None)
+        super().__init__(detail, code=code)
 
-    @staticmethod
-    def _derive_error_code(detail):
+    @classmethod
+    def _derive_error_code(cls, detail):
         if not isinstance(detail, dict) or not detail:
-            return ValidationErrorWithCode.default_code
+            return cls.default_code
         first_field = next(iter(detail.values()))
-        first_err = first_field[0] if isinstance(first_field, list) and first_field else first_field
+        if isinstance(first_field, dict):
+            return cls._derive_error_code(first_field)
+        if isinstance(first_field, (list, tuple)) and first_field:
+            first_err = first_field[0]
+        elif isinstance(first_field, (list, tuple)):
+            first_err = None
+        else:
+            first_err = first_field
         err_code = getattr(first_err, "code", None)
-        return ValidationErrorWithCode.default_code if err_code in (None, "required") else err_code
+        return cls.default_code if err_code in (None, "required") else err_code

--- a/blockauth/utils/tests/test_validation_error_with_code.py
+++ b/blockauth/utils/tests/test_validation_error_with_code.py
@@ -25,17 +25,13 @@ def test_isinstance_check_passes_for_raised_instance():
     """Behavioral form of the subclass contract — catching
     `ValidationError` MUST catch `ValidationErrorWithCode`."""
     with pytest.raises(ValidationError) as exc_info:
-        raise ValidationErrorWithCode(
-            detail={"email": [ErrorDetail("required", code="required")]}
-        )
+        raise ValidationErrorWithCode(detail={"email": [ErrorDetail("required", code="required")]})
     assert isinstance(exc_info.value, ValidationErrorWithCode)
 
 
 def test_detail_is_drf_native_field_map():
     """No flatten — `.detail[field]` stays a list of `ErrorDetail`."""
-    exc = ValidationErrorWithCode(
-        detail={"password": [ErrorDetail("too short", code="min_length")]}
-    )
+    exc = ValidationErrorWithCode(detail={"password": [ErrorDetail("too short", code="min_length")]})
     assert isinstance(exc.detail, dict)
     assert isinstance(exc.detail["password"], list)
     assert exc.detail["password"][0] == "too short"
@@ -43,17 +39,13 @@ def test_detail_is_drf_native_field_map():
 
 
 def test_error_code_derived_from_first_field_code():
-    exc = ValidationErrorWithCode(
-        detail={"email": [ErrorDetail("bad address", code="invalid")]}
-    )
+    exc = ValidationErrorWithCode(detail={"email": [ErrorDetail("bad address", code="invalid")]})
     assert exc.error_code == "invalid"
 
 
 def test_error_code_required_maps_to_4000():
     """`code="required"` is treated as the default-code sentinel."""
-    exc = ValidationErrorWithCode(
-        detail={"email": [ErrorDetail("This field is required.", code="required")]}
-    )
+    exc = ValidationErrorWithCode(detail={"email": [ErrorDetail("This field is required.", code="required")]})
     assert exc.error_code == "4000"
 
 
@@ -106,9 +98,7 @@ def test_multi_message_per_field_preserved_as_list():
 
 
 def test_status_code_is_400():
-    exc = ValidationErrorWithCode(
-        detail={"email": [ErrorDetail("required", code="required")]}
-    )
+    exc = ValidationErrorWithCode(detail={"email": [ErrorDetail("required", code="required")]})
     assert exc.status_code == 400
 
 
@@ -116,9 +106,7 @@ def test_default_drf_handler_renders_field_map():
     """Locks in the new wire contract: DRF's default exception_handler
     renders `{field: [message]}` without the legacy `{"detail": ...}`
     outer wrap."""
-    exc = ValidationErrorWithCode(
-        detail={"password": [ErrorDetail("This field is required.", code="required")]}
-    )
+    exc = ValidationErrorWithCode(detail={"password": [ErrorDetail("This field is required.", code="required")]})
     response = exception_handler(exc, context={})
     assert response is not None
     assert response.status_code == 400

--- a/blockauth/utils/tests/test_validation_error_with_code.py
+++ b/blockauth/utils/tests/test_validation_error_with_code.py
@@ -78,6 +78,40 @@ def test_default_detail_when_none_passed():
     # DRF wraps scalar strings into `[ErrorDetail(...)]` during __init__.
     assert isinstance(exc.detail["non_field_errors"], list)
     assert "validation error" in str(exc.detail["non_field_errors"][0]).lower()
+    # Wrapped ErrorDetail carries the default code so per-field and
+    # top-level `error_code` stay consistent.
+    assert exc.detail["non_field_errors"][0].code == "4000"
+
+
+def test_scalar_per_field_is_normalized_to_list():
+    """Raw scalars per field are wrapped into ``[ErrorDetail(...)]`` so
+    ``.detail`` always matches DRF's ``{field: [ErrorDetail, ...]}`` shape."""
+    exc = ValidationErrorWithCode(detail={"email": "raw string"})
+    assert isinstance(exc.detail["email"], list)
+    assert len(exc.detail["email"]) == 1
+    assert str(exc.detail["email"][0]) == "raw string"
+
+
+def test_explicit_code_propagates_to_per_field_errordetail():
+    """When ``code=`` is passed, it applies to both ``.error_code`` and the
+    per-field wrapping for scalar detail values — no silent split between
+    top-level and per-field codes."""
+    exc = ValidationErrorWithCode(detail={"email": "raw"}, code="4042")
+    assert exc.error_code == "4042"
+    assert exc.detail["email"][0].code == "4042"
+
+
+def test_tuple_per_field_derives_code_from_first_element():
+    """DRF sometimes passes tuples; derivation must accept them alongside lists."""
+    exc = ValidationErrorWithCode(detail={"email": (ErrorDetail("bad", code="invalid"),)})
+    assert exc.error_code == "invalid"
+
+
+def test_nested_dict_recurses_for_error_code():
+    """Nested-serializer validation errors ``{parent: {child: [ErrorDetail]}}``
+    recurse so the deepest code surfaces, not the default."""
+    exc = ValidationErrorWithCode(detail={"user": {"email": [ErrorDetail("bad", code="invalid")]}})
+    assert exc.error_code == "invalid"
 
 
 def test_multi_message_per_field_preserved_as_list():

--- a/blockauth/utils/tests/test_validation_error_with_code.py
+++ b/blockauth/utils/tests/test_validation_error_with_code.py
@@ -1,0 +1,125 @@
+"""Tests for `ValidationErrorWithCode` — the DRF-native upstream fix for #101.
+
+These tests lock in the contract that `ValidationErrorWithCode`:
+  * is a real `rest_framework.exceptions.ValidationError` subclass
+    (so downstream `isinstance` and field-map iteration work without
+    special-casing), and
+  * exposes the legacy numeric top-level code as `.error_code` (a fresh
+    instance attribute) while leaving `.detail` as DRF-native
+    `{field: [ErrorDetail, ...]}`.
+"""
+
+import pytest
+from rest_framework.exceptions import ErrorDetail, ValidationError
+from rest_framework.views import exception_handler
+
+from blockauth.utils.custom_exception import ValidationErrorWithCode
+
+
+def test_is_subclass_of_drf_validation_error():
+    """Regressing this line re-introduces auth-pack#101."""
+    assert issubclass(ValidationErrorWithCode, ValidationError)
+
+
+def test_isinstance_check_passes_for_raised_instance():
+    """Behavioral form of the subclass contract — catching
+    `ValidationError` MUST catch `ValidationErrorWithCode`."""
+    with pytest.raises(ValidationError) as exc_info:
+        raise ValidationErrorWithCode(
+            detail={"email": [ErrorDetail("required", code="required")]}
+        )
+    assert isinstance(exc_info.value, ValidationErrorWithCode)
+
+
+def test_detail_is_drf_native_field_map():
+    """No flatten — `.detail[field]` stays a list of `ErrorDetail`."""
+    exc = ValidationErrorWithCode(
+        detail={"password": [ErrorDetail("too short", code="min_length")]}
+    )
+    assert isinstance(exc.detail, dict)
+    assert isinstance(exc.detail["password"], list)
+    assert exc.detail["password"][0] == "too short"
+    assert exc.detail["password"][0].code == "min_length"
+
+
+def test_error_code_derived_from_first_field_code():
+    exc = ValidationErrorWithCode(
+        detail={"email": [ErrorDetail("bad address", code="invalid")]}
+    )
+    assert exc.error_code == "invalid"
+
+
+def test_error_code_required_maps_to_4000():
+    """`code="required"` is treated as the default-code sentinel."""
+    exc = ValidationErrorWithCode(
+        detail={"email": [ErrorDetail("This field is required.", code="required")]}
+    )
+    assert exc.error_code == "4000"
+
+
+def test_error_code_explicit_overrides_derivation():
+    exc = ValidationErrorWithCode(
+        detail={"email": [ErrorDetail("bad", code="invalid")]},
+        code="4042",
+    )
+    assert exc.error_code == "4042"
+
+
+def test_error_code_falls_back_to_default_for_bare_strings():
+    """A field value that's a plain string (not an ErrorDetail/list) must
+    not blow up derivation — the old implementation called `.code` on it
+    and crashed."""
+    exc = ValidationErrorWithCode(detail={"email": "raw string with no code"})
+    assert exc.error_code == "4000"
+
+
+def test_error_code_falls_back_to_default_for_empty_detail():
+    """An empty dict must not `StopIteration` through `next(iter(...))`."""
+    exc = ValidationErrorWithCode(detail={})
+    assert exc.error_code == "4000"
+
+
+def test_default_detail_when_none_passed():
+    exc = ValidationErrorWithCode()
+    assert exc.error_code == "4000"
+    assert "non_field_errors" in exc.detail
+    # DRF wraps scalar strings into `[ErrorDetail(...)]` during __init__.
+    assert isinstance(exc.detail["non_field_errors"], list)
+    assert "validation error" in str(exc.detail["non_field_errors"][0]).lower()
+
+
+def test_multi_message_per_field_preserved_as_list():
+    """Old class joined multiple messages per field into a single
+    space-separated string. New class preserves DRF's list — per-error
+    codes and messages stay iterable individually."""
+    exc = ValidationErrorWithCode(
+        detail={
+            "password": [
+                ErrorDetail("too short", code="min_length"),
+                ErrorDetail("needs a digit", code="no_digit"),
+            ]
+        }
+    )
+    assert len(exc.detail["password"]) == 2
+    assert exc.detail["password"][0].code == "min_length"
+    assert exc.detail["password"][1].code == "no_digit"
+
+
+def test_status_code_is_400():
+    exc = ValidationErrorWithCode(
+        detail={"email": [ErrorDetail("required", code="required")]}
+    )
+    assert exc.status_code == 400
+
+
+def test_default_drf_handler_renders_field_map():
+    """Locks in the new wire contract: DRF's default exception_handler
+    renders `{field: [message]}` without the legacy `{"detail": ...}`
+    outer wrap."""
+    exc = ValidationErrorWithCode(
+        detail={"password": [ErrorDetail("This field is required.", code="required")]}
+    )
+    response = exception_handler(exc, context={})
+    assert response is not None
+    assert response.status_code == 400
+    assert response.data == {"password": ["This field is required."]}

--- a/docs/superpowers/plans/2026-04-17-validation-error-with-code.md
+++ b/docs/superpowers/plans/2026-04-17-validation-error-with-code.md
@@ -1,0 +1,483 @@
+# `ValidationErrorWithCode` DRF-native subclass — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `blockauth.utils.custom_exception.ValidationErrorWithCode` a real DRF `ValidationError` subclass so downstream `isinstance(exc, ValidationError)` checks fire and `.detail` is a DRF-native `{field: [ErrorDetail, ...]}` map; promote the top-level numeric code to an `.error_code` attribute.
+
+**Architecture:** Single-file behavior change (`blockauth/utils/custom_exception.py`) plus a dedicated test module that locks in the contract. Breaking wire change for consumers using DRF's default handler; fixed with a 0.7.0 minor bump, CHANGELOG entry, and no compat shim.
+
+**Tech Stack:** Python 3.12, Django REST Framework (`rest_framework.exceptions.ValidationError`, `ErrorDetail`), pytest, uv, black/isort/flake8.
+
+**Spec:** `docs/superpowers/specs/2026-04-17-validation-error-with-code-design.md`
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `blockauth/utils/tests/test_validation_error_with_code.py` | Create | 12 tests — locks in subclass contract, `.detail` preservation, `.error_code` derivation, wire body |
+| `blockauth/utils/custom_exception.py` | Modify | Rewrite `ValidationErrorWithCode` to subclass `ValidationError`; add `_derive_error_code` static helper |
+| `CHANGELOG.md` | Modify | Add Breaking Changes + Migration notes entries under `[Unreleased]` |
+| `pyproject.toml` | Modify | Bump `version = "0.7.0"` |
+| `blockauth/__init__.py` | Modify | Bump `__version__ = "0.7.0"` |
+
+---
+
+## Task 1: Write the failing test file
+
+**Files:**
+- Create: `blockauth/utils/tests/test_validation_error_with_code.py`
+
+- [ ] **Step 1: Create the test file with all 12 tests**
+
+Path: `blockauth/utils/tests/test_validation_error_with_code.py`
+
+```python
+"""Tests for `ValidationErrorWithCode` — the DRF-native upstream fix for #101.
+
+These tests lock in the contract that `ValidationErrorWithCode`:
+  * is a real `rest_framework.exceptions.ValidationError` subclass
+    (so downstream `isinstance` and field-map iteration work without
+    special-casing), and
+  * exposes the legacy numeric top-level code as `.error_code` (a fresh
+    instance attribute) while leaving `.detail` as DRF-native
+    `{field: [ErrorDetail, ...]}`.
+"""
+
+import pytest
+from rest_framework.exceptions import ErrorDetail, ValidationError
+from rest_framework.views import exception_handler
+
+from blockauth.utils.custom_exception import ValidationErrorWithCode
+
+
+def test_is_subclass_of_drf_validation_error():
+    """Regressing this line re-introduces auth-pack#101."""
+    assert issubclass(ValidationErrorWithCode, ValidationError)
+
+
+def test_isinstance_check_passes_for_raised_instance():
+    """Behavioral form of the subclass contract — catching
+    `ValidationError` MUST catch `ValidationErrorWithCode`."""
+    with pytest.raises(ValidationError) as exc_info:
+        raise ValidationErrorWithCode(
+            detail={"email": [ErrorDetail("required", code="required")]}
+        )
+    assert isinstance(exc_info.value, ValidationErrorWithCode)
+
+
+def test_detail_is_drf_native_field_map():
+    """No flatten — `.detail[field]` stays a list of `ErrorDetail`."""
+    exc = ValidationErrorWithCode(
+        detail={"password": [ErrorDetail("too short", code="min_length")]}
+    )
+    assert isinstance(exc.detail, dict)
+    assert isinstance(exc.detail["password"], list)
+    assert exc.detail["password"][0] == "too short"
+    assert exc.detail["password"][0].code == "min_length"
+
+
+def test_error_code_derived_from_first_field_code():
+    exc = ValidationErrorWithCode(
+        detail={"email": [ErrorDetail("bad address", code="invalid")]}
+    )
+    assert exc.error_code == "invalid"
+
+
+def test_error_code_required_maps_to_4000():
+    """`code="required"` is treated as the default-code sentinel."""
+    exc = ValidationErrorWithCode(
+        detail={"email": [ErrorDetail("This field is required.", code="required")]}
+    )
+    assert exc.error_code == "4000"
+
+
+def test_error_code_explicit_overrides_derivation():
+    exc = ValidationErrorWithCode(
+        detail={"email": [ErrorDetail("bad", code="invalid")]},
+        code="4042",
+    )
+    assert exc.error_code == "4042"
+
+
+def test_error_code_falls_back_to_default_for_bare_strings():
+    """A field value that's a plain string (not an ErrorDetail/list) must
+    not blow up derivation — the old implementation called `.code` on it
+    and crashed."""
+    exc = ValidationErrorWithCode(detail={"email": "raw string with no code"})
+    assert exc.error_code == "4000"
+
+
+def test_error_code_falls_back_to_default_for_empty_detail():
+    """An empty dict must not `StopIteration` through `next(iter(...))`."""
+    exc = ValidationErrorWithCode(detail={})
+    assert exc.error_code == "4000"
+
+
+def test_default_detail_when_none_passed():
+    exc = ValidationErrorWithCode()
+    assert exc.error_code == "4000"
+    assert "non_field_errors" in exc.detail
+    # DRF wraps scalar strings into `[ErrorDetail(...)]` during __init__.
+    assert isinstance(exc.detail["non_field_errors"], list)
+    assert "validation error" in str(exc.detail["non_field_errors"][0]).lower()
+
+
+def test_multi_message_per_field_preserved_as_list():
+    """Old class joined multiple messages per field into a single
+    space-separated string. New class preserves DRF's list — per-error
+    codes and messages stay iterable individually."""
+    exc = ValidationErrorWithCode(
+        detail={
+            "password": [
+                ErrorDetail("too short", code="min_length"),
+                ErrorDetail("needs a digit", code="no_digit"),
+            ]
+        }
+    )
+    assert len(exc.detail["password"]) == 2
+    assert exc.detail["password"][0].code == "min_length"
+    assert exc.detail["password"][1].code == "no_digit"
+
+
+def test_status_code_is_400():
+    exc = ValidationErrorWithCode(
+        detail={"email": [ErrorDetail("required", code="required")]}
+    )
+    assert exc.status_code == 400
+
+
+def test_default_drf_handler_renders_field_map():
+    """Locks in the new wire contract: DRF's default exception_handler
+    renders `{field: [message]}` without the legacy `{"detail": ...}`
+    outer wrap."""
+    exc = ValidationErrorWithCode(
+        detail={"password": [ErrorDetail("This field is required.", code="required")]}
+    )
+    response = exception_handler(exc, context={})
+    assert response is not None
+    assert response.status_code == 400
+    assert response.data == {"password": ["This field is required."]}
+```
+
+- [ ] **Step 2: Run the new tests and verify they fail**
+
+```bash
+uv run pytest blockauth/utils/tests/test_validation_error_with_code.py -v
+```
+
+Expected: most tests FAIL (notably `test_is_subclass_of_drf_validation_error`, `test_isinstance_check_passes_for_raised_instance`, `test_detail_is_drf_native_field_map`, `test_default_drf_handler_renders_field_map`). `test_status_code_is_400` may pass incidentally because the old class already has `status_code = 400`.
+
+This failure set confirms the tests exercise the new contract. If everything passes on the old class, the tests aren't specific enough — stop and rewrite them.
+
+- [ ] **Step 3: Commit the failing tests**
+
+```bash
+git add blockauth/utils/tests/test_validation_error_with_code.py
+git commit -m "test(custom_exception): add failing tests for DRF-native ValidationErrorWithCode (#101)"
+```
+
+---
+
+## Task 2: Rewrite `ValidationErrorWithCode`
+
+**Files:**
+- Modify: `blockauth/utils/custom_exception.py`
+
+- [ ] **Step 1: Read the current file**
+
+```bash
+cat blockauth/utils/custom_exception.py
+```
+
+The file currently has `WalletConflictError(APIException)` (keep as-is) and the legacy `ValidationErrorWithCode(APIException)` (replace).
+
+- [ ] **Step 2: Replace the full file contents**
+
+```python
+from rest_framework.exceptions import APIException, ValidationError
+
+
+class WalletConflictError(APIException):
+    """Raised when a wallet address is already linked to a different account (HTTP 409)."""
+
+    status_code = 409
+    default_detail = "This wallet address is already linked to another account."
+    default_code = "WALLET_IN_USE"
+
+
+class ValidationErrorWithCode(ValidationError):
+    """DRF ``ValidationError`` with a top-level error-code attribute for legacy envelopes.
+
+    ``.detail`` is DRF-native ``{field: [ErrorDetail, ...]}`` — untransformed.
+    ``.error_code`` carries a single top-level code (convenience for handlers
+    that want to tag the whole response, not just individual fields).
+
+    Subclassing ``ValidationError`` means ``isinstance(exc, ValidationError)``
+    checks in downstream exception handlers pick this up automatically and
+    can iterate ``.detail`` as a standard DRF field map.
+    """
+
+    default_code = "4000"
+
+    def __init__(self, detail=None, code=None):
+        if detail is None:
+            detail = {
+                "non_field_errors": "A validation error occurred. Please check your input and try again."
+            }
+        self.error_code = code if code is not None else self._derive_error_code(detail)
+        super().__init__(detail, code=None)
+
+    @staticmethod
+    def _derive_error_code(detail):
+        if not isinstance(detail, dict) or not detail:
+            return ValidationErrorWithCode.default_code
+        first_field = next(iter(detail.values()))
+        first_err = first_field[0] if isinstance(first_field, list) and first_field else first_field
+        err_code = getattr(first_err, "code", None)
+        return ValidationErrorWithCode.default_code if err_code in (None, "required") else err_code
+```
+
+- [ ] **Step 3: Run the new tests and verify they pass**
+
+```bash
+uv run pytest blockauth/utils/tests/test_validation_error_with_code.py -v
+```
+
+Expected: all 12 tests PASS.
+
+If any fail, read the failure output against the spec's contract table (§Behavioral contract) and the `_derive_error_code` trace. Do NOT adjust the tests to match a broken implementation — fix the implementation.
+
+---
+
+## Task 3: Run the full suite and triage regressions
+
+**Files:** potentially any test that implicitly asserted on the old `{"detail": {"error_code": ..., "detail": ...}}` envelope.
+
+- [ ] **Step 1: Run the full test suite**
+
+```bash
+uv run pytest blockauth/ -q
+```
+
+Expected: all tests PASS. A pre-spec grep confirmed no view/unit tests assert on the legacy body envelope (`response.data["detail"]["error_code"]` appears in zero test files), so regressions are unlikely.
+
+- [ ] **Step 2: If any test fails, triage**
+
+For each failure:
+
+1. Confirm the failure is a shape change caused by this fix (assertion on `.detail["error_code"]`, `.detail["detail"]`, or a single-string-per-field body) — not an unrelated bug.
+2. Update the assertion to the new contract:
+   - `exc.detail["error_code"]` → `exc.error_code`
+   - `exc.detail["detail"][<field>]` → `exc.detail[<field>]`
+   - `response.data["detail"]["detail"][<field>] == "msg"` → `response.data[<field>] == ["msg"]`
+3. Rerun the single test until green.
+
+Only update failing tests — do not sweep the test suite for other edits.
+
+- [ ] **Step 3: Rerun the full suite to confirm green**
+
+```bash
+uv run pytest blockauth/ -q
+```
+
+Expected: all tests PASS.
+
+---
+
+## Task 4: Lint and commit the core fix
+
+**Files:** none new.
+
+- [ ] **Step 1: Format with black and isort**
+
+```bash
+uv run black blockauth/utils/custom_exception.py blockauth/utils/tests/test_validation_error_with_code.py
+uv run isort blockauth/utils/custom_exception.py blockauth/utils/tests/test_validation_error_with_code.py
+```
+
+Expected: both commands succeed; may reformat imports/whitespace.
+
+- [ ] **Step 2: Lint the whole package**
+
+```bash
+uv run flake8 blockauth/
+```
+
+Expected: exit code 0, no warnings.
+
+- [ ] **Step 3: Commit the fix**
+
+```bash
+git add blockauth/utils/custom_exception.py blockauth/utils/tests/test_validation_error_with_code.py
+# If Task 3 triaged any regressions, add those test files too.
+git commit -m "fix(custom_exception): ValidationErrorWithCode subclasses DRF ValidationError (#101)
+
+Closes #101.
+
+- ValidationErrorWithCode now inherits from rest_framework.exceptions.ValidationError,
+  so downstream isinstance(exc, ValidationError) checks fire and .detail is a
+  DRF-native {field: [ErrorDetail, ...]} map.
+- The top-level numeric error code moves from .detail[\"error_code\"] to the
+  .error_code instance attribute.
+- Per-field multi-message behavior changes: DRF's list of ErrorDetail is
+  preserved (old code joined messages into a single space-separated string).
+
+Breaking wire change for consumers using DRF's default handler — see
+CHANGELOG Breaking Changes + Migration notes."
+```
+
+---
+
+## Task 5: Update CHANGELOG
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Read the current `[Unreleased]` section**
+
+```bash
+sed -n '1,50p' CHANGELOG.md
+```
+
+- [ ] **Step 2: Add a Breaking Changes bullet under `[Unreleased]`**
+
+Open `CHANGELOG.md`. Under `## [Unreleased]` → `### Breaking Changes`, append a new bullet (after any existing bullets, before `### Added`):
+
+```markdown
+- **`ValidationErrorWithCode` now subclasses DRF's `ValidationError`** (#101). `.detail` is a DRF-native `{field: [ErrorDetail, ...]}` map; the top-level error code moves from `.detail["error_code"]` to the `.error_code` attribute on the exception instance.
+  - Response body for DRF's default exception handler changes from `{"detail": {"error_code": "4000", "detail": {field: message}}}` to `{field: [message]}`. The top-level code is no longer in the body when using DRF's default handler.
+  - Custom exception handlers that branch on `isinstance(exc, ValidationError)` now pick up `ValidationErrorWithCode` automatically and can iterate `exc.detail` as a DRF-native field map.
+  - Per-field multi-message behavior changes: the old code joined multiple error messages per field into a single space-separated string. The new class preserves DRF's list of `ErrorDetail` so per-error codes and messages are iterable individually.
+```
+
+- [ ] **Step 3: Append a bullet to the `### Migration notes` list under `[Unreleased]`**
+
+```markdown
+- If your service uses a custom DRF `EXCEPTION_HANDLER` that special-cases `ValidationErrorWithCode` by reading `exc.detail["error_code"]` or `exc.detail["detail"]`, switch to reading `exc.error_code` and iterating `exc.detail` as a standard DRF field map. If your service relies on DRF's default handler and was parsing the legacy envelope, switch to the DRF-native `{field: [message]}` shape (#101).
+```
+
+- [ ] **Step 4: Sanity-check the diff**
+
+```bash
+git diff CHANGELOG.md
+```
+
+Confirm both entries land under `[Unreleased]` and the formatting matches surrounding bullets.
+
+---
+
+## Task 6: Bump version to 0.7.0
+
+**Files:**
+- Modify: `pyproject.toml`
+- Modify: `blockauth/__init__.py`
+
+- [ ] **Step 1: Bump `pyproject.toml`**
+
+Open `pyproject.toml`, change line 3 from:
+
+```toml
+version = "0.6.1"
+```
+
+to:
+
+```toml
+version = "0.7.0"
+```
+
+- [ ] **Step 2: Bump `blockauth/__init__.py`**
+
+Open `blockauth/__init__.py`, change the `__version__` line from:
+
+```python
+__version__ = "0.6.1"
+```
+
+to:
+
+```python
+__version__ = "0.7.0"
+```
+
+- [ ] **Step 3: Cut `[Unreleased]` → `[0.7.0] - 2026-04-17` in `CHANGELOG.md`**
+
+Rename the `## [Unreleased]` header to `## [0.7.0] - 2026-04-17`. Add a fresh empty `## [Unreleased]` section above it (with empty `### Added`, `### Changed`, `### Fixed` subsections ready for the next release).
+
+- [ ] **Step 4: Verify versions match and package imports**
+
+```bash
+uv run python -c "import blockauth; print(blockauth.__version__)"
+grep '^version' pyproject.toml
+```
+
+Expected: both print `0.7.0`.
+
+- [ ] **Step 5: Commit the release prep**
+
+```bash
+git add pyproject.toml blockauth/__init__.py CHANGELOG.md
+git commit -m "chore(release): bump version to 0.7.0
+
+Breaking: #101 — ValidationErrorWithCode is now a DRF ValidationError
+subclass; .detail shape and default response body change. See CHANGELOG
+Breaking Changes + Migration notes."
+```
+
+---
+
+## Task 7: Final verification
+
+**Files:** none.
+
+- [ ] **Step 1: Re-run the full suite**
+
+```bash
+uv run pytest blockauth/ -q
+```
+
+Expected: all PASS.
+
+- [ ] **Step 2: Re-run lint**
+
+```bash
+uv run black --check blockauth/
+uv run isort --check-only blockauth/
+uv run flake8 blockauth/
+```
+
+Expected: all exit 0.
+
+- [ ] **Step 3: Confirm downstream breakage surface is the one described**
+
+```bash
+grep -rn 'exc\.detail\["error_code"\]\|response\.data\["detail"\]\["detail"\]' blockauth/ tests/
+```
+
+Expected: no matches. If anything shows up, it's either a forgotten legacy assertion (update to the new shape) or a runtime consumer path we missed (reopen Task 3).
+
+- [ ] **Step 4: Sanity-check the commit history**
+
+```bash
+git log --oneline dev..HEAD
+```
+
+Expected three commits in order:
+
+1. `test(custom_exception): add failing tests for DRF-native ValidationErrorWithCode (#101)`
+2. `fix(custom_exception): ValidationErrorWithCode subclasses DRF ValidationError (#101)`
+3. `chore(release): bump version to 0.7.0`
+
+- [ ] **Step 5: Push and open PR — STOP HERE and confirm with the user before running this step**
+
+Do NOT push or open the PR autonomously. Tagging `v0.7.0` triggers `publish.yml` and cuts a GitHub Release — a cross-service visible action. Surface the diff summary to the user and let them decide when to push.
+
+```bash
+# For the user to run when they're ready:
+git push -u origin HEAD
+gh pr create --base dev --title "fix: ValidationErrorWithCode is a real DRF ValidationError (#101) — 0.7.0" --body "..."
+```
+
+After the PR merges to `dev`, the maintainer tags `v0.7.0` and pushes the tag separately to trigger the publish workflow (per the release flow in the spec).

--- a/docs/superpowers/specs/2026-04-17-validation-error-with-code-design.md
+++ b/docs/superpowers/specs/2026-04-17-validation-error-with-code-design.md
@@ -1,0 +1,200 @@
+# `ValidationErrorWithCode` — DRF-native subclass (upstream fix for #101)
+
+**Date:** 2026-04-17
+**Issue:** [auth-pack#101](https://github.com/BloclabsHQ/auth-pack/issues/101)
+**Downstream context:** [fabric-auth#412](https://github.com/BloclabsHQ/fabric-auth/issues/412), [fabric-auth#417](https://github.com/BloclabsHQ/fabric-auth/pull/417) (workaround already shipped)
+
+---
+
+## Problem
+
+`blockauth.utils.custom_exception.ValidationErrorWithCode` currently inherits from DRF's `APIException`, not from `rest_framework.exceptions.ValidationError`. Every consumer whose custom `EXCEPTION_HANDLER` branches on `isinstance(exc, ValidationError)` misses it, and field-level validation errors fall through to a generic 500-flavored envelope.
+
+fabric-auth hit this on every signup and shipped a local workaround (PR #417). Every new consumer will hit the same paper cut.
+
+A secondary concern: the current class flattens DRF's native `{field: [ErrorDetail, ...]}` shape into `{field: "space-joined message"}`, destroying per-error codes and per-error messages. This makes `ValidationErrorWithCode` misrepresent DRF's type contract even if inheritance were fixed.
+
+## Goal
+
+Make `ValidationErrorWithCode` an honest DRF `ValidationError` subclass so downstream `isinstance` and field-map iteration work without special-casing, and preserve DRF's native per-field list-of-`ErrorDetail` shape so per-error codes survive to the handler.
+
+## Non-goals
+
+- **Do not ship a blockauth exception handler.** Consumers keep owning their own response envelopes.
+- **Do not rename the class.** All 17 callsites use `ValidationErrorWithCode` by name; the rename churn isn't worth the cosmetic win.
+- **Do not ship a compat shim / feature flag for the old body shape.** Pre-1.0, the breaking-change policy (`.github/CONTRIBUTING.md`) explicitly allows breaking changes on minor bumps with a CHANGELOG entry. Two code paths forever is the tech debt we're trying to avoid.
+
+---
+
+## Design
+
+### Class surface
+
+```python
+# blockauth/utils/custom_exception.py
+from rest_framework.exceptions import APIException, ValidationError
+
+
+class WalletConflictError(APIException):
+    """Raised when a wallet address is already linked to a different account (HTTP 409)."""
+
+    status_code = 409
+    default_detail = "This wallet address is already linked to another account."
+    default_code = "WALLET_IN_USE"
+
+
+class ValidationErrorWithCode(ValidationError):
+    """DRF ValidationError with a top-level error-code attribute for legacy envelopes.
+
+    `.detail` is DRF-native `{field: [ErrorDetail, ...]}` — untransformed.
+    `.error_code` carries a single top-level code (convenience for handlers
+    that want to tag the whole response, not just individual fields).
+
+    Subclassing `ValidationError` means `isinstance(exc, ValidationError)`
+    checks in downstream exception handlers pick this up automatically and
+    can iterate `.detail` as a standard DRF field map.
+    """
+
+    default_code = "4000"
+
+    def __init__(self, detail=None, code=None):
+        if detail is None:
+            detail = {
+                "non_field_errors": "A validation error occurred. Please check your input and try again."
+            }
+        self.error_code = code if code is not None else self._derive_error_code(detail)
+        super().__init__(detail, code=None)
+
+    @staticmethod
+    def _derive_error_code(detail):
+        if not isinstance(detail, dict) or not detail:
+            return ValidationErrorWithCode.default_code
+        first_field = next(iter(detail.values()))
+        first_err = first_field[0] if isinstance(first_field, list) and first_field else first_field
+        err_code = getattr(first_err, "code", None)
+        return ValidationErrorWithCode.default_code if err_code in (None, "required") else err_code
+```
+
+### Behavioral contract
+
+| Aspect | Before | After |
+|---|---|---|
+| Base class | `APIException` | `ValidationError` |
+| `isinstance(exc, ValidationError)` | `False` | `True` |
+| `.detail` shape | `{"error_code": "4000", "detail": {field: "joined string"}}` | `{field: [ErrorDetail("msg", code="...")]}` (DRF-native, untransformed) |
+| `.error_code` | not present (nested in `.detail`) | instance attribute |
+| `.status_code` | `400` | `400` (unchanged) |
+| `default_code` | `"4000"` | `"4000"` (unchanged) |
+| Multi-message per field | joined with single space | preserved as a list |
+
+### Response body impact (DRF default handler)
+
+| Scenario | Before | After |
+|---|---|---|
+| Single-field validation failure | `{"detail": {"error_code": "4000", "detail": {"password": "This field is required."}}}` | `{"password": ["This field is required."]}` |
+| Top-level code in wire body | present at `.detail.error_code` | not in body; handler reads `exc.error_code` |
+
+Consumers using DRF's default handler see a flat field-map body. Consumers with custom handlers get `isinstance(exc, ValidationError) == True` and iterate `.detail` as a standard DRF field map; the top-level code is available via `exc.error_code`.
+
+### Callsite impact (in-repo)
+
+All 17 callsites pass `detail=<dict-shape>`; none pass `code=`. No signature change. Callsites keep working verbatim. Example:
+
+```python
+# blockauth/views/basic_auth_views.py (unchanged)
+try:
+    serializer.is_valid(raise_exception=True)
+except ValidationError as e:
+    raise ValidationErrorWithCode(detail=e.detail)
+```
+
+Now that `ValidationErrorWithCode` is a `ValidationError`, the `except (ValidationError, ValidationErrorWithCode)` at `basic_auth_views.py:324` is technically redundant (the second tuple element is covered by the first). **Leave it alone** for readability — deleting a name from a tuple to shave a line isn't worth the diff noise.
+
+---
+
+## Versioning & CHANGELOG
+
+### Version bump
+
+`0.6.1` → `0.7.0`. Breaking wire change per `.github/CONTRIBUTING.md`. Bump in both:
+- `pyproject.toml` → `version = "0.7.0"`
+- `blockauth/__init__.py` → `__version__ = "0.7.0"`
+
+### CHANGELOG entry
+
+Under `[Unreleased]` → `### Breaking Changes`:
+
+> **`ValidationErrorWithCode` now subclasses DRF's `ValidationError`** (#101). `.detail` is a DRF-native `{field: [ErrorDetail, ...]}` map; the top-level error code moves from `.detail["error_code"]` to the `.error_code` attribute on the exception instance.
+>
+> - **Response body for DRF's default exception handler** changes from `{"detail": {"error_code": "4000", "detail": {field: message}}}` to `{field: [message]}`. The top-level code is no longer in the body when using DRF's default handler.
+> - **Custom exception handlers** that branch on `isinstance(exc, ValidationError)` now pick up `ValidationErrorWithCode` automatically and can iterate `exc.detail` as a DRF-native field map.
+> - **Per-field multi-message behavior** changes: the old code joined multiple error messages per field into a single space-separated string. The new class preserves DRF's list of `ErrorDetail` so per-error codes and messages are iterable individually.
+
+Under `### Migration notes`:
+
+> If your service uses a custom DRF `EXCEPTION_HANDLER` that special-cases `ValidationErrorWithCode` by reading `exc.detail["error_code"]` or `exc.detail["detail"]`, switch to reading `exc.error_code` and iterating `exc.detail` as a standard DRF field map. If your service relies on DRF's default handler and was parsing the legacy envelope, switch to the DRF-native `{field: [message]}` shape.
+
+### Release flow
+
+1. Merge fix on `dev`; CI must be green.
+2. Bump version in `pyproject.toml` and `blockauth/__init__.py` → `0.7.0`.
+3. In `CHANGELOG.md`, cut `[Unreleased]` → `[0.7.0] - 2026-04-17`.
+4. Tag `v0.7.0` and push; `publish.yml` validates the version match, builds, and creates a GitHub Release.
+5. **fabric-auth follow-up (separate PR, out of scope for this fix):** bump the blockauth pin (`uv lock --upgrade-package blockauth`) and retire the `ValidationErrorWithCode` special-case branch in `structured_exception_handler` now that the generic `ValidationError` branch covers it. Filed as a fabric-auth issue by the implementer.
+
+---
+
+## Testing
+
+### New test file
+
+`blockauth/utils/tests/test_validation_error_with_code.py` — dedicated coverage, following the `test_wallet_conflict_error.py` convention.
+
+| # | Test | Asserts |
+|---|------|---------|
+| 1 | `is_subclass_of_drf_validation_error` | `issubclass(ValidationErrorWithCode, rest_framework.exceptions.ValidationError)`. Guards the core contract — regressing this re-introduces #101. |
+| 2 | `isinstance_check_passes_for_raised_instance` | Raise `ValidationErrorWithCode(...)`, catch with `except ValidationError`, confirm caught. Behavioral form of #1. |
+| 3 | `detail_is_drf_native_field_map` | Input `{"password": [ErrorDetail("required", code="required")]}` → `.detail["password"]` is a list of `ErrorDetail`, code preserved, no string join. |
+| 4 | `error_code_derived_from_first_field_code` | Input `{"email": [ErrorDetail("bad", code="invalid")]}` → `.error_code == "invalid"`. |
+| 5 | `error_code_required_maps_to_4000` | Input `{"email": [ErrorDetail("x", code="required")]}` → `.error_code == "4000"`. |
+| 6 | `error_code_explicit_overrides_derivation` | `ValidationErrorWithCode(detail={...}, code="4042")` → `.error_code == "4042"`. |
+| 7 | `error_code_falls_back_to_default_for_bare_strings` | Input `{"email": "raw string"}` → `.error_code == "4000"` (no `TypeError`). |
+| 8 | `error_code_falls_back_to_default_for_empty_detail` | Input `{}` → `.error_code == "4000"` (no `IndexError` / `StopIteration`). |
+| 9 | `default_detail_when_none_passed` | `ValidationErrorWithCode()` → `.detail == {"non_field_errors": [ErrorDetail("A validation error occurred...")]}`, `.error_code == "4000"`. |
+| 10 | `multi_message_per_field_preserved_as_list` | Input `{"password": [ErrorDetail("too short"), ErrorDetail("no digits")]}` → `.detail["password"]` is a 2-element list; not joined. |
+| 11 | `status_code_is_400` | Instance `.status_code == 400`. |
+| 12 | `default_drf_handler_renders_field_map` | Drive `rest_framework.views.exception_handler(exc, context)` and assert `response.data == {"password": ["This field is required."]}`, `response.status_code == 400`. Locks in the new wire contract. |
+
+### Existing-test audit
+
+Pre-spec grep of the test tree:
+
+- `blockauth/utils/tests/test_wallet_link_serializer.py` — references `error_code` only on DRF `ErrorDetail.code` surfaced via serializer `.errors`. **Unaffected** (reads the underlying DRF shape, not `ValidationErrorWithCode.detail`).
+- `blockauth/totp/tests/{test_totp_service,test_security}.py` — reference `error_code` only on TOTP's own exception classes (unrelated). **Unaffected.**
+- `blockauth/views/tests/*.py` — no assertions on `response.data["detail"]["error_code"]` or the legacy double-nested envelope. **No updates needed.**
+
+If an implementation-time regression surfaces a test that did implicitly rely on the legacy body shape, update it to the new `{field: [message]}` shape and call it out in the PR.
+
+### Verification commands
+
+```bash
+uv run pytest blockauth/utils/tests/test_validation_error_with_code.py -v
+uv run pytest blockauth/ -q          # full suite must stay green
+uv run black blockauth/ && uv run isort blockauth/ && uv run flake8 blockauth/
+```
+
+---
+
+## Implementation notes
+
+- **Single-file change** for the core behavior: `blockauth/utils/custom_exception.py`.
+- **Docs:** no runtime doc changes required. `CLAUDE.md` mentions `ValidationErrorWithCode` once in the architecture tree — no edit needed.
+- **Lint gate:** `flake8`, `black`, `isort` are enforced.
+- **No new dependencies.**
+- **No migration** (the class is in-process only; no DB, no cache).
+
+## Out of scope
+
+- Shipping a `blockauth.utils.exception_handler.blockauth_exception_handler` (issue #101's Option B). Reasonable follow-up; separate design.
+- Retiring fabric-auth PR #417's `ValidationErrorWithCode` special-case branch — fabric-auth-side work, filed as a separate issue there.
+- Any change to `WalletConflictError` or other blockauth exceptions.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "blockauth"
-version = "0.6.1"
+version = "0.7.0"
 description = "Comprehensive Python authentication package bridging Web2 and Web3"
 authors = [{name = "BloclabsHQ", email = "eng@bloclabs.com"}]
 license = {text = "MIT"}

--- a/uv.lock
+++ b/uv.lock
@@ -312,7 +312,7 @@ wheels = [
 
 [[package]]
 name = "blockauth"
-version = "0.6.1"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "argon2-cffi" },


### PR DESCRIPTION
## Summary

Closes #101.

Makes `blockauth.utils.custom_exception.ValidationErrorWithCode` a real `rest_framework.exceptions.ValidationError` subclass, so downstream `isinstance(exc, ValidationError)` checks in custom `EXCEPTION_HANDLER`s fire and `.detail` is a DRF-native `{field: [ErrorDetail, ...]}` map. The top-level numeric error code moves from `.detail["error_code"]` to the `.error_code` attribute on the exception instance. Per-field multi-message behavior is now DRF-native (list of `ErrorDetail`) instead of the legacy single-space-joined string.

This retires the root cause of the fabric-auth signup regression (fabric-auth#412 / PR #417 workaround).

## Breaking change

Ships as **0.7.0** per the repo's breaking-change policy. See `CHANGELOG.md` for the full Breaking Changes + Migration notes entries. Summary:

- **Custom handlers** that `isinstance(exc, ValidationError)`: now catch `ValidationErrorWithCode` automatically and can iterate `.detail` as a DRF field map. Fabric-auth's local special-case branch from PR #417 becomes dead code and can be retired (separate fabric-auth follow-up).
- **Default DRF exception handler wire body**: `{"detail": {"error_code": "4000", "detail": {field: message}}}` → `{field: [message]}`. Top-level code moves off-body onto `exc.error_code`.
- **Per-field messages**: preserved as a list of `ErrorDetail` (old code joined with spaces, destroying per-error codes).

## Design & plan

- Spec: `docs/superpowers/specs/2026-04-17-validation-error-with-code-design.md` (merged to dev in `5da33ca`)
- Plan: `docs/superpowers/plans/2026-04-17-validation-error-with-code.md` (merged to dev in `5e2db66`)

## Test plan

- [x] 12 new tests in `blockauth/utils/tests/test_validation_error_with_code.py` lock in the contract: subclass check, isinstance behavior, DRF-native `.detail`, `.error_code` derivation (default/required/explicit/bare-string/empty), default detail shape, multi-message preservation, 400 status, and DRF default-handler wire body. All pass.
- [x] Full suite: `uv run pytest blockauth/` → **462 passed, 0 failed**. No regressions — zero existing tests asserted on the legacy double-nested `{"detail": {"error_code": ...}}` envelope.
- [x] Lint (scoped to touched files under project's configured line-length=120): black/isort/flake8 all clean.
- [x] Regression grep (`exc.detail["error_code"]`, `response.data["detail"]["detail"]`): zero hits across `blockauth/` and `tests/`.
- [x] Version consistency: `blockauth.__version__ == "0.7.0"`, `pyproject.toml` and `uv.lock` aligned, CHANGELOG `[Unreleased]` cut to `[0.7.0] - 2026-04-17`.

## Release flow after merge

1. Maintainer tags `v0.7.0` on `dev` after this merges; `publish.yml` builds and creates the GitHub Release.
2. In fabric-auth, bump the blockauth pin (`uv lock --upgrade-package blockauth`) and retire PR #417's `ValidationErrorWithCode` special-case branch.

## Follow-ups (separate issues)

- auth-pack: no flake8 config; raw `uv run flake8 blockauth/` fails project-wide against its 79-char default while the codebase is formatted at `[tool.black] line-length = 120`. Worth a config fix (`.flake8` or `pyproject.toml [tool.flake8]` with `max-line-length=120`, `extend-ignore=E203`).
- fabric-auth: retire the `ValidationErrorWithCode` special-case branch in `structured_exception_handler` once bumped to 0.7.0.