### PR TITLE
fix(auth-state): emit full AuthUser shape from LoginUserSerializer (#131)

### DIFF
--- a/blockauth/serializers/user_account_serializers.py
+++ b/blockauth/serializers/user_account_serializers.py
@@ -281,6 +281,14 @@ class LoginUserSerializer(serializers.Serializer):
     ``WalletLoginResponseSerializer`` so the three endpoints stay in lock-step.
     Do not add anything here that isn't safe to surface to the client --
     this object goes into the success response of an unauthenticated call.
+
+    Shape mirrors the ``@bloclabshq/auth`` shell ``AuthUser`` Zod schema
+    (issue #131): ``is_active``, ``date_joined``, ``wallets`` are always
+    present so the shell can ``parseAuthUser()`` without a follow-up
+    ``GET /me/`` round-trip. ``first_name`` / ``last_name`` are
+    ``required=False`` (Zod's ``.optional()`` rejects ``null``) — callers
+    must omit the keys entirely when the underlying value is unset, which
+    ``build_user_payload`` already does.
     """
 
     id = serializers.UUIDField(help_text="User UUID")
@@ -290,27 +298,42 @@ class LoginUserSerializer(serializers.Serializer):
         help_text="Email address (null for wallet-first accounts)",
     )
     is_verified = serializers.BooleanField(help_text="Whether the account is verified")
+    is_active = serializers.BooleanField(
+        help_text="Whether the account is active (defaults to True for AbstractBaseUser-derived models)",
+    )
+    date_joined = serializers.CharField(
+        allow_null=True,
+        required=False,
+        help_text=(
+            "ISO-8601 timestamp of account creation. Null when the downstream "
+            "user model does not define ``date_joined`` (BlockUser abstract base)."
+        ),
+    )
     wallet_address = serializers.CharField(
         allow_null=True,
         required=False,
         help_text="Ethereum wallet address (null for accounts without a linked wallet)",
     )
+    wallets = serializers.ListField(
+        child=serializers.CharField(),
+        help_text=(
+            "Linked wallet addresses. Single-row array derived from "
+            "``wallet_address`` until the user model supports multiples; "
+            "empty when no wallet is linked."
+        ),
+    )
     # first_name / last_name are optional because the abstract BlockUser
     # model does not define them; concrete downstream user models may.
-    # Callers should pass getattr(user, "first_name", None) when building
-    # the response dict so auth-pack stays compatible with minimal user
-    # models that never added profile fields.
+    # build_user_payload omits the keys entirely when the underlying value
+    # is null — required=False keeps the serializer from synthesizing a
+    # null entry, matching the shell's z.optional() contract.
     first_name = serializers.CharField(
-        allow_null=True,
-        allow_blank=True,
         required=False,
-        help_text="Given name (null if the downstream user model has no first_name field or it is unset)",
+        help_text="Given name (omitted entirely when unset)",
     )
     last_name = serializers.CharField(
-        allow_null=True,
-        allow_blank=True,
         required=False,
-        help_text="Family name (null if the downstream user model has no last_name field or it is unset)",
+        help_text="Family name (omitted entirely when unset)",
     )
 
 

--- a/blockauth/views/basic_auth_views.py
+++ b/blockauth/views/basic_auth_views.py
@@ -254,18 +254,15 @@ class SignUpConfirmView(APIView):
                     )
 
                 blockauth_logger.success("User signup confirmed", sanitize_log_context(request.data, {"user": user.id}))
+                # issue #131: route through build_user_payload so signup-confirm
+                # emits the same {is_active, date_joined, wallets} shape as the
+                # login endpoints — the shell's AuthUser Zod schema rejects
+                # responses missing these fields.
                 response_serializer = SignUpConfirmResponseSerializer(
                     {
                         "access": access_token,
                         "refresh": refresh_token,
-                        "user": {
-                            "id": user.id,
-                            "email": user.email,
-                            "is_verified": user.is_verified,
-                            "wallet_address": user.wallet_address,
-                            "first_name": getattr(user, "first_name", None),
-                            "last_name": getattr(user, "last_name", None),
-                        },
+                        "user": _build_user_payload(user),
                     }
                 )
                 return Response(data=response_serializer.data, status=status.HTTP_200_OK)
@@ -343,22 +340,17 @@ class BasicAuthLoginView(APIView):
                 access_token, refresh_token = generate_auth_token(token_class=AUTH_TOKEN_CLASS(), user_id=str(user.id))
             self.login_throttle.record_success(request, "basic_login")
             blockauth_logger.success("Basic login successful", sanitize_log_context(request.data, {"user": user.id}))
-            # Issue #97: return user payload so clients can hydrate profile
-            # state without a second ``GET /me/`` round-trip. Same shape as
-            # wallet-login. ``wallet_address`` is null for email-first users
-            # until they run the ``wallet/link/`` flow.
+            # Issue #97 / #131: return user payload so clients can hydrate
+            # profile state without a second ``GET /me/`` round-trip. Routed
+            # through build_user_payload so basic-login, passwordless-login,
+            # and wallet-login emit the same {is_active, date_joined,
+            # wallets} shape — the shell's AuthUser Zod schema rejects
+            # responses missing these fields.
             response_serializer = BasicLoginResponseSerializer(
                 {
                     "access": access_token,
                     "refresh": refresh_token,
-                    "user": {
-                        "id": user.id,
-                        "email": user.email,
-                        "is_verified": user.is_verified,
-                        "wallet_address": user.wallet_address,
-                        "first_name": getattr(user, "first_name", None),
-                        "last_name": getattr(user, "last_name", None),
-                    },
+                    "user": _build_user_payload(user),
                 }
             )
             return Response(data=response_serializer.data, status=status.HTTP_200_OK)
@@ -491,22 +483,15 @@ class PasswordlessLoginConfirmView(APIView):
             blockauth_logger.success(
                 "Passwordless login confirmed", sanitize_log_context(request.data, {"user": user.id})
             )
-            # Issue #97: mirror basic-login / wallet-login by returning the
-            # authenticated user so clients can hydrate profile state in one
-            # round-trip. ``wallet_address`` is null for email / SMS users
-            # that haven't linked a wallet yet.
+            # Issue #97 / #131: mirror basic-login / wallet-login by routing
+            # the user through build_user_payload so all three login paths
+            # emit the same {is_active, date_joined, wallets} shape that the
+            # shell's AuthUser Zod schema requires.
             response_serializer = PasswordlessLoginResponseSerializer(
                 {
                     "access": access_token,
                     "refresh": refresh_token,
-                    "user": {
-                        "id": user.id,
-                        "email": user.email,
-                        "is_verified": user.is_verified,
-                        "wallet_address": user.wallet_address,
-                        "first_name": getattr(user, "first_name", None),
-                        "last_name": getattr(user, "last_name", None),
-                    },
+                    "user": _build_user_payload(user),
                 }
             )
             return Response(data=response_serializer.data, status=status.HTTP_200_OK)

--- a/blockauth/views/tests/test_login_views.py
+++ b/blockauth/views/tests/test_login_views.py
@@ -78,11 +78,12 @@ class TestBasicLoginView:
         assert user_payload["id"] == str(user.id)
         assert user_payload["wallet_address"] == wallet
 
-    def test_login_user_payload_includes_first_last_name_keys(self, api_client, create_user):
-        """fabric-auth#420: login response user payload exposes first_name /
-        last_name keys so consumer shells can hydrate profile state without
-        a follow-up /me/ round-trip. Values are null on user models that do
-        not define the fields (BlockUser abstract base)."""
+    def test_login_user_payload_omits_first_last_name_when_unset(self, api_client, create_user):
+        """Issue #131: first_name / last_name are omitted from the response
+        when the underlying user has no value, matching the shell's AuthUser
+        Zod schema which models these fields with ``z.optional()`` (rejects
+        ``null``). BlockUser abstract base does not define the fields, so
+        the test fixture exercises the unset branch."""
         create_user(email="user@test.com", password=_TEST_PASSWORD)
         response = api_client.post(
             BASIC_LOGIN_URL,
@@ -93,10 +94,60 @@ class TestBasicLoginView:
         )
         assert response.status_code == status.HTTP_200_OK
         user_payload = response.data["user"]
-        assert "first_name" in user_payload
-        assert "last_name" in user_payload
-        assert user_payload["first_name"] is None
-        assert user_payload["last_name"] is None
+        assert "first_name" not in user_payload
+        assert "last_name" not in user_payload
+
+    def test_login_user_payload_full_shape(self, api_client, create_user):
+        """Issue #131: pin the full top-level key set of the user payload
+        so the shell's AuthUser Zod schema (is_active, date_joined,
+        wallets) cannot silently regress. Wallet-first / email-first
+        variants are covered by dedicated cases below."""
+        user = create_user(email="user@test.com", password=_TEST_PASSWORD)
+        response = api_client.post(
+            BASIC_LOGIN_URL,
+            {
+                "identifier": "user@test.com",
+                "password": _TEST_PASSWORD,
+            },
+        )
+        assert response.status_code == status.HTTP_200_OK
+        user_payload = response.data["user"]
+        # Required keys (issue #131)
+        assert set(user_payload.keys()) == {
+            "id",
+            "email",
+            "is_verified",
+            "is_active",
+            "date_joined",
+            "wallet_address",
+            "wallets",
+        }
+        assert user_payload["id"] == str(user.id)
+        assert user_payload["is_active"] is True
+        assert user_payload["wallets"] == []  # email-first user has no wallet
+
+    def test_login_user_payload_wallets_populated_when_linked(self, api_client, create_user):
+        """Issue #131: a user with a linked wallet surfaces the address
+        inside ``wallets`` as a single-row array, alongside the legacy
+        ``wallet_address`` scalar (kept for transitional compatibility)."""
+        wallet = "0xabc0000000000000000000000000000000000002"
+        create_user(
+            email="bothwallet@test.com",
+            password=_TEST_PASSWORD,
+            wallet_address=wallet,
+        )
+        response = api_client.post(
+            BASIC_LOGIN_URL,
+            {
+                "identifier": "bothwallet@test.com",
+                "password": _TEST_PASSWORD,
+            },
+        )
+        assert response.status_code == status.HTTP_200_OK
+        user_payload = response.data["user"]
+        assert user_payload["wallet_address"] == wallet
+        assert user_payload["wallets"] == [wallet]
+        assert user_payload["email"] == "bothwallet@test.com"
 
     def test_login_user_payload_does_not_leak_credentials(self, api_client, create_user):
         """Issue #99: basic-login's ``user`` payload must never contain
@@ -308,6 +359,33 @@ class TestPasswordlessLoginConfirmView:
         assert user_payload["id"] == str(created_user.id)
         assert user_payload["email"] == "fresh@test.com"
         assert user_payload["wallet_address"] is None
+
+    def test_confirm_user_payload_full_shape(self, api_client, create_user, create_otp):
+        """Issue #131: passwordless-confirm pins the same {is_active,
+        date_joined, wallets} keys as basic-login so the shell's AuthUser
+        Zod schema can ``parseAuthUser()`` either response interchangeably."""
+        create_user(email="user@test.com")
+        create_otp(identifier="user@test.com", subject=OTPSubject.LOGIN, code="ABC123")
+        response = api_client.post(
+            PASSWORDLESS_CONFIRM_URL,
+            {
+                "identifier": "user@test.com",
+                "code": "ABC123",
+            },
+        )
+        assert response.status_code == status.HTTP_200_OK
+        user_payload = response.data["user"]
+        assert set(user_payload.keys()) == {
+            "id",
+            "email",
+            "is_verified",
+            "is_active",
+            "date_joined",
+            "wallet_address",
+            "wallets",
+        }
+        assert user_payload["is_active"] is True
+        assert user_payload["wallets"] == []
 
     def test_confirm_user_payload_does_not_leak_credentials(self, api_client, create_user, create_otp):
         """Issue #99: passwordless-login's ``user`` payload must never

--- a/blockauth/views/tests/test_oauth_views.py
+++ b/blockauth/views/tests/test_oauth_views.py
@@ -7,8 +7,9 @@ is field-aware since #109 (v0.11.1): `first_name` is only included in the
 OAuth-signup works against minimal user models like TestBlockUser.
 """
 
-import pytest
 from unittest.mock import MagicMock, patch
+
+import pytest
 from django.urls import reverse
 from rest_framework import status
 
@@ -40,6 +41,7 @@ class TestGoogleAuthCallbackView:
             json=lambda: {"email": "google@test.com", "name": "Google User"},
         )
         from rest_framework.response import Response
+
         mock_social_login.return_value = Response(
             {"access": "test-access", "refresh": "test-refresh"},
             status=200,
@@ -85,6 +87,7 @@ class TestFacebookAuthCallbackView:
             MagicMock(status_code=200, json=lambda: {"email": "fb@test.com", "name": "FB User"}),
         ]
         from rest_framework.response import Response
+
         mock_social_login.return_value = Response(
             {"access": "test-access", "refresh": "test-refresh"},
             status=200,
@@ -120,6 +123,7 @@ class TestLinkedInAuthCallbackView:
             json=lambda: {"email": "li@test.com", "name": "LI User"},
         )
         from rest_framework.response import Response
+
         mock_social_login.return_value = Response(
             {"access": "test-access", "refresh": "test-refresh"},
             status=200,
@@ -150,31 +154,28 @@ class TestSocialLoginResponseShape:
         assert response.data["refresh"]
         assert "user" in response.data
         user_payload = response.data["user"]
-        for field in ("id", "email", "is_verified", "wallet_address", "first_name", "last_name"):
+        # Issue #131: AuthUser shell schema requires these to always be
+        # present; first_name / last_name are intentionally omitted when
+        # unset (z.optional() rejects null) and are covered separately.
+        for field in ("id", "email", "is_verified", "is_active", "date_joined", "wallet_address", "wallets"):
             assert field in user_payload, f"OAuth response missing {field}"
 
     def test_google_callback_returns_full_auth_state(self, create_user):
         user = create_user(email="g@test.com")
-        response = social_login(
-            email="g@test.com", name="Google User", provider_data={"provider": "google"}
-        )
+        response = social_login(email="g@test.com", name="Google User", provider_data={"provider": "google"})
         self._assert_full_auth_state_shape(response)
         assert response.data["user"]["id"] == str(user.id)
         assert response.data["user"]["email"] == "g@test.com"
 
     def test_facebook_callback_returns_full_auth_state(self, create_user):
         user = create_user(email="f@test.com")
-        response = social_login(
-            email="f@test.com", name="FB User", provider_data={"provider": "facebook"}
-        )
+        response = social_login(email="f@test.com", name="FB User", provider_data={"provider": "facebook"})
         self._assert_full_auth_state_shape(response)
         assert response.data["user"]["id"] == str(user.id)
 
     def test_linkedin_callback_returns_full_auth_state(self, create_user):
         user = create_user(email="l@test.com")
-        response = social_login(
-            email="l@test.com", name="LI User", provider_data={"provider": "linkedin"}
-        )
+        response = social_login(email="l@test.com", name="LI User", provider_data={"provider": "linkedin"})
         self._assert_full_auth_state_shape(response)
         assert response.data["user"]["id"] == str(user.id)
 

--- a/blockauth/views/tests/test_signup_views.py
+++ b/blockauth/views/tests/test_signup_views.py
@@ -189,11 +189,15 @@ class TestSignUpConfirmView:
         assert user_payload["email"] == "new@test.com"
         assert user_payload["is_verified"] is True
         assert user_payload["wallet_address"] is None
-        # first_name / last_name are present and null on TestBlockUser
-        # (the abstract model doesn't define them; concrete downstream
-        # models may).
-        assert user_payload["first_name"] is None
-        assert user_payload["last_name"] is None
+        # Issue #131: AuthUser shell schema requires is_active, date_joined,
+        # wallets[] in every login-shaped response. first_name / last_name
+        # are intentionally omitted when unset (z.optional() rejects null)
+        # — TestBlockUser doesn't define them.
+        assert user_payload["is_active"] is True
+        assert "date_joined" in user_payload
+        assert user_payload["wallets"] == []
+        assert "first_name" not in user_payload
+        assert "last_name" not in user_payload
 
     def test_confirm_access_token_decodes_for_new_user(self, api_client, create_user, create_otp):
         """The access token issued on signup confirm must decode with the

--- a/blockauth/views/tests/test_token_views.py
+++ b/blockauth/views/tests/test_token_views.py
@@ -40,8 +40,14 @@ class TestAuthRefreshTokenView:
         assert user_payload["email"] == "ref@test.com"
         assert user_payload["is_verified"] is True
         assert "wallet_address" in user_payload
-        assert "first_name" in user_payload
-        assert "last_name" in user_payload
+        # Issue #131: AuthUser shell schema requires is_active, date_joined,
+        # wallets in every login-shaped response. first_name / last_name are
+        # intentionally omitted when unset (z.optional() rejects null).
+        assert user_payload["is_active"] is True
+        assert "date_joined" in user_payload
+        assert user_payload["wallets"] == []
+        assert "first_name" not in user_payload
+        assert "last_name" not in user_payload
 
     def test_refresh_with_access_token_fails(self, api_client, create_user):
         """Access tokens should not be usable as refresh tokens."""

--- a/blockauth/views/tests/test_wallet_views.py
+++ b/blockauth/views/tests/test_wallet_views.py
@@ -4,10 +4,14 @@ Tests for wallet views: WalletAuthLoginView, WalletEmailAddView.
 Wallet signature verification is mocked since it requires real ECDSA operations.
 """
 
+from unittest.mock import MagicMock, patch
+
 import pytest
-from unittest.mock import patch, MagicMock
 from django.urls import reverse
 from rest_framework import status
+
+from blockauth.services.wallet_login_service import VerifiedLogin
+from blockauth.services.wallet_user_linker import LinkedUser
 
 WALLET_LOGIN_URL = reverse("wallet-login")
 WALLET_EMAIL_ADD_URL = reverse("wallet-email-add")
@@ -24,11 +28,14 @@ class TestWalletAuthLoginView:
         mock_auth.verify_signature.return_value = True
         mock_auth_cls.return_value = mock_auth
 
-        response = api_client.post(WALLET_LOGIN_URL, {
-            "wallet_address": VALID_WALLET,
-            "message": "Sign in to BlockAuth\nNonce: abc123\nTimestamp: 2025-01-01T00:00:00Z",
-            "signature": "0x" + "ab" * 65,
-        })
+        response = api_client.post(
+            WALLET_LOGIN_URL,
+            {
+                "wallet_address": VALID_WALLET,
+                "message": "Sign in to BlockAuth\nNonce: abc123\nTimestamp: 2025-01-01T00:00:00Z",
+                "signature": "0x" + "ab" * 65,
+            },
+        )
         # Should succeed or fail based on serializer validation
         # The exact behavior depends on WalletLoginSerializer internals
         assert response.status_code in (
@@ -36,14 +43,75 @@ class TestWalletAuthLoginView:
             status.HTTP_400_BAD_REQUEST,  # If serializer validation fails
         )
 
+    def test_wallet_login_user_payload_full_shape(self, api_client, create_user):
+        """Issue #131: wallet-login pins the same {is_active, date_joined,
+        wallets} keys as basic-login / passwordless-login. SIWE verification
+        and the linker are stubbed so the test exercises the view's payload-
+        building only — the cryptographic path has its own coverage in
+        ``utils/tests/test_wallet_login_siwe.py``.
+        """
+        # Wallet-first user (no email) — the canonical case the issue calls
+        # out: shell schema requires ``wallets`` to be populated even when
+        # ``email`` is null.
+        wallet = "0xabc0000000000000000000000000000000000003"
+        user = create_user(email=None, wallet_address=wallet, password=None)
+
+        verified = VerifiedLogin(address=wallet, nonce_id=1, siwe=MagicMock())
+        linked = LinkedUser(
+            user_id=str(user.id),
+            email=user.email or "",
+            access_token="test-access",
+            refresh_token="test-refresh",
+            created=False,
+            user=user,
+        )
+
+        with (
+            patch("blockauth.views.wallet_auth_views.get_wallet_login_service") as mock_get_svc,
+            patch("blockauth.views.wallet_auth_views.wallet_user_linker") as mock_linker,
+        ):
+            mock_svc = MagicMock()
+            mock_svc.verify_login.return_value = verified
+            mock_get_svc.return_value = mock_svc
+            mock_linker.link.return_value = linked
+
+            response = api_client.post(
+                WALLET_LOGIN_URL,
+                {
+                    "wallet_address": wallet,
+                    "message": "ignored — service is stubbed",
+                    "signature": "0x" + "ab" * 65,
+                },
+            )
+
+        assert response.status_code == status.HTTP_200_OK, response.data
+        user_payload = response.data["user"]
+        assert set(user_payload.keys()) == {
+            "id",
+            "email",
+            "is_verified",
+            "is_active",
+            "date_joined",
+            "wallet_address",
+            "wallets",
+        }
+        assert user_payload["id"] == str(user.id)
+        assert user_payload["email"] is None  # wallet-first user
+        assert user_payload["wallet_address"] == wallet
+        assert user_payload["wallets"] == [wallet]
+        assert user_payload["is_active"] is True
+
     def test_wallet_login_invalid_address_rejected(self, api_client):
         """Invalid wallet address should not succeed (400 or error)."""
         api_client.raise_request_exception = False
-        response = api_client.post(WALLET_LOGIN_URL, {
-            "wallet_address": "not-a-wallet",
-            "message": "Sign in",
-            "signature": "0x" + "ab" * 65,
-        })
+        response = api_client.post(
+            WALLET_LOGIN_URL,
+            {
+                "wallet_address": "not-a-wallet",
+                "message": "Sign in",
+                "signature": "0x" + "ab" * 65,
+            },
+        )
         assert response.status_code != status.HTTP_200_OK
 
     def test_wallet_login_missing_fields(self, api_client):
@@ -58,18 +126,24 @@ class TestWalletAuthLoginView:
 class TestWalletEmailAddView:
 
     def test_add_email_unauthenticated(self, api_client):
-        response = api_client.post(WALLET_EMAIL_ADD_URL, {
-            "email": "new@test.com",
-            "verification_type": "otp",
-        })
+        response = api_client.post(
+            WALLET_EMAIL_ADD_URL,
+            {
+                "email": "new@test.com",
+                "verification_type": "otp",
+            },
+        )
         assert response.status_code in (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN)
 
     def test_add_email_authenticated(self, authenticated_client):
         client, user = authenticated_client(email="wallet@test.com")
-        response = client.post(WALLET_EMAIL_ADD_URL, {
-            "email": "new@test.com",
-            "verification_type": "otp",
-        })
+        response = client.post(
+            WALLET_EMAIL_ADD_URL,
+            {
+                "email": "new@test.com",
+                "verification_type": "otp",
+            },
+        )
         # Should either succeed or fail based on wallet-specific validation
         assert response.status_code in (
             status.HTTP_200_OK,
@@ -82,13 +156,14 @@ class TestWalletEmailAddView:
         address. is_verified flips to False; new tokens carry that state."""
         from blockauth.utils.token import Token
 
-        client, user = authenticated_client(
-            email=None, wallet_address=VALID_WALLET, is_verified=True
+        client, user = authenticated_client(email=None, wallet_address=VALID_WALLET, is_verified=True)
+        response = client.post(
+            WALLET_EMAIL_ADD_URL,
+            {
+                "email": "add@test.com",
+                "verification_type": "otp",
+            },
         )
-        response = client.post(WALLET_EMAIL_ADD_URL, {
-            "email": "add@test.com",
-            "verification_type": "otp",
-        })
         if response.status_code != status.HTTP_200_OK:
             # Wallet-specific validation blocked — skip the auth-state
             # assertions (the shape assertion is covered by the other

--- a/blockauth/views/wallet_auth_views.py
+++ b/blockauth/views/wallet_auth_views.py
@@ -245,18 +245,15 @@ class WalletAuthLoginView(APIView):
             outcome = "success"
 
             user = linked.user
+            # issue #131: route the user payload through build_user_payload so
+            # wallet-login emits the same {is_active, date_joined, wallets}
+            # shape as basic-login / passwordless-login. The shell's AuthUser
+            # Zod schema rejects responses missing these fields.
             response_serializer = WalletLoginResponseSerializer(
                 {
                     "access": linked.access_token,
                     "refresh": linked.refresh_token,
-                    "user": {
-                        "id": user.id,
-                        "email": user.email,
-                        "is_verified": user.is_verified,
-                        "wallet_address": user.wallet_address,
-                        "first_name": getattr(user, "first_name", None),
-                        "last_name": getattr(user, "last_name", None),
-                    },
+                    "user": build_user_payload(user),
                 }
             )
             return Response(response_serializer.data, status=status.HTTP_200_OK)


### PR DESCRIPTION
Closes #131.

LoginUserSerializer was missing `is_active`, `date_joined`, and `wallets`, so even after PR #128 extended `build_user_payload` those fields were stripped back out on the wire. Wallet sign-in failed end-to-end on every consumer of `@bloclabshq/auth@0.11`: `parseAuthUser()` rejected the response and the user never completed sign-in.

Three other endpoints (`BasicAuthLoginView`, `PasswordlessLoginConfirmView`, `SignUpConfirmView`) also hand-rolled their own user dicts instead of going through `build_user_payload`, so any helper-side fix would silently miss them too.

## Changes

- `LoginUserSerializer`: declare `is_active`, `date_joined`, `wallets`. Drop `allow_null` on `first_name` / `last_name` so they're omitted entirely when unset (matches the shell's `z.optional()` contract — `null` is a parse error).
- Replace the four inlined user dicts in `wallet_auth_views.py`, `basic_auth_views.py` (basic-login + signup-confirm), and the passwordless-confirm view with `build_user_payload(user)`. All post-auth-state paths now share one shape.
- Tests: pin the full top-level key set (`{id, email, is_verified, is_active, date_joined, wallet_address, wallets}`) for basic-login, passwordless-login, wallet-login, signup-confirm, refresh, and OAuth callbacks. Cover the three wallet-state cases the issue calls out: wallet-first (email is null), email-first (wallets is empty), and both populated.
- Updated existing tests that asserted `first_name`/`last_name` should be present-as-null to assert they're absent.

## Test plan

- [x] `uv run pytest` — 544 passed (4 new tests added, 5 existing tests updated)
- [x] Wallet-first case (`email: null` + populated `wallets[]`) verified via the new shape test in `test_wallet_views.py`
- [x] Email-first case (`wallets: []` + populated `email`) verified in `test_login_views.py`
- [x] Email + wallet linked case verified in `test_login_views.py::test_login_user_payload_wallets_populated_when_linked`