### PR TITLE
feat(observability): pluggable wallet-login metrics hook (#118, #116)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1204,6 +1204,150 @@ The rate limit can be configured in the settings.
 
 ---
 
+## Observability / Metrics
+
+BlockAuth emits observability events from the wallet-login flow via a
+single callback hook — it does **not** take a dependency on any
+particular metrics backend. Consumers wire the events into Prometheus,
+StatsD, OpenTelemetry, structured logs, or nothing at all.
+
+Set `BLOCK_AUTH_SETTINGS["METRICS_CALLBACK"]` to the dotted path of a
+callable with signature:
+
+```python
+def emit(
+    event: str,
+    tags: dict | None = None,
+    *,
+    duration_s: float | None = None,
+    count: int = 1,
+) -> None: ...
+```
+
+If the setting is absent, events are dropped. Any exception raised by
+the callback is caught and logged — a broken metrics pipe will never
+fail an auth request.
+
+### Events
+
+| Event | When | Tags | Extra |
+|---|---|---|---|
+| `wallet_login.challenge_issued` | `POST /login/wallet/challenge/` success | — | — |
+| `wallet_login.success` | `POST /login/wallet/` success | `flow` (`"siwe"`) | — |
+| `wallet_login.failure` | `POST /login/wallet/` rejection | `code` (e.g. `nonce_invalid`, `domain_mismatch`, `uri_host_mismatch`, `signature_mismatch`, `validation_error`, ...) | — |
+| `wallet_login.latency` | Every `POST /login/wallet/` (both outcomes) | `outcome` (`"success"` / `"failure"`) | `duration_s` |
+| `wallet_nonce.pruned` | Per batch in `prune_wallet_nonces` | — | `count` = rows deleted |
+
+Event names are a stable public contract; adding new events is
+non-breaking, renaming existing ones is not.
+
+### Example: Prometheus
+
+```python
+# myapp/observability.py
+from prometheus_client import Counter, Histogram
+
+_CHAL = Counter("wallet_login_challenge_issued_total", "...")
+_SUCCESS = Counter("wallet_login_success_total", "...", ["flow"])
+_FAIL = Counter("wallet_login_failure_total", "...", ["code"])
+_LAT = Histogram("wallet_login_latency_seconds", "...", ["outcome"])
+_PRUNED = Counter("wallet_nonce_pruned_total", "...")
+
+
+def emit(event, tags=None, *, duration_s=None, count=1):
+    tags = tags or {}
+    if event == "wallet_login.challenge_issued":
+        _CHAL.inc(count)
+    elif event == "wallet_login.success":
+        _SUCCESS.labels(**tags).inc(count)
+    elif event == "wallet_login.failure":
+        _FAIL.labels(**tags).inc(count)
+    elif event == "wallet_login.latency":
+        _LAT.labels(**tags).observe(duration_s or 0.0)
+    elif event == "wallet_nonce.pruned":
+        _PRUNED.inc(count)
+```
+
+```python
+# settings.py
+BLOCK_AUTH_SETTINGS = {
+    # ...
+    "METRICS_CALLBACK": "myapp.observability.emit",
+}
+```
+
+The host service owns the `/metrics` exposition endpoint (via
+`django-prometheus`, `prometheus_client.make_wsgi_app`, or a custom
+middleware). The default Prometheus registry is process-wide, so any
+counter the callback increments is scraped automatically.
+
+### Example: StatsD / OTel / logs
+
+The same callback works for any backend — translate the event in the
+consumer. For structured logging:
+
+```python
+import logging
+
+log = logging.getLogger("blockauth.metrics")
+
+def emit(event, tags=None, *, duration_s=None, count=1):
+    log.info(event, extra={"tags": tags or {}, "duration_s": duration_s, "count": count})
+```
+
+### Scheduling `prune_wallet_nonces`
+
+The `wallet_nonce.pruned` counter is only useful if the reaper actually
+runs. BlockAuth does **not** ship a scheduler — the consumer decides.
+Recommended cadence: every 5–15 minutes. Example invocations:
+
+```bash
+# cron / systemd timer
+*/10 * * * *  python manage.py prune_wallet_nonces
+
+# Celery Beat
+from celery import shared_task
+from django.core.management import call_command
+
+@shared_task
+def prune_wallet_nonces():
+    call_command("prune_wallet_nonces")
+```
+
+```yaml
+# Kubernetes CronJob (excerpt)
+apiVersion: batch/v1
+kind: CronJob
+spec:
+  schedule: "*/10 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: prune
+            image: my-auth-service:latest
+            command: ["python", "manage.py", "prune_wallet_nonces"]
+          restartPolicy: OnFailure
+```
+
+```hcl
+# ECS scheduled task (Terraform sketch)
+resource "aws_cloudwatch_event_rule" "prune_nonces" {
+  schedule_expression = "rate(10 minutes)"
+}
+# Target: RunTask on the auth-service task-definition with command
+# override ["python", "manage.py", "prune_wallet_nonces"]
+```
+
+Default behaviour deletes every expired row plus every consumed row
+older than 1 hour. `--older-than` (seconds), `--batch-size`, and
+`--dry-run` flags are available; see `python manage.py
+prune_wallet_nonces --help`. Failure mode if the command is never run:
+unbounded nonce-table growth and replay-window memory pressure.
+
+---
+
 ## 🧪 KDF Development & Testing
 
 ### Development Setup

--- a/blockauth/management/commands/prune_wallet_nonces.py
+++ b/blockauth/management/commands/prune_wallet_nonces.py
@@ -39,6 +39,7 @@ from django.db.models import Q
 from django.utils import timezone
 
 from blockauth.models.wallet_login_nonce import WalletLoginNonce
+from blockauth.observability import emit as emit_metric
 
 
 class Command(BaseCommand):
@@ -102,5 +103,6 @@ class Command(BaseCommand):
                 # Safety belt against an infinite loop if something goes
                 # wrong with the filter predicate.
                 break
+            emit_metric("wallet_nonce.pruned", count=batch_deleted)
 
         self.stdout.write(self.style.SUCCESS(f"Deleted {deleted} wallet login nonce(s)."))

--- a/blockauth/observability.py
+++ b/blockauth/observability.py
@@ -1,0 +1,159 @@
+"""
+Metrics / observability hook.
+
+Auth-pack is library code and must stay backend-agnostic: different
+consumers ship different stacks (Prometheus, StatsD, OpenTelemetry,
+structured-log sinks, or nothing at all). Rather than take a hard
+dependency on any of them, we expose a single callback and let the host
+service translate events into whatever it already has wired up.
+
+Configuration
+-------------
+
+Set ``BLOCK_AUTH_SETTINGS["METRICS_CALLBACK"]`` to the dotted path of a
+callable with signature::
+
+    def emit(
+        event: str,
+        tags: dict | None = None,
+        *,
+        duration_s: float | None = None,
+        count: int = 1,
+    ) -> None: ...
+
+If the setting is absent (the default), events are dropped and emission
+costs one dict lookup plus one attribute read.
+
+Events emitted by auth-pack
+---------------------------
+
+``wallet_login.challenge_issued``
+    On successful ``POST /login/wallet/challenge/``.
+
+``wallet_login.success``
+    On successful ``POST /login/wallet/``. Tags: ``flow`` (``"siwe"``).
+
+``wallet_login.failure``
+    On any rejected ``POST /login/wallet/``. Tags: ``code`` (the
+    machine-readable error code returned to the client).
+
+``wallet_login.latency``
+    Always emitted from ``POST /login/wallet/`` (both success and
+    failure paths). Tags: ``outcome`` (``"success"`` or ``"failure"``).
+    ``duration_s`` carries the wall-clock time spent in the handler.
+
+``wallet_nonce.pruned``
+    From the ``prune_wallet_nonces`` management command. ``count``
+    carries the number of rows deleted in the most recent batch.
+
+The event names are a stable public contract; adding new events is
+non-breaking, renaming existing ones is not.
+
+Safety
+------
+
+Exceptions raised by the consumer's callback are caught and logged. A
+broken metrics pipe must never take down an auth endpoint.
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+from typing import Any, Callable, Dict, Optional
+
+from django.conf import settings as django_settings
+from django.core.signals import setting_changed
+from django.dispatch import receiver
+
+logger = logging.getLogger(__name__)
+
+_SENTINEL = object()
+_resolved_callback: Any = _SENTINEL
+
+
+def _noop(event: str, tags: Optional[Dict[str, Any]] = None, **kwargs: Any) -> None:
+    """Default callback: drop everything."""
+
+
+def _resolve_callback() -> Callable[..., None]:
+    """Import and cache the user-supplied callback.
+
+    Missing / ``None`` setting resolves to :func:`_noop` so the hot path
+    stays branch-free after the first call. Any import error is logged
+    and we fall back to the no-op -- a misconfigured callback must not
+    take the login endpoint down.
+    """
+    global _resolved_callback
+    if _resolved_callback is not _SENTINEL:
+        return _resolved_callback
+
+    block_auth_settings = getattr(django_settings, "BLOCK_AUTH_SETTINGS", None) or {}
+    dotted: Optional[str] = (
+        block_auth_settings.get("METRICS_CALLBACK") if isinstance(block_auth_settings, dict) else None
+    )
+    if not dotted:
+        _resolved_callback = _noop
+        return _resolved_callback
+
+    try:
+        module_path, attr = dotted.rsplit(".", 1)
+        module = importlib.import_module(module_path)
+        callback = getattr(module, attr)
+    except (ValueError, ImportError, AttributeError) as exc:
+        logger.error(
+            "METRICS_CALLBACK %r could not be imported; falling back to no-op: %s",
+            dotted,
+            exc,
+        )
+        _resolved_callback = _noop
+        return _resolved_callback
+
+    if not callable(callback):
+        logger.error(
+            "METRICS_CALLBACK %r resolved to a non-callable; falling back to no-op",
+            dotted,
+        )
+        _resolved_callback = _noop
+        return _resolved_callback
+
+    _resolved_callback = callback
+    return _resolved_callback
+
+
+def reset_callback_cache() -> None:
+    """Clear the resolved-callback cache.
+
+    Only public so tests can rebind ``METRICS_CALLBACK`` via
+    ``override_settings`` and have the next :func:`emit` re-resolve.
+    Also wired to Django's ``setting_changed`` signal below so tests
+    generally don't need to call this directly.
+    """
+    global _resolved_callback
+    _resolved_callback = _SENTINEL
+
+
+@receiver(setting_changed)
+def _invalidate_cache_on_setting_change(sender, setting, **kwargs):
+    if setting == "BLOCK_AUTH_SETTINGS":
+        reset_callback_cache()
+
+
+def emit(
+    event: str,
+    tags: Optional[Dict[str, Any]] = None,
+    *,
+    duration_s: Optional[float] = None,
+    count: int = 1,
+) -> None:
+    """Emit a single observability event.
+
+    Never raises. If the consumer's callback raises, the exception is
+    logged and swallowed -- a broken metrics pipe cannot be allowed to
+    fail an auth request.
+    """
+    callback = _resolve_callback()
+    try:
+        callback(event, tags, duration_s=duration_s, count=count)
+    except Exception as exc:  # pragma: no cover - defensive, narrow not possible here
+        logger.exception("METRICS_CALLBACK raised while emitting %r: %s", event, exc)

--- a/blockauth/utils/tests/test_observability.py
+++ b/blockauth/utils/tests/test_observability.py
@@ -1,0 +1,336 @@
+"""Tests for ``blockauth.observability`` and the wallet-login emission points (#118).
+
+Split into three concerns:
+
+1. The callback-resolution contract — missing setting, bad dotted path,
+   non-callable target all fall back to the no-op. A raising callback is
+   caught and does not fail the caller.
+
+2. Each of the five wallet-login events fires from the expected site
+   with the expected tags. We register an in-memory callback via
+   ``override_settings`` and capture events, then drive real HTTP
+   requests / service calls / the management command.
+
+3. Latency emission covers both success and failure outcomes so a
+   consumer's histogram doesn't miss rejections.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from io import StringIO
+from typing import Any, Dict, List, Optional
+
+import pytest
+from django.core.cache import cache
+from django.core.management import call_command
+from django.test import override_settings
+from django.urls import reverse
+from django.utils import timezone as django_timezone
+from eth_account import Account
+from eth_account.messages import encode_defunct
+from rest_framework.test import APIClient
+
+from blockauth import observability
+from blockauth.models.wallet_login_nonce import WalletLoginNonce
+from blockauth.services.wallet_login_service import reset_wallet_login_service
+from blockauth.utils.siwe import build_siwe_message
+
+_TEST_PRIVATE_KEY = "0x" + "1" * 64
+_TEST_ACCOUNT = Account.from_key(_TEST_PRIVATE_KEY)
+_TEST_ADDRESS = _TEST_ACCOUNT.address
+_TEST_ADDRESS_LC = _TEST_ADDRESS.lower()
+
+
+# =============================================================================
+# Capture helper
+# =============================================================================
+
+#: Module-level recorder so ``override_settings`` can reach it by dotted
+#: path. Each test clears it in the fixture below.
+_events: List[Dict[str, Any]] = []
+
+
+def _record(event, tags=None, *, duration_s=None, count=1):
+    _events.append(
+        {"event": event, "tags": tags or {}, "duration_s": duration_s, "count": count},
+    )
+
+
+def _record_raising(event, tags=None, *, duration_s=None, count=1):
+    raise RuntimeError("metrics callback blew up")
+
+
+_NOT_CALLABLE = "not a callable"
+
+
+@pytest.fixture(autouse=True)
+def _reset_observability():
+    _events.clear()
+    observability.reset_callback_cache()
+    yield
+    _events.clear()
+    observability.reset_callback_cache()
+
+
+@pytest.fixture(autouse=True)
+def _override_wallet_login_settings(settings):
+    settings.WALLET_LOGIN_EXPECTED_DOMAINS = ("example.com",)
+    settings.WALLET_LOGIN_DEFAULT_CHAIN_ID = 1
+    settings.WALLET_LOGIN_NONCE_TTL_SECONDS = 300
+    reset_wallet_login_service()
+    yield
+    reset_wallet_login_service()
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache_between_tests():
+    cache.clear()
+    yield
+    cache.clear()
+
+
+def _sign(message: str) -> str:
+    signed = _TEST_ACCOUNT.sign_message(encode_defunct(text=message))
+    sig_hex = signed.signature.hex()
+    return sig_hex if sig_hex.startswith("0x") else "0x" + sig_hex
+
+
+def _find(event: str) -> Optional[Dict[str, Any]]:
+    for entry in _events:
+        if entry["event"] == event:
+            return entry
+    return None
+
+
+# =============================================================================
+# Callback resolution contract
+# =============================================================================
+
+
+class TestCallbackResolution:
+    def test_missing_setting_is_noop(self):
+        # No METRICS_CALLBACK set — the autouse fixture clears
+        # BLOCK_AUTH_SETTINGS between tests, so this emit must simply
+        # succeed without raising and without side effects.
+        observability.emit("wallet_login.success", {"flow": "siwe"})
+        assert _events == []
+
+    @override_settings(BLOCK_AUTH_SETTINGS={"METRICS_CALLBACK": "does.not.exist.callable"})
+    def test_unimportable_callback_falls_back_to_noop(self, caplog):
+        # First call logs and caches the no-op.
+        observability.emit("wallet_login.success", {"flow": "siwe"})
+        assert _events == []
+        assert any("could not be imported" in rec.getMessage() for rec in caplog.records)
+
+    @override_settings(
+        BLOCK_AUTH_SETTINGS={
+            "METRICS_CALLBACK": "blockauth.utils.tests.test_observability._NOT_CALLABLE",
+        }
+    )
+    def test_non_callable_target_falls_back_to_noop(self, caplog):
+        observability.emit("wallet_login.success", {"flow": "siwe"})
+        assert _events == []
+        assert any("non-callable" in rec.getMessage() for rec in caplog.records)
+
+    @override_settings(
+        BLOCK_AUTH_SETTINGS={
+            "METRICS_CALLBACK": "blockauth.utils.tests.test_observability._record_raising",
+        }
+    )
+    def test_callback_exception_is_swallowed(self, caplog):
+        # A broken metrics pipe must never fail the caller. The emit
+        # returns normally; the exception is logged.
+        observability.emit("wallet_login.success", {"flow": "siwe"})
+        assert any("METRICS_CALLBACK raised" in rec.getMessage() for rec in caplog.records)
+
+    @override_settings(
+        BLOCK_AUTH_SETTINGS={
+            "METRICS_CALLBACK": "blockauth.utils.tests.test_observability._record",
+        }
+    )
+    def test_setting_change_invalidates_cache(self):
+        # Resolve once under the record callback.
+        observability.emit("wallet_login.success", {"flow": "siwe"})
+        assert len(_events) == 1
+
+        # Flip to a different callback via override_settings. The
+        # setting_changed signal clears the cache, so the next emit
+        # resolves afresh.
+        with override_settings(BLOCK_AUTH_SETTINGS={"METRICS_CALLBACK": None}):
+            observability.emit("wallet_login.success", {"flow": "siwe"})
+            # No new entry — callback resolved to no-op this time.
+            assert len(_events) == 1
+
+
+# =============================================================================
+# Wallet-login emission sites
+# =============================================================================
+
+
+@pytest.fixture
+def _record_callback(settings):
+    settings.BLOCK_AUTH_SETTINGS = {
+        "METRICS_CALLBACK": "blockauth.utils.tests.test_observability._record",
+    }
+    observability.reset_callback_cache()
+    yield
+    observability.reset_callback_cache()
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("_record_callback")
+class TestWalletLoginEmissions:
+    def _challenge_then_login(self, client):
+        challenge = client.post(
+            reverse("wallet-login-challenge"),
+            {"address": _TEST_ADDRESS_LC},
+            format="json",
+        )
+        assert challenge.status_code == 200, challenge.content
+        message = challenge.json()["message"]
+        return client.post(
+            reverse("wallet-login"),
+            {
+                "wallet_address": _TEST_ADDRESS_LC,
+                "message": message,
+                "signature": _sign(message),
+            },
+            format="json",
+        )
+
+    def test_challenge_issued_fires_on_success(self):
+        client = APIClient()
+        resp = client.post(
+            reverse("wallet-login-challenge"),
+            {"address": _TEST_ADDRESS_LC},
+            format="json",
+        )
+        assert resp.status_code == 200
+        assert _find("wallet_login.challenge_issued") is not None
+
+    def test_success_fires_with_siwe_flow_tag(self):
+        client = APIClient()
+        resp = self._challenge_then_login(client)
+        assert resp.status_code == 200, resp.content
+
+        success = _find("wallet_login.success")
+        assert success is not None
+        assert success["tags"] == {"flow": "siwe"}
+
+    def test_failure_fires_with_service_error_code(self):
+        client = APIClient()
+        issued = django_timezone.now()
+        rogue = build_siwe_message(
+            domain="phisher.example",
+            address=_TEST_ADDRESS,
+            uri="https://phisher.example/",
+            chain_id=1,
+            nonce="abcdef1234567890abcdef1234567890",
+            issued_at=issued,
+            expiration_time=issued + timedelta(minutes=5),
+        )
+        resp = client.post(
+            reverse("wallet-login"),
+            {
+                "wallet_address": _TEST_ADDRESS_LC,
+                "message": rogue,
+                "signature": _sign(rogue),
+            },
+            format="json",
+        )
+        assert resp.status_code == 401
+        failure = _find("wallet_login.failure")
+        assert failure is not None
+        assert failure["tags"] == {"code": "domain_mismatch"}
+
+    def test_failure_fires_with_validation_error_code(self):
+        """Serializer-level validation failures get a distinct code so
+        Grafana can keep "malformed request" separate from
+        service-layer rejections.
+        """
+        client = APIClient()
+        # Missing ``signature`` field triggers the DRF validation path
+        # before the service layer ever sees the request.
+        resp = client.post(
+            reverse("wallet-login"),
+            {"wallet_address": _TEST_ADDRESS_LC, "message": "x"},
+            format="json",
+        )
+        assert resp.status_code == 400
+        failure = _find("wallet_login.failure")
+        assert failure is not None
+        assert failure["tags"] == {"code": "validation_error"}
+
+    def test_latency_fires_on_success_path(self):
+        client = APIClient()
+        resp = self._challenge_then_login(client)
+        assert resp.status_code == 200, resp.content
+        latency = _find("wallet_login.latency")
+        assert latency is not None
+        assert latency["tags"] == {"outcome": "success"}
+        assert latency["duration_s"] is not None
+        assert latency["duration_s"] >= 0.0
+
+    def test_latency_fires_on_failure_path(self):
+        """A rejected login must still produce a latency sample so
+        slow-failure trends are visible. Regression guard: moving the
+        emit out of the ``finally`` would silently drop failure
+        latency.
+        """
+        client = APIClient()
+        resp = client.post(
+            reverse("wallet-login"),
+            {"wallet_address": _TEST_ADDRESS_LC, "message": "x"},
+            format="json",
+        )
+        assert resp.status_code == 400
+        latency = _find("wallet_login.latency")
+        assert latency is not None
+        assert latency["tags"] == {"outcome": "failure"}
+
+
+# =============================================================================
+# Management command emission
+# =============================================================================
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("_record_callback")
+class TestPruneNonceEmission:
+    def test_pruned_event_carries_deleted_count(self):
+        now = django_timezone.now()
+        # Three expired rows, all will be reaped in a single batch.
+        for idx in range(3):
+            WalletLoginNonce.objects.create(
+                address="0x" + "a" * 40,
+                nonce=f"exp{idx:03d}" + "0" * 26,
+                domain="example.com",
+                uri="https://example.com/",
+                chain_id=1,
+                issued_at=now,
+                expires_at=now - timedelta(seconds=1),
+            )
+        call_command("prune_wallet_nonces", stdout=StringIO())
+
+        pruned = _find("wallet_nonce.pruned")
+        assert pruned is not None
+        assert pruned["count"] == 3
+
+    def test_pruned_event_not_fired_when_nothing_to_delete(self):
+        call_command("prune_wallet_nonces", stdout=StringIO())
+        assert _find("wallet_nonce.pruned") is None
+
+    def test_dry_run_does_not_emit(self):
+        now = django_timezone.now()
+        WalletLoginNonce.objects.create(
+            address="0x" + "a" * 40,
+            nonce="expired" + "0" * 25,
+            domain="example.com",
+            uri="https://example.com/",
+            chain_id=1,
+            issued_at=now,
+            expires_at=now - timedelta(seconds=1),
+        )
+        call_command("prune_wallet_nonces", "--dry-run", stdout=StringIO())
+        assert _find("wallet_nonce.pruned") is None

--- a/blockauth/views/wallet_auth_views.py
+++ b/blockauth/views/wallet_auth_views.py
@@ -15,6 +15,7 @@ Background: issue #90 (upstream port of fabric-auth #401 / #402).
 """
 
 import logging
+import time
 from typing import Union
 
 from drf_spectacular.utils import extend_schema
@@ -28,6 +29,8 @@ from blockauth.docs.wallet_auth_docs import wallet_email_add_docs
 from blockauth.enums import AuthenticationType
 from blockauth.models.otp import OTPSubject
 from blockauth.notification import send_otp
+from blockauth.observability import emit as emit_metric
+from blockauth.serializers.user_account_serializers import AuthStateResponseSerializer
 from blockauth.serializers.wallet_auth_serializers import (
     WalletChallengeRequestSerializer,
     WalletChallengeResponseSerializer,
@@ -46,7 +49,6 @@ from blockauth.services.wallet_user_linker import (
     WalletUserLinkError,
     wallet_user_linker,
 )
-from blockauth.serializers.user_account_serializers import AuthStateResponseSerializer
 from blockauth.utils.auth_state import build_user_payload, issue_auth_tokens
 from blockauth.utils.config import get_block_auth_user_model, get_config
 from blockauth.utils.custom_exception import ValidationErrorWithCode, WalletConflictError
@@ -147,6 +149,8 @@ class WalletChallengeView(APIView):
             )
             return _reject(exc)
 
+        emit_metric("wallet_login.challenge_issued")
+
         response_serializer = WalletChallengeResponseSerializer(
             {
                 "message": result.message,
@@ -198,56 +202,70 @@ class WalletAuthLoginView(APIView):
         tags=["Wallet"],
     )
     def post(self, request):
-        serializer = WalletLoginRequestSerializer(data=request.data)
+        started = time.perf_counter()
+        outcome = "failure"
         try:
-            serializer.is_valid(raise_exception=True)
-        except ValidationError as exc:
-            raise ValidationErrorWithCode(detail=exc.detail)
+            serializer = WalletLoginRequestSerializer(data=request.data)
+            try:
+                serializer.is_valid(raise_exception=True)
+            except ValidationError as exc:
+                emit_metric("wallet_login.failure", {"code": "validation_error"})
+                raise ValidationErrorWithCode(detail=exc.detail)
 
-        service = get_wallet_login_service()
-        try:
-            verified = service.verify_login(
-                wallet_address=serializer.validated_data["wallet_address"],
-                message=serializer.validated_data["message"],
-                signature=serializer.validated_data["signature"],
+            service = get_wallet_login_service()
+            try:
+                verified = service.verify_login(
+                    wallet_address=serializer.validated_data["wallet_address"],
+                    message=serializer.validated_data["message"],
+                    signature=serializer.validated_data["signature"],
+                )
+            except WalletLoginError as exc:
+                blockauth_logger.warning(
+                    "Wallet login rejected",
+                    sanitize_log_context({"error_code": exc.code}),
+                )
+                emit_metric("wallet_login.failure", {"code": exc.code})
+                return _reject(exc)
+
+            try:
+                linked = wallet_user_linker.link(wallet_address=verified.address)
+            except WalletUserLinkError as exc:
+                blockauth_logger.warning(
+                    "Wallet login link rejected",
+                    sanitize_log_context({"error_code": exc.code}),
+                )
+                emit_metric("wallet_login.failure", {"code": exc.code})
+                return _reject(exc)
+
+            blockauth_logger.success(
+                "Wallet login successful",
+                sanitize_log_context({"user": linked.user_id, "created": linked.created}),
             )
-        except WalletLoginError as exc:
-            blockauth_logger.warning(
-                "Wallet login rejected",
-                sanitize_log_context({"error_code": exc.code}),
+            emit_metric("wallet_login.success", {"flow": "siwe"})
+            outcome = "success"
+
+            user = linked.user
+            response_serializer = WalletLoginResponseSerializer(
+                {
+                    "access": linked.access_token,
+                    "refresh": linked.refresh_token,
+                    "user": {
+                        "id": user.id,
+                        "email": user.email,
+                        "is_verified": user.is_verified,
+                        "wallet_address": user.wallet_address,
+                        "first_name": getattr(user, "first_name", None),
+                        "last_name": getattr(user, "last_name", None),
+                    },
+                }
             )
-            return _reject(exc)
-
-        try:
-            linked = wallet_user_linker.link(wallet_address=verified.address)
-        except WalletUserLinkError as exc:
-            blockauth_logger.warning(
-                "Wallet login link rejected",
-                sanitize_log_context({"error_code": exc.code}),
+            return Response(response_serializer.data, status=status.HTTP_200_OK)
+        finally:
+            emit_metric(
+                "wallet_login.latency",
+                {"outcome": outcome},
+                duration_s=time.perf_counter() - started,
             )
-            return _reject(exc)
-
-        blockauth_logger.success(
-            "Wallet login successful",
-            sanitize_log_context({"user": linked.user_id, "created": linked.created}),
-        )
-
-        user = linked.user
-        response_serializer = WalletLoginResponseSerializer(
-            {
-                "access": linked.access_token,
-                "refresh": linked.refresh_token,
-                "user": {
-                    "id": user.id,
-                    "email": user.email,
-                    "is_verified": user.is_verified,
-                    "wallet_address": user.wallet_address,
-                    "first_name": getattr(user, "first_name", None),
-                    "last_name": getattr(user, "last_name", None),
-                },
-            }
-        )
-        return Response(response_serializer.data, status=status.HTTP_200_OK)
 
 
 class WalletEmailAddView(APIView):


### PR DESCRIPTION
Closes #118. Closes #116.

## Summary

- Add `BLOCK_AUTH_SETTINGS["METRICS_CALLBACK"]` — a single dotted-path callable the host wires to whatever metrics stack it already uses. Missing setting = no-op (zero overhead). Callback exceptions are caught and logged so a broken metrics pipe cannot fail login.
- Emit five events from the SIWE wallet-login path:
  - `wallet_login.challenge_issued`
  - `wallet_login.success` (tags: `flow=siwe`)
  - `wallet_login.failure` (tags: `code=<machine-readable>` — `nonce_invalid`, `domain_mismatch`, `uri_host_mismatch` once #117 lands, `signature_mismatch`, `validation_error`, ...)
  - `wallet_login.latency` (tags: `outcome=success|failure`, `duration_s`)
  - `wallet_nonce.pruned` (`count` = rows deleted per batch, from the management command)
- README section covers the callback contract, a Prometheus example, a structured-logging example, and (closing #116) `prune_wallet_nonces` scheduling guidance for cron, Celery Beat, Kubernetes CronJob, and ECS scheduled tasks.

## Why a callback instead of `prometheus_client`

Auth-pack is library code with ~10+ consumers on different stacks. Taking a hard dep on any specific metrics backend would couple all of them to it. The callback stays backend-agnostic: fabric-auth wires Prometheus, others can wire StatsD, OpenTelemetry, log sinks, or leave it unset.

## Tests

New module `blockauth/utils/tests/test_observability.py` — 14 tests across three concerns:

- **Callback resolution:** missing setting, unimportable dotted path, non-callable target, and raising callback all fall back to the no-op without breaking the caller. `setting_changed` invalidates the cache so `override_settings` works.
- **Emission sites:** every event fires from the expected site with the expected tags, driven by real HTTP requests.
- **Latency:** emitted on both success and failure outcomes (regression guard — moving the emit out of the `finally` would silently drop failure latency).
- **Prune command:** event fires per batch with the correct `count`; not emitted when nothing to delete or in `--dry-run`.

Full suite: 494 passed (480 previous + 14 new).

## Out of scope

- The Grafana dashboard / alert rules (live in fabric-auth / iac).
- Taking `prometheus_client` as a dep (explicit non-goal — see above).
- Tracing / OTel spans (separate concern).