### PR TITLE
feat: post-auth-state-change endpoints return full auth tuple — 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,24 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — pre-1
 
 ---
 
+## [0.9.0] - 2026-04-17
+
+### Added
+
+- **`POST /token/refresh/` returns the user payload** (api-optimization follow-up to fabric-auth#420). Response shape expands from `{access, refresh}` to `{access, refresh, user}` using the new shared `AuthStateResponseSerializer`. The user row is already loaded in the view for custom-claims population, so surfacing it is free. Consumers can drop the 5-min `/me/` poller pattern once on this version.
+- **`POST /password/reset/confirm/` auto-signs-in after a successful reset**. Response shape changes from `{"message": "..."}` to `{access, refresh, user}`. The OTP + new password prove ownership — forcing a second `/login/basic/` round-trip was pure ceremony.
+- **`POST /password/change/` returns a fresh token pair + user**. Response shape changes from `{"message": "..."}` to `{access, refresh, user}`. When `ROTATE_REFRESH_TOKENS` is enabled this is also the right moment to rotate out tokens issued under the prior password.
+- **`blockauth.serializers.user_account_serializers.AuthStateResponseSerializer`** — shared response class for all three endpoints above. Reusable by downstream services that add similar "full post-mutation auth state" endpoints.
+
+### Changed
+
+- `POST /password/reset/confirm/` and `POST /password/change/` success bodies change from `{"message": "..."}` to `{access, refresh, user}`. Clients that only inspected the HTTP status code are unaffected; clients that read the `message` field must switch to the new shape or ignore extra keys.
+- `POST /token/refresh/` adds a `user` field; existing consumers reading `access` / `refresh` are unaffected.
+
+### Fixed
+
+---
+
 ## [0.8.0] - 2026-04-17
 
 ### Added

--- a/blockauth/__init__.py
+++ b/blockauth/__init__.py
@@ -28,7 +28,7 @@ Static utilities (no storage needed):
     backup_codes = TOTPService.generate_backup_codes()
 """
 
-__version__ = "0.8.0"
+__version__ = "0.9.0"
 
 # =============================================================================
 # Direct imports (Django-independent, no AppRegistryNotReady errors)

--- a/blockauth/serializers/user_account_serializers.py
+++ b/blockauth/serializers/user_account_serializers.py
@@ -339,6 +339,20 @@ class PasswordlessLoginResponseSerializer(serializers.Serializer):
     user = LoginUserSerializer(help_text="Authenticated user profile")
 
 
+class AuthStateResponseSerializer(serializers.Serializer):
+    """Response body for endpoints that mutate auth state and must hand
+    the client the full post-mutation auth tuple in one round trip.
+
+    Used by ``/token/refresh/``, ``/password/reset/confirm/``, and
+    ``/password/change/`` so clients never need a follow-up ``/me/`` or
+    ``/login/basic/`` to reconcile state after a mutation.
+    """
+
+    access = serializers.CharField(help_text="JWT access token (freshly issued)")
+    refresh = serializers.CharField(help_text="JWT refresh token (rotated where applicable)")
+    user = LoginUserSerializer(help_text="Current user profile")
+
+
 class SignUpConfirmResponseSerializer(serializers.Serializer):
     """Response body for successful ``POST /signup/confirm/`` (fabric-auth#420).
 

--- a/blockauth/views/basic_auth_views.py
+++ b/blockauth/views/basic_auth_views.py
@@ -26,6 +26,7 @@ from blockauth.enums import AuthenticationType
 from blockauth.models.otp import OTP, OTPSubject
 from blockauth.notification import NotificationEvent, send_otp
 from blockauth.serializers.user_account_serializers import (
+    AuthStateResponseSerializer,
     BasicLoginResponseSerializer,
     BasicLoginSerializer,
     EmailChangeConfirmationSerializer,
@@ -51,6 +52,36 @@ from blockauth.utils.token import AUTH_TOKEN_CLASS, generate_auth_token
 
 logger = logging.getLogger(__name__)
 _User = get_block_auth_user_model()
+
+
+def _build_user_payload(user):
+    """Shape the ``user`` block used by every post-auth-state response.
+
+    Kept as a helper so basic-login, passwordless-confirm, wallet-login,
+    signup-confirm, refresh, and password mutation endpoints all emit the
+    same field set — clients can't tell one endpoint's user block from
+    another. ``first_name`` / ``last_name`` use ``getattr`` to stay
+    compatible with downstream user models that never added those fields.
+    """
+    return {
+        "id": user.id,
+        "email": user.email,
+        "is_verified": user.is_verified,
+        "wallet_address": user.wallet_address,
+        "first_name": getattr(user, "first_name", None),
+        "last_name": getattr(user, "last_name", None),
+    }
+
+
+def _issue_auth_tokens(user):
+    """Issue a fresh (access, refresh) pair for ``user`` using the custom-claims
+    path when available. Mirrors the pattern used by login + signup-confirm."""
+    try:
+        from blockauth.utils.token import generate_auth_token_with_custom_claims
+
+        return generate_auth_token_with_custom_claims(token_class=AUTH_TOKEN_CLASS(), user_id=str(user.id))
+    except ImportError:
+        return generate_auth_token(token_class=AUTH_TOKEN_CLASS(), user_id=str(user.id))
 
 
 class SignUpView(APIView):
@@ -585,7 +616,18 @@ class AuthRefreshTokenView(APIView):
             blockauth_logger.success(
                 "Refresh token successful", sanitize_log_context(request.data, {"user_id": user_id})
             )
-            return Response(data={"access": access_token, "refresh": new_refresh_token}, status=status.HTTP_200_OK)
+            # api-optimization: return user so shells can drop the
+            # follow-up /me/ round-trip on every refresh tick. The user
+            # row is already loaded above for custom-claims population
+            # so serializing it here is free.
+            response_serializer = AuthStateResponseSerializer(
+                {
+                    "access": access_token,
+                    "refresh": new_refresh_token,
+                    "user": _build_user_payload(user),
+                }
+            )
+            return Response(data=response_serializer.data, status=status.HTTP_200_OK)
         except AuthenticationFailed:
             raise
         except Exception as e:
@@ -700,8 +742,21 @@ class PasswordResetConfirmView(APIView):
             # send notification to user
             communication_class = get_config("DEFAULT_NOTIFICATION_CLASS")()
             communication_class.notify(method=method, event=NotificationEvent.SUCCESS_PASSWORD_RESET, context=context)
+
+            # api-optimization: auto-sign-in after reset. The user just
+            # proved ownership via the email OTP and the new password;
+            # forcing them to follow up with /login/basic/ is pure
+            # ceremony.
+            access_token, refresh_token = _issue_auth_tokens(user)
             blockauth_logger.success("Password reset confirmed", {"user": user.id, **request.data})
-            return Response({"message": "Password has been reset successfully."}, status=status.HTTP_200_OK)
+            response_serializer = AuthStateResponseSerializer(
+                {
+                    "access": access_token,
+                    "refresh": refresh_token,
+                    "user": _build_user_payload(user),
+                }
+            )
+            return Response(data=response_serializer.data, status=status.HTTP_200_OK)
         except ValidationError as e:
             blockauth_logger.warning(
                 "Password reset confirmation validation failed",
@@ -773,8 +828,22 @@ class PasswordChangeView(APIView):
 
             communication_class = get_config("DEFAULT_NOTIFICATION_CLASS")()
             communication_class.notify(method=method, event=NotificationEvent.SUCCESS_PASSWORD_CHANGE, context=context)
+
+            # api-optimization: hand back a fresh token pair so the
+            # client doesn't have to re-login or run a refresh round-trip
+            # after a password change. If refresh-token rotation is on,
+            # this is also the right moment to rotate out any tokens
+            # that were issued against the old password.
+            access_token, refresh_token = _issue_auth_tokens(user)
             blockauth_logger.success("Password change successful", {"user": user.id, **request.data})
-            return Response({"message": "Password has been changed successfully."}, status=status.HTTP_200_OK)
+            response_serializer = AuthStateResponseSerializer(
+                {
+                    "access": access_token,
+                    "refresh": refresh_token,
+                    "user": _build_user_payload(user),
+                }
+            )
+            return Response(data=response_serializer.data, status=status.HTTP_200_OK)
         except ValidationError as e:
             blockauth_logger.warning(
                 "Password change validation failed", sanitize_log_context(request.data, {"errors": e.detail})

--- a/blockauth/views/tests/test_password_views.py
+++ b/blockauth/views/tests/test_password_views.py
@@ -98,6 +98,33 @@ class TestPasswordResetConfirmView:
         })
         assert response.status_code in (status.HTTP_400_BAD_REQUEST, status.HTTP_429_TOO_MANY_REQUESTS)
 
+    def test_reset_confirm_auto_signs_in(self, api_client, create_user, create_otp):
+        """api-optimization v0.9.0: reset confirmation issues tokens + user
+        so the client is signed in immediately instead of following up
+        with /login/basic/."""
+        from blockauth.utils.token import Token
+
+        user = create_user(email="auto@test.com", password=STRONG_PASS)
+        create_otp(identifier="auto@test.com", subject=OTPSubject.PASSWORD_RESET, code="ABC123")
+
+        response = api_client.post(PASSWORD_RESET_CONFIRM_URL, {
+            "identifier": "auto@test.com",
+            "code": "ABC123",
+            "new_password": STRONG_PASS_NEW,
+            "confirm_password": STRONG_PASS_NEW,
+        })
+        assert response.status_code == status.HTTP_200_OK
+        assert "access" in response.data
+        assert "refresh" in response.data
+        assert response.data["access"]
+        assert response.data["refresh"]
+        user_payload = response.data["user"]
+        assert user_payload["id"] == str(user.id)
+        assert user_payload["email"] == "auto@test.com"
+        # Issued token is usable for the newly verified user
+        payload = Token().decode_token(response.data["access"])
+        assert str(payload["user_id"]) == str(user.id)
+
 
 @pytest.mark.django_db
 class TestPasswordChangeView:
@@ -138,3 +165,25 @@ class TestPasswordChangeView:
             "confirm_password": WEAK_PASS,
         })
         assert response.status_code in (status.HTTP_400_BAD_REQUEST, status.HTTP_429_TOO_MANY_REQUESTS)
+
+    def test_change_returns_fresh_tokens_and_user(self, authenticated_client):
+        """api-optimization v0.9.0: password change returns fresh tokens
+        so the client doesn't have to re-login or run an extra refresh
+        round-trip. Critical when ROTATE_REFRESH_TOKENS is enabled."""
+        from blockauth.utils.token import Token
+
+        client, user = authenticated_client(password=STRONG_PASS)
+        response = client.post(PASSWORD_CHANGE_URL, {
+            "old_password": STRONG_PASS,
+            "new_password": STRONG_PASS_NEW,
+            "confirm_password": STRONG_PASS_NEW,
+        })
+        assert response.status_code == status.HTTP_200_OK
+        assert "access" in response.data
+        assert "refresh" in response.data
+        assert response.data["access"]
+        assert response.data["refresh"]
+        user_payload = response.data["user"]
+        assert user_payload["id"] == str(user.id)
+        payload = Token().decode_token(response.data["access"])
+        assert str(payload["user_id"]) == str(user.id)

--- a/blockauth/views/tests/test_token_views.py
+++ b/blockauth/views/tests/test_token_views.py
@@ -24,6 +24,25 @@ class TestAuthRefreshTokenView:
         assert "access" in response.data
         assert "refresh" in response.data
 
+    def test_refresh_returns_user_payload(self, api_client, create_user):
+        """api-optimization v0.9.0: refresh response includes the user so
+        the shell can drop the 5-min /me/ poller. The view already loads
+        the user for custom-claims population."""
+        user = create_user(email="ref@test.com")
+        token = Token()
+        _, refresh = generate_auth_token(token_class=token, user_id=str(user.id))
+
+        response = api_client.post(REFRESH_URL, {"refresh_token": refresh})
+        assert response.status_code == status.HTTP_200_OK
+        assert "user" in response.data
+        user_payload = response.data["user"]
+        assert user_payload["id"] == str(user.id)
+        assert user_payload["email"] == "ref@test.com"
+        assert user_payload["is_verified"] is True
+        assert "wallet_address" in user_payload
+        assert "first_name" in user_payload
+        assert "last_name" in user_payload
+
     def test_refresh_with_access_token_fails(self, api_client, create_user):
         """Access tokens should not be usable as refresh tokens."""
         user = create_user()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "blockauth"
-version = "0.8.0"
+version = "0.9.0"
 description = "Comprehensive Python authentication package bridging Web2 and Web3"
 authors = [{name = "BloclabsHQ", email = "eng@bloclabs.com"}]
 license = {text = "MIT"}

--- a/uv.lock
+++ b/uv.lock
@@ -312,7 +312,7 @@ wheels = [
 
 [[package]]
 name = "blockauth"
-version = "0.8.0"
+version = "0.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "argon2-cffi" },


### PR DESCRIPTION
## Summary

API-optimization follow-up to [fabric-auth#420](https://github.com/BloclabsHQ/fabric-auth/issues/420). Any endpoint that mutates or re-issues auth state now hands the client the full post-mutation `{access, refresh, user}` tuple in one round-trip — no more \"succeeded, now call /me/\" ceremony.

## Changes

| Endpoint | Before | After |
|---|---|---|
| `POST /token/refresh/` | `{access, refresh}` | `{access, refresh, user}` (additive) |
| `POST /password/reset/confirm/` | `{\"message\": \"...\"}` | `{access, refresh, user}` (auto-login) |
| `POST /password/change/` | `{\"message\": \"...\"}` | `{access, refresh, user}` (fresh pair) |

### Round-trip math

| Flow | Before | After |
|---|---|---|
| Token refresh + profile hydration | 2 (refresh + `/me/`) | 1 |
| Password reset completion | 3 (request + confirm + login) | 2 |
| Password change + token rotation | 3 (change + login or refresh + `/me/`) | 1 |

Combined with v0.8.0 this closes the \"one call, complete answer\" loop on every auth-state-change endpoint. The shell's 5-min `/me/` poller (fabric-auth#420 task 3) can now be removed without losing profile-drift visibility — refresh ticks double as hydration.

## Infrastructure

- New **`AuthStateResponseSerializer`** in `user_account_serializers.py`. Shared across the three endpoints and usable by downstream services that add similar mutation endpoints.
- **`_build_user_payload`** / **`_issue_auth_tokens`** helpers in `basic_auth_views.py` so the user-dict shape stays lock-stepped with login + signup-confirm. Adding a field to the user payload is now a one-line change.

## Breaking change

Shipping as **0.9.0** per the pre-1.0 breaking-change policy. `/password/reset/confirm/` and `/password/change/` change body shape from `{\"message\": \"...\"}` to `{access, refresh, user}`. `/token/refresh/` is additive (existing `access` / `refresh` readers unaffected). Full migration notes in `CHANGELOG.md`.

## Out of scope

- `/email/change/confirm/` and `/wallet/link/` — both mutate identity-bearing state that may feed custom JWT claims; deferred to a follow-up once we've done a custom-claims-provider compatibility pass.
- OAuth callback response-shape audit (Google/Facebook/LinkedIn) — separate investigation.

## Test plan

- [x] 3 new tests: user payload on `/token/refresh/`, auto-login on `/password/reset/confirm/`, fresh tokens + user on `/password/change/`. Each asserts the access token decodes to the correct `user_id` so it's usable immediately.
- [x] Full suite: `uv run pytest blockauth/` → **472 passed, 0 failed**.
- [x] Version consistency: `blockauth.__version__ == \"0.9.0\"`, `pyproject.toml` + `uv.lock` aligned, CHANGELOG cut to `[0.9.0] - 2026-04-17`.