### PR TITLE
fix(auth-state): align build_user_payload with shell AuthUser schema (#128)

### DIFF
--- a/blockauth/utils/auth_state.py
+++ b/blockauth/utils/auth_state.py
@@ -15,18 +15,39 @@ from blockauth.utils.token import AUTH_TOKEN_CLASS, generate_auth_token
 def build_user_payload(user) -> dict:
     """Shape the ``user`` block used by every post-auth-state response.
 
-    ``first_name`` / ``last_name`` use ``getattr`` so downstream user
-    models that never added those fields stay compatible. The field set
-    matches ``blockauth.serializers.user_account_serializers.LoginUserSerializer``.
+    Matches the ``@bloclabshq/auth`` shell ``AuthUser`` schema:
+    ``is_active`` and ``date_joined`` (ISO-8601) are always present;
+    ``wallets`` is an array (empty when unlinked) so the model can grow
+    to many-wallet-per-user without another payload change;
+    ``wallet_address`` stays alongside ``wallets`` for transitional
+    compatibility. ``first_name`` / ``last_name`` are omitted when
+    unset (the shell models these as ``z.optional``, which rejects
+    ``null``) and use ``getattr`` so downstream user models that never
+    added those fields stay compatible.
+
+    ``is_active`` and ``date_joined`` are also read via ``getattr`` —
+    ``BlockUser`` extends ``AbstractBaseUser``, which exposes
+    ``is_active`` only as a class-attribute default and does not define
+    ``date_joined`` at all. Defensive reads keep the helper safe across
+    downstream user models that don't define these fields.
     """
-    return {
+    date_joined = getattr(user, "date_joined", None)
+    payload = {
         "id": user.id,
         "email": user.email,
         "is_verified": user.is_verified,
+        "is_active": getattr(user, "is_active", True),
+        "date_joined": date_joined.isoformat() if date_joined else None,
         "wallet_address": user.wallet_address,
-        "first_name": getattr(user, "first_name", None),
-        "last_name": getattr(user, "last_name", None),
+        "wallets": [user.wallet_address] if user.wallet_address else [],
     }
+    first_name = getattr(user, "first_name", None)
+    if first_name:
+        payload["first_name"] = first_name
+    last_name = getattr(user, "last_name", None)
+    if last_name:
+        payload["last_name"] = last_name
+    return payload
 
 
 def issue_auth_tokens(user) -> Tuple[str, str]:

--- a/blockauth/utils/tests/test_auth_state.py
+++ b/blockauth/utils/tests/test_auth_state.py
@@ -1,0 +1,172 @@
+"""Tests for ``blockauth.utils.auth_state.build_user_payload``.
+
+Covers the shape fix (#128) where the helper drifted from the
+``@bloclabshq/auth`` shell ``AuthUser`` schema:
+
+* ``is_active`` always present (true + false cases).
+* ``date_joined`` always present and serialized as ISO-8601 string.
+* ``wallets`` is ``[]`` when ``wallet_address`` unset, ``[address]`` when set.
+* ``first_name`` / ``last_name`` absent from payload when falsy, present
+  as string when set.
+* Downstream user model without ``first_name`` / ``last_name`` attributes
+  (the ``getattr`` guard path) — payload omits both keys cleanly, no
+  ``AttributeError``.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+from blockauth.utils.auth_state import build_user_payload
+
+
+def _make_user(**overrides):
+    """Build a duck-typed user stub. ``build_user_payload`` reads
+    attributes only, so a ``SimpleNamespace`` is sufficient — no Django
+    model or DB write needed.
+    """
+    defaults = {
+        "id": "01936f4e-1234-7abc-8def-0123456789ab",
+        "email": "user@example.com",
+        "is_verified": True,
+        "is_active": True,
+        "date_joined": datetime(2026, 4, 20, 12, 0, 0, tzinfo=timezone.utc),
+        "wallet_address": None,
+        "first_name": "",
+        "last_name": "",
+    }
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+class TestIsActive:
+    def test_is_active_true_present(self):
+        payload = build_user_payload(_make_user(is_active=True))
+        assert payload["is_active"] is True
+
+    def test_is_active_false_present(self):
+        payload = build_user_payload(_make_user(is_active=False))
+        assert payload["is_active"] is False
+
+
+class TestDateJoined:
+    def test_date_joined_serialized_as_iso8601_string(self):
+        joined = datetime(2026, 4, 20, 12, 0, 0, tzinfo=timezone.utc)
+        payload = build_user_payload(_make_user(date_joined=joined))
+        assert payload["date_joined"] == "2026-04-20T12:00:00+00:00"
+        assert isinstance(payload["date_joined"], str)
+
+    def test_date_joined_none_emits_null(self):
+        payload = build_user_payload(_make_user(date_joined=None))
+        assert payload["date_joined"] is None
+
+
+class TestWallets:
+    def test_wallets_empty_when_unset(self):
+        payload = build_user_payload(_make_user(wallet_address=None))
+        assert payload["wallets"] == []
+        assert payload["wallet_address"] is None
+
+    def test_wallets_populated_when_set(self):
+        address = "0x1234567890abcdef1234567890abcdef12345678"
+        payload = build_user_payload(_make_user(wallet_address=address))
+        assert payload["wallets"] == [address]
+        assert payload["wallet_address"] == address
+
+
+class TestFirstLastNameDropWhenFalsy:
+    def test_first_name_absent_when_empty_string(self):
+        payload = build_user_payload(_make_user(first_name=""))
+        assert "first_name" not in payload
+
+    def test_first_name_absent_when_none(self):
+        payload = build_user_payload(_make_user(first_name=None))
+        assert "first_name" not in payload
+
+    def test_first_name_present_when_set(self):
+        payload = build_user_payload(_make_user(first_name="Ada"))
+        assert payload["first_name"] == "Ada"
+
+    def test_last_name_absent_when_empty_string(self):
+        payload = build_user_payload(_make_user(last_name=""))
+        assert "last_name" not in payload
+
+    def test_last_name_present_when_set(self):
+        payload = build_user_payload(_make_user(last_name="Lovelace"))
+        assert payload["last_name"] == "Lovelace"
+
+
+class TestGetattrGuard:
+    """Downstream user models that never added ``first_name`` /
+    ``last_name`` fields should not trigger ``AttributeError``. Same
+    for ``date_joined`` (not defined on ``AbstractBaseUser``) — the
+    helper reads it defensively and emits ``None`` when absent.
+    """
+
+    def test_user_without_name_fields_omits_keys(self):
+        user = SimpleNamespace(
+            id="01936f4e-1234-7abc-8def-0123456789ab",
+            email="user@example.com",
+            is_verified=True,
+            is_active=True,
+            date_joined=datetime(2026, 4, 20, 12, 0, 0, tzinfo=timezone.utc),
+            wallet_address=None,
+        )
+        payload = build_user_payload(user)
+        assert "first_name" not in payload
+        assert "last_name" not in payload
+        assert payload["id"] == "01936f4e-1234-7abc-8def-0123456789ab"
+        assert payload["wallets"] == []
+
+    def test_user_without_date_joined_emits_null(self):
+        """``BlockUser`` extends ``AbstractBaseUser``, which has no
+        ``date_joined`` field. The helper must not crash on such models.
+        """
+        user = SimpleNamespace(
+            id="01936f4e-1234-7abc-8def-0123456789ab",
+            email="user@example.com",
+            is_verified=True,
+            is_active=True,
+            wallet_address=None,
+        )
+        payload = build_user_payload(user)
+        assert payload["date_joined"] is None
+        assert payload["is_active"] is True
+
+    def test_user_without_is_active_defaults_true(self):
+        """``AbstractBaseUser.is_active`` is a class attribute (default
+        ``True``). Downstream models that drop it entirely still get a
+        sensible default.
+        """
+        user = SimpleNamespace(
+            id="01936f4e-1234-7abc-8def-0123456789ab",
+            email="user@example.com",
+            is_verified=True,
+            wallet_address=None,
+        )
+        payload = build_user_payload(user)
+        assert payload["is_active"] is True
+
+
+class TestFullShape:
+    def test_payload_contains_all_required_keys(self):
+        address = "0x1234567890abcdef1234567890abcdef12345678"
+        payload = build_user_payload(
+            _make_user(
+                wallet_address=address,
+                first_name="Ada",
+                last_name="Lovelace",
+            )
+        )
+        assert set(payload.keys()) == {
+            "id",
+            "email",
+            "is_verified",
+            "is_active",
+            "date_joined",
+            "wallet_address",
+            "wallets",
+            "first_name",
+            "last_name",
+        }


### PR DESCRIPTION
## Summary

- Align `build_user_payload` with the `@bloclabshq/auth` shell `AuthUser` schema. Every login, signup-confirm, refresh, password-mutation, OAuth-callback, and identity-mutation response currently fails shell validation with "Login response user payload failed validation".
- Two problems fixed: missing `is_active` / `date_joined` / `wallets[]` keys, and `first_name` / `last_name` emitted as literal `null` (shell models these as `z.optional`, which rejects `null`).
- Closes #128.

## Shape change

Before (v0.13.1):
~~~python
{
    "id": user.id,
    "email": user.email,
    "is_verified": user.is_verified,
    "wallet_address": user.wallet_address,
    "first_name": None,
    "last_name": None,
}
~~~

After:
~~~python
{
    "id": user.id,
    "email": user.email,
    "is_verified": user.is_verified,
    "is_active": True,
    "date_joined": "2026-04-20T12:00:00+00:00",
    "wallet_address": user.wallet_address,
    "wallets": [user.wallet_address] if user.wallet_address else [],
    # first_name / last_name absent when unset; string when present
}
~~~

## Divergence from the issue proposal

The issue proposed reading `is_active` and `date_joined` as direct attributes — "safe to read directly on any downstream user model." That's not quite right: `BlockUser` extends `AbstractBaseUser`, which exposes `is_active` only as a class-attribute default and **does not define `date_joined` at all** (only `AbstractUser` does). Direct access crashed 18 existing view tests with `AttributeError: 'TestBlockUser' object has no attribute 'date_joined'`.

I kept the intended shape (both keys always present in the JSON) but read them via `getattr` with sensible defaults — same defensive pattern already used for `first_name` / `last_name`. For user models that extend `AbstractBaseUser` only, `date_joined` becomes `null` in the payload, which the shell schema can accept (`z.string().datetime().nullable()` or equivalent). For models that extend `AbstractUser` or add the field manually, the ISO-8601 string comes through as intended.

## Test plan

- [x] `blockauth/utils/tests/test_auth_state.py` — 15 new tests covering `is_active` true/false, `date_joined` ISO-8601 + null emission, `wallets[]` empty vs populated, `first_name` / `last_name` drop when falsy, and getattr-guard paths for user models without `date_joined` / `is_active` / `first_name` / `last_name`.
- [x] Full suite: 527 passed (no regressions).
- [x] `black`, `isort` clean on changed files.

## Release

No version bump here — this fix lands on `dev`. A separate release PR (`chore/release-0.13.2` → `main`) will bump `pyproject.toml` + `blockauth/__init__.py` to `0.13.2` and tag the release, matching the workflow used for #125 → #127.

## Downstream follow-up

Once v0.13.2 ships, fabric-auth bumps the pin v0.13.1 → v0.13.2 in a two-line PR. No code changes needed on that side — the helper's single call site at `fabric_auth/base/services/wallet_unlink_service.py:134` passes the dict through unchanged.