### PR TITLE
feat(wallet-auth): WalletUnlinkView — upstream primitive symmetric to WalletLinkView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — pre-1
 
 ### Added
 
+- **`POST /wallet/unlink/`** (#122). Symmetric primitive to `POST /wallet/link/` that clears the authenticated user's linked wallet. No request body — the wallet to unlink is derived from the authenticated user (one linked wallet per user today). Clears `wallet_address` and drops the `WALLET` authentication-type marker. Response: `{"status": "unlinked"}`. Idempotent: returns `404 no_wallet_linked` when the user has no wallet linked (or on a second call after a successful unlink). Gated by the existing `Features.WALLET_LINK` flag — link and unlink enable together. Policy decisions (last-auth-method safeguard, event publication, audit logging) are deliberately left to the consumer layer, matching how `WalletLinkView` works.
+
 ### Changed
 
 ### Fixed

--- a/blockauth/constants/core.py
+++ b/blockauth/constants/core.py
@@ -240,6 +240,7 @@ class URLNames:
     # Wallet
     WALLET_EMAIL_ADD = "wallet-email-add"
     WALLET_LINK = "wallet-link"
+    WALLET_UNLINK = "wallet-unlink"
 
     # Social Auth
     GOOGLE_LOGIN = "google-login"

--- a/blockauth/urls.py
+++ b/blockauth/urls.py
@@ -60,6 +60,7 @@ from blockauth.views.wallet_auth_views import (
     WalletChallengeView,
     WalletEmailAddView,
     WalletLinkView,
+    WalletUnlinkView,
 )
 
 # Note: All endpoints include trailing slashes for consistency.
@@ -117,6 +118,7 @@ URL_PATTERN_MAPPINGS = {
     ],
     Features.WALLET_LINK: [
         ("wallet/link/", WalletLinkView, URLNames.WALLET_LINK),
+        ("wallet/unlink/", WalletUnlinkView, URLNames.WALLET_UNLINK),
     ],
     # Passkey/WebAuthn authentication endpoints
     Features.PASSKEY_AUTH: [

--- a/blockauth/views/tests/test_wallet_unlink_view.py
+++ b/blockauth/views/tests/test_wallet_unlink_view.py
@@ -1,0 +1,146 @@
+"""
+Integration tests for WalletUnlinkView.
+
+Focus: HTTP contract, credential wipe, idempotency, auth gate, feature flag.
+No crypto here — unlink takes no body.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from rest_framework import status
+from rest_framework.test import APIRequestFactory
+
+from blockauth.views.wallet_auth_views import WalletUnlinkView
+
+factory = APIRequestFactory()
+VIEW = WalletUnlinkView.as_view()
+
+LINKED_ADDRESS = "0xabcdef1234567890abcdef1234567890abcdef12"
+
+
+def _make_user(wallet_address=LINKED_ADDRESS):
+    user = MagicMock()
+    user.id = "user-test-uuid-123"
+    user.pk = "user-test-uuid-123"
+    user.wallet_address = wallet_address
+    user.is_authenticated = True
+    user.authentication_types = ["WALLET"] if wallet_address else []
+    return user
+
+
+class TestAuthGate:
+    def test_unauthenticated_returns_401(self):
+        request = factory.post("/wallet/unlink/")
+        response = VIEW(request)
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+class TestSuccessPath:
+    def test_valid_request_returns_200_with_unlinked_status(self):
+        user = _make_user()
+        request = factory.post("/wallet/unlink/")
+        request._force_auth_user = user
+
+        response = VIEW(request)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data == {"status": "unlinked"}
+
+    def test_clears_wallet_address(self):
+        user = _make_user()
+        request = factory.post("/wallet/unlink/")
+        request._force_auth_user = user
+
+        VIEW(request)
+
+        assert user.wallet_address is None
+        user.save.assert_called()
+
+    def test_removes_wallet_authentication_type(self):
+        user = _make_user()
+        request = factory.post("/wallet/unlink/")
+        request._force_auth_user = user
+
+        VIEW(request)
+
+        user.remove_authentication_type.assert_called_once_with("WALLET")
+
+
+class TestIdempotency:
+    def test_user_with_no_wallet_returns_404_no_wallet_linked(self):
+        user = _make_user(wallet_address=None)
+        request = factory.post("/wallet/unlink/")
+        request._force_auth_user = user
+
+        response = VIEW(request)
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert response.data["error"]["code"] == "no_wallet_linked"
+
+    def test_user_with_empty_wallet_returns_404(self):
+        user = _make_user(wallet_address="")
+        request = factory.post("/wallet/unlink/")
+        request._force_auth_user = user
+
+        response = VIEW(request)
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert response.data["error"]["code"] == "no_wallet_linked"
+
+    def test_second_unlink_after_success_returns_404(self):
+        """First unlink clears wallet_address; second call sees None and 404s."""
+        user = _make_user()
+        request1 = factory.post("/wallet/unlink/")
+        request1._force_auth_user = user
+        first = VIEW(request1)
+        assert first.status_code == status.HTTP_200_OK
+
+        request2 = factory.post("/wallet/unlink/")
+        request2._force_auth_user = user
+        second = VIEW(request2)
+        assert second.status_code == status.HTTP_404_NOT_FOUND
+        assert second.data["error"]["code"] == "no_wallet_linked"
+
+    def test_no_wallet_does_not_call_remove_auth_type(self):
+        user = _make_user(wallet_address=None)
+        request = factory.post("/wallet/unlink/")
+        request._force_auth_user = user
+
+        VIEW(request)
+
+        user.remove_authentication_type.assert_not_called()
+        user.save.assert_not_called()
+
+
+class TestFeatureFlag:
+    def test_wallet_unlink_url_absent_when_wallet_link_disabled(self):
+        from blockauth.urls import build_urlpatterns
+
+        with patch("blockauth.urls.is_feature_enabled", side_effect=lambda f: f != "WALLET_LINK"):
+            patterns = build_urlpatterns()
+            names = [p.name for p in patterns if hasattr(p, "name")]
+            assert "wallet-unlink" not in names
+
+    def test_wallet_unlink_url_present_when_wallet_link_enabled(self):
+        from blockauth.urls import build_urlpatterns
+
+        with (
+            patch("blockauth.urls.is_feature_enabled", return_value=True),
+            patch("blockauth.urls.is_social_auth_configured", return_value=False),
+        ):
+            patterns = build_urlpatterns()
+            names = [p.name for p in patterns if hasattr(p, "name")]
+            assert "wallet-unlink" in names
+
+
+class TestRateLimiter:
+    def test_rate_limited_returns_429(self):
+        user = _make_user()
+        request = factory.post("/wallet/unlink/")
+        request._force_auth_user = user
+
+        with patch.object(WalletUnlinkView.unlink_throttle, "allow_request", return_value=False):
+            with patch.object(WalletUnlinkView.unlink_throttle, "get_block_reason", return_value="rate_limit"):
+                response = VIEW(request)
+
+        assert response.status_code == status.HTTP_429_TOO_MANY_REQUESTS

--- a/blockauth/views/wallet_auth_views.py
+++ b/blockauth/views/wallet_auth_views.py
@@ -414,3 +414,75 @@ class WalletLinkView(APIView):
             blockauth_logger.error("Wallet link failed", sanitize_log_context(request.data, {"error": str(e)}))
             logger.error(f"Wallet link request failed: {e}", exc_info=True)
             raise APIException()
+
+
+class WalletUnlinkView(APIView):
+    """``POST /wallet/unlink/`` — clear the caller's linked wallet.
+
+    Symmetric primitive to :class:`WalletLinkView`. The wallet to unlink is
+    derived from the authenticated user (one linked wallet per user today) —
+    no request body. On success, clears ``wallet_address`` and drops the
+    ``WALLET`` authentication-type marker.
+
+    Policy decisions (last-auth-method safeguard, event publication, audit
+    logging) are deliberately left to the consumer layer — this is the
+    credential-wipe primitive only. See issue #122.
+    """
+
+    permission_classes = (IsAuthenticated,)
+    unlink_throttle = EnhancedThrottle(rate=(10, 60), max_failures=5, cooldown_minutes=15)
+
+    @extend_schema(
+        operation_id="wallet-unlink",
+        summary="Wallet unlink — clear linked wallet for authenticated user",
+        description=(
+            "Clears the authenticated user's linked wallet address and drops "
+            "the `WALLET` authentication-type marker. Idempotent: returns "
+            "`404 no_wallet_linked` if the user has no wallet linked. No "
+            "request body — the wallet to unlink is derived from the "
+            "authenticated user."
+        ),
+        request=None,
+        responses={
+            200: {"type": "object", "properties": {"status": {"type": "string"}}},
+            401: {"description": "Unauthenticated"},
+            404: {"description": "No wallet linked"},
+        },
+        tags=["Wallet"],
+    )
+    def post(self, request):
+        if not self.unlink_throttle.allow_request(request, "wallet_unlink"):
+            reason = self.unlink_throttle.get_block_reason()
+            msg = (
+                "Too many failed attempts. Please try again later."
+                if reason == "cooldown"
+                else "Rate limit exceeded. Please try again later."
+            )
+            return Response(data={"detail": msg}, status=status.HTTP_429_TOO_MANY_REQUESTS)
+
+        user = request.user
+        blockauth_logger.info("Wallet unlink attempt", sanitize_log_context({"user": user.id}))
+
+        if not getattr(user, "wallet_address", None):
+            self.unlink_throttle.record_failure(request, "wallet_unlink")
+            return Response(
+                data={"error": {"code": "no_wallet_linked", "message": "No wallet linked to this account."}},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        try:
+            user.wallet_address = None
+            user.save(update_fields=["wallet_address"])
+            user.remove_authentication_type(AuthenticationType.WALLET)
+
+            self.unlink_throttle.record_success(request, "wallet_unlink")
+            blockauth_logger.success(
+                "Wallet unlinked successfully",
+                sanitize_log_context({"user": user.id}),
+            )
+            return Response(data={"status": "unlinked"}, status=status.HTTP_200_OK)
+        except Exception as e:
+            self.unlink_throttle.record_failure(request, "wallet_unlink")
+            blockauth_logger.error("Wallet unlink failed", sanitize_log_context({"user": user.id, "error": str(e)}))
+            logger.error(f"Wallet unlink request failed: {e}", exc_info=True)
+            raise APIException()


### PR DESCRIPTION
Closes #122.

## Summary

Adds `POST /wallet/unlink/` as the upstream credential-wipe primitive symmetric to the existing `POST /wallet/link/`. Scope is deliberately narrow — policy decisions (last-auth-method safeguard, event publication, audit logging) stay in the consumer layer, matching how `WalletLinkView` works today. fabric-auth #443 tracks the downstream wrapper.

## What ships

- `WalletUnlinkView` in `blockauth/views/wallet_auth_views.py`
  - `IsAuthenticated`, no request body — wallet derived from the authenticated user (one linked wallet per user today)
  - Clears `wallet_address`, drops `WALLET` authentication-type marker
  - Rate-limited via `EnhancedThrottle` with the same config as `WalletLinkView` (10 req / 60s, 5 failures, 15 min cooldown) under a separate `wallet_unlink` bucket so the two endpoints can't starve each other
- `URLNames.WALLET_UNLINK`
- Route wired under the existing `Features.WALLET_LINK` flag — link and unlink enable together (bundle option 1 from the issue)
- 11 integration tests in `blockauth/views/tests/test_wallet_unlink_view.py`
- CHANGELOG Unreleased entry

## Contract

| Scenario | Status | Body |
|----------|--------|------|
| Linked wallet, valid auth | 200 | `{"status": "unlinked"}` |
| No wallet linked (first call or second call after unlink) | 404 | `{"error": {"code": "no_wallet_linked", ...}}` |
| Unauthenticated | 401 | DRF default |
| Rate limited | 429 | `{"detail": ...}` |

## Acceptance (from #122)

- [x] Consumer can call `POST /wallet/unlink/` on a user with a linked wallet → 200, `wallet_address` is None afterward
- [x] Second call returns 404 `no_wallet_linked`
- [x] User with no wallet linked returns 404 `no_wallet_linked`
- [x] Unauthenticated returns 401
- [x] Rate-limited consistent with other `/wallet/*` routes
- [x] OpenAPI / schema reflection — `@extend_schema` applied
- [ ] Wiki `Key-Flows` page unlink row — follow-up, coordinate with #115 wiki rewrite

## Out of scope (intentionally)

- Last-auth-method safeguard — consumer-side policy (fabric-auth handles in #443)
- Event publication (`auth.user.auth_method_removed`) — consumer responsibility
- Audit logging — consumer responsibility (different sinks across consumers)
- Multi-wallet support — one wallet per user today; if/when this lands the endpoint grows an address param as separate work

## Test plan

- [x] `uv run pytest blockauth/views/tests/test_wallet_unlink_view.py` — 11/11 pass
- [x] `uv run pytest` — 509/509 pass (no regression in existing wallet/link/email/passkey/totp tests)
- [x] `uv run black --check` and `uv run isort --check-only` on all modified files — clean