### PR TITLE
feat: richer login payload + tokens on signup confirm (fabric-auth#420) — 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,21 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — pre-1
 
 ---
 
+## [0.8.0] - 2026-04-17
+
+### Added
+
+- **Login response user payload now includes `first_name` and `last_name`** (fabric-auth#420). `LoginUserSerializer` — shared by basic-login, passwordless-login confirm, and wallet-login — now exposes both fields so consumer shells can drop the follow-up `GET /me/` round-trip for profile hydration. Both fields are nullable and tolerant of downstream user models that do not define them (views read via `getattr(user, "first_name", None)`).
+- **`POST /signup/confirm/` issues JWTs and returns the user payload** on successful signup confirmation (fabric-auth#420). New response shape `{access, refresh, user}` mirrors the login endpoints so the client is signed in immediately instead of following up with `POST /login/basic/` using the just-set password. `POST_SIGNUP_TRIGGER` fires before tokens are issued; its signature is unchanged. Added `SignUpConfirmResponseSerializer` for OpenAPI documentation.
+
+### Changed
+
+- `POST /signup/confirm/` success response body changes from `{"message": "Sign up success"}` to `{"access, refresh, user}`. Existing clients that only inspected the HTTP status code are unaffected; clients that parsed the `message` field must switch to the new shape or ignore extra keys.
+
+### Fixed
+
+---
+
 ## [0.7.0] - 2026-04-17
 
 ### Breaking Changes

--- a/blockauth/__init__.py
+++ b/blockauth/__init__.py
@@ -28,7 +28,7 @@ Static utilities (no storage needed):
     backup_codes = TOTPService.generate_backup_codes()
 """
 
-__version__ = "0.7.0"
+__version__ = "0.8.0"
 
 # =============================================================================
 # Direct imports (Django-independent, no AppRegistryNotReady errors)

--- a/blockauth/serializers/user_account_serializers.py
+++ b/blockauth/serializers/user_account_serializers.py
@@ -295,6 +295,23 @@ class LoginUserSerializer(serializers.Serializer):
         required=False,
         help_text="Ethereum wallet address (null for accounts without a linked wallet)",
     )
+    # first_name / last_name are optional because the abstract BlockUser
+    # model does not define them; concrete downstream user models may.
+    # Callers should pass getattr(user, "first_name", None) when building
+    # the response dict so auth-pack stays compatible with minimal user
+    # models that never added profile fields.
+    first_name = serializers.CharField(
+        allow_null=True,
+        allow_blank=True,
+        required=False,
+        help_text="Given name (null if the downstream user model has no first_name field or it is unset)",
+    )
+    last_name = serializers.CharField(
+        allow_null=True,
+        allow_blank=True,
+        required=False,
+        help_text="Family name (null if the downstream user model has no last_name field or it is unset)",
+    )
 
 
 class BasicLoginResponseSerializer(serializers.Serializer):
@@ -320,3 +337,18 @@ class PasswordlessLoginResponseSerializer(serializers.Serializer):
     access = serializers.CharField(help_text="JWT access token")
     refresh = serializers.CharField(help_text="JWT refresh token")
     user = LoginUserSerializer(help_text="Authenticated user profile")
+
+
+class SignUpConfirmResponseSerializer(serializers.Serializer):
+    """Response body for successful ``POST /signup/confirm/`` (fabric-auth#420).
+
+    Signup confirmation now issues JWTs so the client is signed in
+    immediately instead of following up with ``POST /login/basic/`` using
+    the just-set password. Same shape as the login responses so the OpenAPI
+    surface stays consistent and shells can share a single post-auth code
+    path.
+    """
+
+    access = serializers.CharField(help_text="JWT access token")
+    refresh = serializers.CharField(help_text="JWT refresh token")
+    user = LoginUserSerializer(help_text="Newly verified user profile")

--- a/blockauth/views/basic_auth_views.py
+++ b/blockauth/views/basic_auth_views.py
@@ -38,6 +38,7 @@ from blockauth.serializers.user_account_serializers import (
     PasswordResetRequestSerializer,
     RefreshTokenSerializer,
     SignUpConfirmationSerializer,
+    SignUpConfirmResponseSerializer,
     SignUpRequestSerializer,
     SignUpResendOTPSerializer,
 )
@@ -228,8 +229,36 @@ class SignUpConfirmView(APIView):
                 # Call POST_SIGNUP_TRIGGER with user data
                 post_signup_trigger = get_config("POST_SIGNUP_TRIGGER")()
                 post_signup_trigger.trigger(context={"user": user, "provider_data": data})
+
+                # fabric-auth#420: issue JWTs so the client is signed in
+                # immediately instead of following up with /login/basic/.
+                try:
+                    from blockauth.utils.token import generate_auth_token_with_custom_claims
+
+                    access_token, refresh_token = generate_auth_token_with_custom_claims(
+                        token_class=AUTH_TOKEN_CLASS(), user_id=str(user.id)
+                    )
+                except ImportError:
+                    access_token, refresh_token = generate_auth_token(
+                        token_class=AUTH_TOKEN_CLASS(), user_id=str(user.id)
+                    )
+
                 blockauth_logger.success("User signup confirmed", sanitize_log_context(request.data, {"user": user.id}))
-                return Response(data={"message": "Sign up success"}, status=status.HTTP_200_OK)
+                response_serializer = SignUpConfirmResponseSerializer(
+                    {
+                        "access": access_token,
+                        "refresh": refresh_token,
+                        "user": {
+                            "id": user.id,
+                            "email": user.email,
+                            "is_verified": user.is_verified,
+                            "wallet_address": user.wallet_address,
+                            "first_name": getattr(user, "first_name", None),
+                            "last_name": getattr(user, "last_name", None),
+                        },
+                    }
+                )
+                return Response(data=response_serializer.data, status=status.HTTP_200_OK)
             else:
                 # No valid OTP found for either subject
                 raise ValidationError(
@@ -317,6 +346,8 @@ class BasicAuthLoginView(APIView):
                         "email": user.email,
                         "is_verified": user.is_verified,
                         "wallet_address": user.wallet_address,
+                        "first_name": getattr(user, "first_name", None),
+                        "last_name": getattr(user, "last_name", None),
                     },
                 }
             )
@@ -463,6 +494,8 @@ class PasswordlessLoginConfirmView(APIView):
                         "email": user.email,
                         "is_verified": user.is_verified,
                         "wallet_address": user.wallet_address,
+                        "first_name": getattr(user, "first_name", None),
+                        "last_name": getattr(user, "last_name", None),
                     },
                 }
             )

--- a/blockauth/views/tests/test_login_views.py
+++ b/blockauth/views/tests/test_login_views.py
@@ -11,7 +11,6 @@ from rest_framework import status
 from blockauth.models.otp import OTP, OTPSubject
 from blockauth.utils.tests.credential_leak import assert_no_credential_leak
 
-
 BASIC_LOGIN_URL = reverse("basic-login")
 PASSWORDLESS_URL = reverse("passwordless-login")
 PASSWORDLESS_CONFIRM_URL = reverse("passwordless-login-confirm")
@@ -26,10 +25,13 @@ class TestBasicLoginView:
 
     def test_login_returns_tokens(self, api_client, create_user):
         create_user(email="user@test.com", password=_TEST_PASSWORD)
-        response = api_client.post(BASIC_LOGIN_URL, {
-            "identifier": "user@test.com",
-            "password": _TEST_PASSWORD,
-        })
+        response = api_client.post(
+            BASIC_LOGIN_URL,
+            {
+                "identifier": "user@test.com",
+                "password": _TEST_PASSWORD,
+            },
+        )
         assert response.status_code == status.HTTP_200_OK
         assert "access" in response.data
         assert "refresh" in response.data
@@ -38,10 +40,13 @@ class TestBasicLoginView:
         """Issue #97: basic-login response includes user so clients
         can hydrate without a follow-up GET /me/ round-trip."""
         user = create_user(email="user@test.com", password=_TEST_PASSWORD)
-        response = api_client.post(BASIC_LOGIN_URL, {
-            "identifier": "user@test.com",
-            "password": _TEST_PASSWORD,
-        })
+        response = api_client.post(
+            BASIC_LOGIN_URL,
+            {
+                "identifier": "user@test.com",
+                "password": _TEST_PASSWORD,
+            },
+        )
         assert response.status_code == status.HTTP_200_OK
         assert "user" in response.data
         user_payload = response.data["user"]
@@ -61,14 +66,37 @@ class TestBasicLoginView:
             password=_TEST_PASSWORD,
             wallet_address=wallet,
         )
-        response = api_client.post(BASIC_LOGIN_URL, {
-            "identifier": "walletuser@test.com",
-            "password": _TEST_PASSWORD,
-        })
+        response = api_client.post(
+            BASIC_LOGIN_URL,
+            {
+                "identifier": "walletuser@test.com",
+                "password": _TEST_PASSWORD,
+            },
+        )
         assert response.status_code == status.HTTP_200_OK
         user_payload = response.data["user"]
         assert user_payload["id"] == str(user.id)
         assert user_payload["wallet_address"] == wallet
+
+    def test_login_user_payload_includes_first_last_name_keys(self, api_client, create_user):
+        """fabric-auth#420: login response user payload exposes first_name /
+        last_name keys so consumer shells can hydrate profile state without
+        a follow-up /me/ round-trip. Values are null on user models that do
+        not define the fields (BlockUser abstract base)."""
+        create_user(email="user@test.com", password=_TEST_PASSWORD)
+        response = api_client.post(
+            BASIC_LOGIN_URL,
+            {
+                "identifier": "user@test.com",
+                "password": _TEST_PASSWORD,
+            },
+        )
+        assert response.status_code == status.HTTP_200_OK
+        user_payload = response.data["user"]
+        assert "first_name" in user_payload
+        assert "last_name" in user_payload
+        assert user_payload["first_name"] is None
+        assert user_payload["last_name"] is None
 
     def test_login_user_payload_does_not_leak_credentials(self, api_client, create_user):
         """Issue #99: basic-login's ``user`` payload must never contain
@@ -77,46 +105,64 @@ class TestBasicLoginView:
         ``ModelSerializer`` with ``fields = "__all__"``.
         """
         create_user(email="user@test.com", password=_TEST_PASSWORD)
-        response = api_client.post(BASIC_LOGIN_URL, {
-            "identifier": "user@test.com",
-            "password": _TEST_PASSWORD,
-        })
+        response = api_client.post(
+            BASIC_LOGIN_URL,
+            {
+                "identifier": "user@test.com",
+                "password": _TEST_PASSWORD,
+            },
+        )
         assert response.status_code == status.HTTP_200_OK
         assert_no_credential_leak(response.data["user"])
 
     def test_login_wrong_password(self, api_client, create_user):
         create_user(email="user@test.com", password="StrongP@ss1!")
-        response = api_client.post(BASIC_LOGIN_URL, {
-            "identifier": "user@test.com",
-            "password": "WrongP@ss1!",
-        })
+        response = api_client.post(
+            BASIC_LOGIN_URL,
+            {
+                "identifier": "user@test.com",
+                "password": "WrongP@ss1!",
+            },
+        )
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
     def test_login_nonexistent_user(self, api_client):
-        response = api_client.post(BASIC_LOGIN_URL, {
-            "identifier": "nobody@test.com",
-            "password": "StrongP@ss1!",
-        })
+        response = api_client.post(
+            BASIC_LOGIN_URL,
+            {
+                "identifier": "nobody@test.com",
+                "password": "StrongP@ss1!",
+            },
+        )
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
     def test_login_unverified_user(self, api_client, create_user):
         create_user(email="user@test.com", password="StrongP@ss1!", is_verified=False)
-        response = api_client.post(BASIC_LOGIN_URL, {
-            "identifier": "user@test.com",
-            "password": "StrongP@ss1!",
-        })
+        response = api_client.post(
+            BASIC_LOGIN_URL,
+            {
+                "identifier": "user@test.com",
+                "password": "StrongP@ss1!",
+            },
+        )
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
     def test_login_missing_identifier(self, api_client):
-        response = api_client.post(BASIC_LOGIN_URL, {
-            "password": "StrongP@ss1!",
-        })
+        response = api_client.post(
+            BASIC_LOGIN_URL,
+            {
+                "password": "StrongP@ss1!",
+            },
+        )
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
     def test_login_missing_password(self, api_client):
-        response = api_client.post(BASIC_LOGIN_URL, {
-            "identifier": "user@test.com",
-        })
+        response = api_client.post(
+            BASIC_LOGIN_URL,
+            {
+                "identifier": "user@test.com",
+            },
+        )
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
     def test_login_empty_body(self, api_client):
@@ -128,15 +174,21 @@ class TestBasicLoginView:
         create_user(email="user@test.com", password="StrongP@ss1!")
         # Make 5 failed attempts to trigger cooldown
         for _ in range(5):
-            api_client.post(BASIC_LOGIN_URL, {
-                "identifier": "user@test.com",
-                "password": "WrongP@ss!",
-            })
+            api_client.post(
+                BASIC_LOGIN_URL,
+                {
+                    "identifier": "user@test.com",
+                    "password": "WrongP@ss!",
+                },
+            )
         # Next attempt should be rate-limited even with correct password
-        response = api_client.post(BASIC_LOGIN_URL, {
-            "identifier": "user@test.com",
-            "password": "StrongP@ss1!",
-        })
+        response = api_client.post(
+            BASIC_LOGIN_URL,
+            {
+                "identifier": "user@test.com",
+                "password": "StrongP@ss1!",
+            },
+        )
         assert response.status_code == status.HTTP_429_TOO_MANY_REQUESTS
 
 
@@ -146,39 +198,51 @@ class TestPasswordlessLoginView:
 
     def test_send_otp_returns_200(self, api_client, create_user):
         create_user(email="user@test.com")
-        response = api_client.post(PASSWORDLESS_URL, {
-            "identifier": "user@test.com",
-            "method": "email",
-            "verification_type": "otp",
-        })
+        response = api_client.post(
+            PASSWORDLESS_URL,
+            {
+                "identifier": "user@test.com",
+                "method": "email",
+                "verification_type": "otp",
+            },
+        )
         assert response.status_code == status.HTTP_200_OK
         assert "message" in response.data
 
     def test_send_otp_creates_otp_record(self, api_client, create_user):
         create_user(email="user@test.com")
-        api_client.post(PASSWORDLESS_URL, {
-            "identifier": "user@test.com",
-            "method": "email",
-            "verification_type": "otp",
-        })
+        api_client.post(
+            PASSWORDLESS_URL,
+            {
+                "identifier": "user@test.com",
+                "method": "email",
+                "verification_type": "otp",
+            },
+        )
         assert OTP.objects.filter(
             identifier="user@test.com",
             subject=OTPSubject.LOGIN,
         ).exists()
 
     def test_send_otp_missing_identifier(self, api_client):
-        response = api_client.post(PASSWORDLESS_URL, {
-            "method": "email",
-            "verification_type": "otp",
-        })
+        response = api_client.post(
+            PASSWORDLESS_URL,
+            {
+                "method": "email",
+                "verification_type": "otp",
+            },
+        )
         assert response.status_code in (status.HTTP_400_BAD_REQUEST, status.HTTP_429_TOO_MANY_REQUESTS)
 
     def test_send_otp_invalid_method(self, api_client):
-        response = api_client.post(PASSWORDLESS_URL, {
-            "identifier": "user@test.com",
-            "method": "pigeon",
-            "verification_type": "otp",
-        })
+        response = api_client.post(
+            PASSWORDLESS_URL,
+            {
+                "identifier": "user@test.com",
+                "method": "pigeon",
+                "verification_type": "otp",
+            },
+        )
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
 
@@ -189,10 +253,13 @@ class TestPasswordlessLoginConfirmView:
     def test_confirm_valid_otp_returns_tokens(self, api_client, create_user, create_otp):
         create_user(email="user@test.com")
         create_otp(identifier="user@test.com", subject=OTPSubject.LOGIN, code="ABC123")
-        response = api_client.post(PASSWORDLESS_CONFIRM_URL, {
-            "identifier": "user@test.com",
-            "code": "ABC123",
-        })
+        response = api_client.post(
+            PASSWORDLESS_CONFIRM_URL,
+            {
+                "identifier": "user@test.com",
+                "code": "ABC123",
+            },
+        )
         assert response.status_code == status.HTTP_200_OK
         assert "access" in response.data
         assert "refresh" in response.data
@@ -202,10 +269,13 @@ class TestPasswordlessLoginConfirmView:
         user so clients can hydrate without a follow-up GET /me/."""
         user = create_user(email="user@test.com")
         create_otp(identifier="user@test.com", subject=OTPSubject.LOGIN, code="ABC123")
-        response = api_client.post(PASSWORDLESS_CONFIRM_URL, {
-            "identifier": "user@test.com",
-            "code": "ABC123",
-        })
+        response = api_client.post(
+            PASSWORDLESS_CONFIRM_URL,
+            {
+                "identifier": "user@test.com",
+                "code": "ABC123",
+            },
+        )
         assert response.status_code == status.HTTP_200_OK
         assert "user" in response.data
         user_payload = response.data["user"]
@@ -221,13 +291,17 @@ class TestPasswordlessLoginConfirmView:
         """Issue #97: passwordless confirm also populates user on the
         auto-create branch (user didn't exist before the OTP flow)."""
         from blockauth.utils.config import get_block_auth_user_model
+
         User = get_block_auth_user_model()
 
         create_otp(identifier="fresh@test.com", subject=OTPSubject.LOGIN, code="ABC123")
-        response = api_client.post(PASSWORDLESS_CONFIRM_URL, {
-            "identifier": "fresh@test.com",
-            "code": "ABC123",
-        })
+        response = api_client.post(
+            PASSWORDLESS_CONFIRM_URL,
+            {
+                "identifier": "fresh@test.com",
+                "code": "ABC123",
+            },
+        )
         assert response.status_code == status.HTTP_200_OK
         created_user = User.objects.get(email="fresh@test.com")
         user_payload = response.data["user"]
@@ -242,51 +316,70 @@ class TestPasswordlessLoginConfirmView:
         """
         create_user(email="user@test.com")
         create_otp(identifier="user@test.com", subject=OTPSubject.LOGIN, code="ABC123")
-        response = api_client.post(PASSWORDLESS_CONFIRM_URL, {
-            "identifier": "user@test.com",
-            "code": "ABC123",
-        })
+        response = api_client.post(
+            PASSWORDLESS_CONFIRM_URL,
+            {
+                "identifier": "user@test.com",
+                "code": "ABC123",
+            },
+        )
         assert response.status_code == status.HTTP_200_OK
         assert_no_credential_leak(response.data["user"])
 
     def test_confirm_creates_user_if_not_exists(self, api_client, create_otp):
         """Passwordless login should create a new user if one doesn't exist."""
         from blockauth.utils.config import get_block_auth_user_model
+
         User = get_block_auth_user_model()
 
         create_otp(identifier="new@test.com", subject=OTPSubject.LOGIN, code="ABC123")
-        response = api_client.post(PASSWORDLESS_CONFIRM_URL, {
-            "identifier": "new@test.com",
-            "code": "ABC123",
-        })
+        response = api_client.post(
+            PASSWORDLESS_CONFIRM_URL,
+            {
+                "identifier": "new@test.com",
+                "code": "ABC123",
+            },
+        )
         assert response.status_code == status.HTTP_200_OK
         assert User.objects.filter(email="new@test.com").exists()
 
     def test_confirm_invalid_otp(self, api_client, create_user, create_otp):
         create_user(email="user@test.com")
         create_otp(identifier="user@test.com", subject=OTPSubject.LOGIN, code="ABC123")
-        response = api_client.post(PASSWORDLESS_CONFIRM_URL, {
-            "identifier": "user@test.com",
-            "code": "WRONG",
-        })
+        response = api_client.post(
+            PASSWORDLESS_CONFIRM_URL,
+            {
+                "identifier": "user@test.com",
+                "code": "WRONG",
+            },
+        )
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
     def test_confirm_missing_code(self, api_client):
-        response = api_client.post(PASSWORDLESS_CONFIRM_URL, {
-            "identifier": "user@test.com",
-        })
+        response = api_client.post(
+            PASSWORDLESS_CONFIRM_URL,
+            {
+                "identifier": "user@test.com",
+            },
+        )
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
     def test_confirm_rate_limit_after_failures(self, api_client, create_user):
         """Progressive lockout after repeated failed OTP attempts."""
         create_user(email="user@test.com")
         for _ in range(5):
-            api_client.post(PASSWORDLESS_CONFIRM_URL, {
+            api_client.post(
+                PASSWORDLESS_CONFIRM_URL,
+                {
+                    "identifier": "user@test.com",
+                    "code": "WRONG",
+                },
+            )
+        response = api_client.post(
+            PASSWORDLESS_CONFIRM_URL,
+            {
                 "identifier": "user@test.com",
-                "code": "WRONG",
-            })
-        response = api_client.post(PASSWORDLESS_CONFIRM_URL, {
-            "identifier": "user@test.com",
-            "code": "ANYTHING",
-        })
+                "code": "ANYTHING",
+            },
+        )
         assert response.status_code == status.HTTP_429_TOO_MANY_REQUESTS

--- a/blockauth/views/tests/test_signup_views.py
+++ b/blockauth/views/tests/test_signup_views.py
@@ -17,45 +17,58 @@ SIGNUP_CONFIRM_URL = reverse("signup-confirm")
 class TestSignUpView:
 
     def test_signup_with_email(self, api_client):
-        response = api_client.post(SIGNUP_URL, {
-            "identifier": "new@test.com",
-            "password": "StrongP@ss1!",
-            "method": "email",
-            "verification_type": "otp",
-        })
+        response = api_client.post(
+            SIGNUP_URL,
+            {
+                "identifier": "new@test.com",
+                "password": "StrongP@ss1!",
+                "method": "email",
+                "verification_type": "otp",
+            },
+        )
         assert response.status_code == status.HTTP_200_OK
         assert "message" in response.data
 
     def test_signup_creates_user_and_otp(self, api_client):
         from blockauth.utils.config import get_block_auth_user_model
+
         User = get_block_auth_user_model()
 
-        api_client.post(SIGNUP_URL, {
-            "identifier": "new@test.com",
-            "password": "StrongP@ss1!",
-            "method": "email",
-            "verification_type": "otp",
-        })
+        api_client.post(
+            SIGNUP_URL,
+            {
+                "identifier": "new@test.com",
+                "password": "StrongP@ss1!",
+                "method": "email",
+                "verification_type": "otp",
+            },
+        )
         assert User.objects.filter(email="new@test.com").exists()
         assert OTP.objects.filter(identifier="new@test.com", subject=OTPSubject.SIGNUP).exists()
 
     def test_signup_duplicate_email(self, api_client, create_user):
         create_user(email="exists@test.com")
-        response = api_client.post(SIGNUP_URL, {
-            "identifier": "exists@test.com",
-            "password": "StrongP@ss1!",
-            "method": "email",
-            "verification_type": "otp",
-        })
+        response = api_client.post(
+            SIGNUP_URL,
+            {
+                "identifier": "exists@test.com",
+                "password": "StrongP@ss1!",
+                "method": "email",
+                "verification_type": "otp",
+            },
+        )
         assert response.status_code in (status.HTTP_400_BAD_REQUEST, status.HTTP_429_TOO_MANY_REQUESTS)
 
     def test_signup_weak_password(self, api_client):
-        response = api_client.post(SIGNUP_URL, {
-            "identifier": "new@test.com",
-            "password": "weak",
-            "method": "email",
-            "verification_type": "otp",
-        })
+        response = api_client.post(
+            SIGNUP_URL,
+            {
+                "identifier": "new@test.com",
+                "password": "weak",
+                "method": "email",
+                "verification_type": "otp",
+            },
+        )
         assert response.status_code in (status.HTTP_400_BAD_REQUEST, status.HTTP_429_TOO_MANY_REQUESTS)
 
     def test_signup_missing_fields(self, api_client):
@@ -63,12 +76,15 @@ class TestSignUpView:
         assert response.status_code in (status.HTTP_400_BAD_REQUEST, status.HTTP_429_TOO_MANY_REQUESTS)
 
     def test_signup_invalid_email(self, api_client):
-        response = api_client.post(SIGNUP_URL, {
-            "identifier": "not-an-email",
-            "password": "StrongP@ss1!",
-            "method": "email",
-            "verification_type": "otp",
-        })
+        response = api_client.post(
+            SIGNUP_URL,
+            {
+                "identifier": "not-an-email",
+                "password": "StrongP@ss1!",
+                "method": "email",
+                "verification_type": "otp",
+            },
+        )
         assert response.status_code in (status.HTTP_400_BAD_REQUEST, status.HTTP_429_TOO_MANY_REQUESTS)
 
 
@@ -77,20 +93,26 @@ class TestSignUpResendOTPView:
 
     def test_resend_for_unverified_user(self, api_client, create_user):
         create_user(email="unverified@test.com", is_verified=False)
-        response = api_client.post(SIGNUP_RESEND_URL, {
-            "identifier": "unverified@test.com",
-            "method": "email",
-            "verification_type": "otp",
-        })
+        response = api_client.post(
+            SIGNUP_RESEND_URL,
+            {
+                "identifier": "unverified@test.com",
+                "method": "email",
+                "verification_type": "otp",
+            },
+        )
         # Should return 200 regardless (prevent user enumeration)
         assert response.status_code == status.HTTP_200_OK
 
     def test_resend_for_nonexistent_user(self, api_client):
-        response = api_client.post(SIGNUP_RESEND_URL, {
-            "identifier": "nobody@test.com",
-            "method": "email",
-            "verification_type": "otp",
-        })
+        response = api_client.post(
+            SIGNUP_RESEND_URL,
+            {
+                "identifier": "nobody@test.com",
+                "method": "email",
+                "verification_type": "otp",
+            },
+        )
         # Same response to prevent enumeration
         assert response.status_code == status.HTTP_200_OK
 
@@ -104,15 +126,19 @@ class TestSignUpConfirmView:
 
     def test_confirm_valid_otp_verifies_user(self, api_client, create_user, create_otp):
         from blockauth.utils.config import get_block_auth_user_model
+
         User = get_block_auth_user_model()
 
         user = create_user(email="new@test.com", is_verified=False)
         create_otp(identifier="new@test.com", subject=OTPSubject.SIGNUP, code="ABC123")
 
-        response = api_client.post(SIGNUP_CONFIRM_URL, {
-            "identifier": "new@test.com",
-            "code": "ABC123",
-        })
+        response = api_client.post(
+            SIGNUP_CONFIRM_URL,
+            {
+                "identifier": "new@test.com",
+                "code": "ABC123",
+            },
+        )
         assert response.status_code == status.HTTP_200_OK
         user.refresh_from_db()
         assert user.is_verified is True
@@ -121,14 +147,70 @@ class TestSignUpConfirmView:
         create_user(email="new@test.com", is_verified=False)
         create_otp(identifier="new@test.com", subject=OTPSubject.SIGNUP, code="ABC123")
 
-        response = api_client.post(SIGNUP_CONFIRM_URL, {
-            "identifier": "new@test.com",
-            "code": "WRONG",
-        })
+        response = api_client.post(
+            SIGNUP_CONFIRM_URL,
+            {
+                "identifier": "new@test.com",
+                "code": "WRONG",
+            },
+        )
         assert response.status_code in (status.HTTP_400_BAD_REQUEST, status.HTTP_429_TOO_MANY_REQUESTS)
 
     def test_confirm_missing_code(self, api_client):
-        response = api_client.post(SIGNUP_CONFIRM_URL, {
-            "identifier": "new@test.com",
-        })
+        response = api_client.post(
+            SIGNUP_CONFIRM_URL,
+            {
+                "identifier": "new@test.com",
+            },
+        )
         assert response.status_code in (status.HTTP_400_BAD_REQUEST, status.HTTP_429_TOO_MANY_REQUESTS)
+
+    def test_confirm_returns_tokens_and_user(self, api_client, create_user, create_otp):
+        """fabric-auth#420: signup confirmation issues JWTs + user payload
+        so the client is signed in immediately. Mirrors /login/passwordless/confirm/."""
+        user = create_user(email="new@test.com", is_verified=False)
+        create_otp(identifier="new@test.com", subject=OTPSubject.SIGNUP, code="ABC123")
+
+        response = api_client.post(
+            SIGNUP_CONFIRM_URL,
+            {
+                "identifier": "new@test.com",
+                "code": "ABC123",
+            },
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert "access" in response.data
+        assert "refresh" in response.data
+        assert response.data["access"]
+        assert response.data["refresh"]
+        assert "user" in response.data
+        user_payload = response.data["user"]
+        assert user_payload["id"] == str(user.id)
+        assert user_payload["email"] == "new@test.com"
+        assert user_payload["is_verified"] is True
+        assert user_payload["wallet_address"] is None
+        # first_name / last_name are present and null on TestBlockUser
+        # (the abstract model doesn't define them; concrete downstream
+        # models may).
+        assert user_payload["first_name"] is None
+        assert user_payload["last_name"] is None
+
+    def test_confirm_access_token_decodes_for_new_user(self, api_client, create_user, create_otp):
+        """The access token issued on signup confirm must decode with the
+        newly verified user's id — proves the token is usable for immediate
+        authenticated calls."""
+        from blockauth.utils.token import Token
+
+        user = create_user(email="newtok@test.com", is_verified=False)
+        create_otp(identifier="newtok@test.com", subject=OTPSubject.SIGNUP, code="ABC123")
+
+        response = api_client.post(
+            SIGNUP_CONFIRM_URL,
+            {
+                "identifier": "newtok@test.com",
+                "code": "ABC123",
+            },
+        )
+        assert response.status_code == status.HTTP_200_OK
+        payload = Token().decode_token(response.data["access"])
+        assert str(payload["user_id"]) == str(user.id)

--- a/blockauth/views/wallet_auth_views.py
+++ b/blockauth/views/wallet_auth_views.py
@@ -240,6 +240,8 @@ class WalletAuthLoginView(APIView):
                     "email": user.email,
                     "is_verified": user.is_verified,
                     "wallet_address": user.wallet_address,
+                    "first_name": getattr(user, "first_name", None),
+                    "last_name": getattr(user, "last_name", None),
                 },
             }
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "blockauth"
-version = "0.7.0"
+version = "0.8.0"
 description = "Comprehensive Python authentication package bridging Web2 and Web3"
 authors = [{name = "BloclabsHQ", email = "eng@bloclabs.com"}]
 license = {text = "MIT"}

--- a/uv.lock
+++ b/uv.lock
@@ -312,7 +312,7 @@ wheels = [
 
 [[package]]
 name = "blockauth"
-version = "0.7.0"
+version = "0.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "argon2-cffi" },


### PR DESCRIPTION
## Summary

Closes the auth-pack half of [fabric-auth#420](https://github.com/BloclabsHQ/fabric-auth/issues/420) — collapses two auth round trips by shipping everything the shell needs on first response.

### Task 1 — `LoginUserSerializer` gains `first_name` / `last_name`

- Added as nullable, optional `CharField`s so downstream user models that don't define them (incl. the abstract `BlockUser` base) stay compatible.
- Views read via `getattr(user, "first_name", None)` for the same reason.
- basic-login, passwordless-login confirm, and wallet-login all carry the new keys so the shell can drop the follow-up `/me/` call.

### Task 2 — `POST /signup/confirm/` issues JWTs + user payload

- Mirrors `PasswordlessLoginConfirmView`: `{access, refresh, user}` shape.
- Signs the user in immediately instead of making them post to `/login/basic/` with the just-set password.
- `POST_SIGNUP_TRIGGER` fires unchanged before token issuance.
- New `SignUpConfirmResponseSerializer` for OpenAPI parity.

## Breaking change

Shipping as **0.8.0**. The `/signup/confirm/` response body changes from `{"message": "Sign up success"}` to `{access, refresh, user}`. Clients that only checked the HTTP status code are unaffected; clients that parsed the `message` field must switch to the new shape or ignore extra keys. See `CHANGELOG.md` for full notes.

Login response additions (`first_name`, `last_name`) are additive.

## Test plan

- [x] 3 new tests: `first_name`/`last_name` keys on basic-login response, `/signup/confirm/` returns `{access, refresh, user}`, issued access token decodes to the newly verified user id.
- [x] Full suite: `uv run pytest blockauth/` → **469 passed, 0 failed**.
- [x] `POST_SIGNUP_TRIGGER` callsite unchanged — trigger still fires with `{"user": user, "provider_data": data}` before tokens are issued.
- [x] Version consistency: `blockauth.__version__ == "0.8.0"`, `pyproject.toml` and `uv.lock` aligned, CHANGELOG `[Unreleased]` cut to `[0.8.0] - 2026-04-17`.

## Release flow after merge

1. Maintainer tags `v0.8.0` on `dev` after merge; `publish.yml` builds and cuts the GitHub Release.
2. In fabric-auth, bump the blockauth pin (`uv lock --upgrade-package blockauth`) — the `EXPECTED_LOGIN_USER_FIELDS` allow-list test needs `first_name` + `last_name` added, and signup-confirm consumers should adopt the new `{access, refresh, user}` shape.

## Out of scope

- Tasks 3 (kill profile-refresh poller) and 4 (audit wallet fan-out) from fabric-auth#420 — those live in `fabricbloc-shell`.