### PR TITLE
fix(wallet-auth): normalize port in SIWE domain checks (#125)

### DIFF
--- a/blockauth/services/wallet_login_service.py
+++ b/blockauth/services/wallet_login_service.py
@@ -135,6 +135,12 @@ class WalletLoginService:
             host = _host_from_url(client_url)
             configured_domains = (host,) if host else ()
         self.expected_domains = configured_domains
+        # Issue #125: EIP-4361 §3.2 ``domain`` is the authority (``host[:port]``)
+        # and wallets bind it to ``window.location.host`` -- ports included.
+        # Membership tests run against the port-stripped host so the allow-list
+        # stays host-only and dev ports (Vite/Webpack/Next) don't need their
+        # own entries. Strict host equality on both sides preserves the binding.
+        self._expected_hosts = frozenset(_authority_host(d) for d in configured_domains if d)
         self.default_chain_id = default_chain_id or int(getattr(settings, "WALLET_LOGIN_DEFAULT_CHAIN_ID", 1))
         # Web3 instance only used for ``recover_message``. No network I/O --
         # ``Web3()`` without a provider is fine.
@@ -231,7 +237,11 @@ class WalletLoginService:
                 "wallet_address does not match the address embedded in the signed message",
             )
 
-        if parsed.domain not in self.expected_domains:
+        # Issue #125: ``parsed.domain`` is the EIP-4361 authority and may carry
+        # a port (``localhost:5173``). The allow-list is matched on host only --
+        # see ``_expected_hosts`` for why.
+        domain_host = _authority_host(parsed.domain)
+        if not domain_host or domain_host not in self._expected_hosts:
             raise WalletLoginError(
                 "domain_mismatch",
                 f"SIWE domain {parsed.domain!r} is not in the allowed set",
@@ -241,9 +251,12 @@ class WalletLoginService:
         # ``domain``. A SIWE message can carry a trusted domain but a URI
         # pointing at an attacker-controlled host; the user sees the
         # phisher origin and signs anyway. Enforce strict host equality
-        # (no subdomain leniency — matches the domain allow-list policy).
-        uri_host = urlparse(parsed.uri).hostname if parsed.uri else None
-        if uri_host is None or uri_host.lower() != parsed.domain.lower():
+        # (no subdomain leniency -- matches the domain allow-list policy).
+        # Issue #125: compare host-to-host so a non-default port on the
+        # authority (``localhost:5173``) doesn't trip the check against
+        # ``urlparse(uri).hostname`` (which strips the port by design).
+        uri_host = (urlparse(parsed.uri).hostname or "").lower() if parsed.uri else ""
+        if not uri_host or uri_host != domain_host:
             raise WalletLoginError(
                 "uri_host_mismatch",
                 f"SIWE URI host {uri_host!r} does not match domain {parsed.domain!r}",
@@ -342,7 +355,11 @@ class WalletLoginService:
                     "No allowed domains configured for wallet login",
                 )
             return self.expected_domains[0]
-        if domain not in self.expected_domains:
+        # Issue #125: callers pass the full authority (``localhost:5173``).
+        # Match on the bare host so the allow-list stays host-only -- the
+        # returned value preserves the port so the SIWE message the wallet
+        # signs carries the same authority the browser exposes.
+        if _authority_host(domain) not in self._expected_hosts:
             raise WalletLoginError(
                 "domain_not_allowed",
                 f"domain {domain!r} is not in the allowed set",
@@ -476,6 +493,27 @@ def _host_from_url(url: str) -> str:
     except ValueError:
         return ""
     return parsed.hostname or ""
+
+
+def _authority_host(authority: str) -> str:
+    """Return the lowercased host of an EIP-4361 ``domain`` authority.
+
+    EIP-4361 §3.2 lets ``domain`` carry the full ``host[:port]``. Wallets
+    bind it to ``window.location.host`` so dapps on a non-default port
+    (Vite/Webpack/Next dev servers, Docker host-forwarded ports, preview
+    deploys on ``:8443``) sign messages whose authority includes the port.
+    Membership tests against the allow-list and the URI-host equality
+    check both run on the bare host so port handling stays out of those
+    comparisons. IPv6 (``[::1]:5173``) routes through ``urlparse`` so the
+    bracket form parses correctly.
+    """
+    if not authority:
+        return ""
+    try:
+        parsed = urlparse(f"http://{authority}")
+    except ValueError:
+        return ""
+    return (parsed.hostname or "").lower()
 
 
 _singleton: Optional[WalletLoginService] = None

--- a/blockauth/utils/tests/test_wallet_login_siwe.py
+++ b/blockauth/utils/tests/test_wallet_login_siwe.py
@@ -492,6 +492,84 @@ class TestVerifyLogin:
             )
         assert exc_info.value.code == "nonce_chain_mismatch"
 
+    def test_accepts_authority_with_port(self):
+        """Issue #125 — EIP-4361 §3.2 lets ``domain`` carry ``host:port``.
+
+        MetaMask and other wallets bind ``siwe.domain`` to
+        ``window.location.host`` which keeps the port. ``urlparse(uri).hostname``
+        strips it. The pre-fix uri-host equality check therefore rejected
+        every dapp on a non-default port (Vite/Webpack/Next dev servers,
+        Docker host-forwarded ports, preview deploys on ``:8443``).
+        """
+        svc = WalletLoginService(
+            expected_domains=("localhost",),
+            default_chain_id=1,
+        )
+        challenge = svc.issue_challenge(
+            address=_TEST_ADDRESS_LC,
+            domain="localhost:5173",
+            uri="https://localhost:5173",
+        )
+        assert challenge.domain == "localhost:5173"
+        result = svc.verify_login(
+            wallet_address=_TEST_ADDRESS_LC,
+            message=challenge.message,
+            signature=_sign(challenge.message),
+        )
+        assert result.address == _TEST_ADDRESS_LC
+
+    def test_accepts_authority_with_port_when_allowlist_has_port(self):
+        """Issue #125 — existing deployments with port-equipped allow-list
+        entries (``localhost:5173``) keep working. Both sides of the
+        membership test get port-stripped, so the entry matches the
+        signed authority.
+        """
+        svc = WalletLoginService(
+            expected_domains=("localhost:5173",),
+            default_chain_id=1,
+        )
+        challenge = svc.issue_challenge(
+            address=_TEST_ADDRESS_LC,
+            domain="localhost:5173",
+            uri="https://localhost:5173",
+        )
+        result = svc.verify_login(
+            wallet_address=_TEST_ADDRESS_LC,
+            message=challenge.message,
+            signature=_sign(challenge.message),
+        )
+        assert result.address == _TEST_ADDRESS_LC
+
+    def test_rejects_authority_port_mismatch_against_different_host(self):
+        """Issue #125 — port normalization must not weaken host binding.
+
+        A signed message with domain ``localhost:5173`` and a URI on a
+        different host but the same port (``https://attacker.example:5173/``)
+        must still be rejected as ``uri_host_mismatch``. Stripping the port
+        only affects the port comparison; the host comparison stays strict.
+        """
+        svc = WalletLoginService(
+            expected_domains=("localhost",),
+            default_chain_id=1,
+        )
+        issued = django_timezone.now()
+        tampered = build_siwe_message(
+            domain="localhost:5173",
+            address=_TEST_ADDRESS,
+            uri="https://attacker.example:5173/",
+            chain_id=1,
+            nonce="abcdef1234567890abcdef1234567890",
+            issued_at=issued,
+            expiration_time=issued + timedelta(minutes=5),
+        )
+        with pytest.raises(WalletLoginError) as exc_info:
+            svc.verify_login(
+                wallet_address=_TEST_ADDRESS_LC,
+                message=tampered,
+                signature=_sign(tampered),
+            )
+        assert exc_info.value.code == "uri_host_mismatch"
+
 
 # =============================================================================
 # HTTP round-trip


### PR DESCRIPTION
Closes #125.

## Summary
- `parsed.domain` is the EIP-4361 §3.2 authority (`host[:port]`); wallets bind it to `window.location.host`. The pre-fix `uri_host_mismatch` check compared it to `urlparse(uri).hostname` (port stripped), so every dapp on a non-default port (Vite/Webpack/Next dev servers, Docker host-forwarded ports, preview deploys on `:8443`) was rejected.
- New `_authority_host()` strips the port via `urlparse(f"http://{authority}")` so the bare-host comparison works for IPv6 (`[::1]:5173`) too. The allow-list (`self._expected_hosts`) is normalized once at init so existing port-equipped configs (`WALLET_LOGIN_EXPECTED_DOMAINS=("localhost:5173",)`) keep working unchanged.
- Authority binding stays strict via the separate `nonce_row.domain == parsed.domain` check inside the consume transaction — the wallet still has to sign the exact authority the server minted.

## Behavior change worth flagging
The allow-list is now host-matched on both sides, so an entry of `localhost:5173` accepts any port on `localhost` (e.g. `localhost:8080`). This matches the issue's stated intent — "the allowlist stays host-only and doesn't need a separate entry for every dev port" — and the authority cross-check still rejects any message whose authority diverges from the one the server minted for that nonce.

## Test plan
- [x] New `TestVerifyLogin::test_accepts_authority_with_port` — exact issue-#125 repro (allow-list host-only, signed authority `localhost:5173`).
- [x] New `TestVerifyLogin::test_accepts_authority_with_port_when_allowlist_has_port` — back-compat for existing port-equipped allow-list entries.
- [x] New `TestVerifyLogin::test_rejects_authority_port_mismatch_against_different_host` — port stripping must not weaken host binding (`domain=localhost:5173`, `uri=https://attacker.example:5173/` still rejects).
- [x] Full `pytest` suite green (512 passed).
- [x] `black --check` and `isort --check-only` clean on changed files.