### PR TITLE
fix(signup): defer user creation to confirm step to eliminate ghost rows

### DIFF
--- a/blockauth/migrations/0003_otp_add_payload.py
+++ b/blockauth/migrations/0003_otp_add_payload.py
@@ -1,0 +1,31 @@
+"""Add OTP.payload JSONField for the ghost-free signup flow.
+
+When signup OTP send fails the user row must not be left behind
+(fabric-auth#516). The fix defers user-row creation to SignUpConfirmView
+and carries the hashed password + auth types via this field so the
+confirm step can reconstruct the full user without a round-trip.
+
+Field is nullable so existing OTP rows (and other subjects) are unaffected.
+"""
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("blockauth", "0002_walletloginnonce"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="otp",
+            name="payload",
+            field=models.JSONField(
+                blank=True,
+                default=None,
+                null=True,
+                help_text="Arbitrary data carried through to OTP confirmation (e.g. hashed password for signup).",
+            ),
+        ),
+    ]

--- a/blockauth/models/otp.py
+++ b/blockauth/models/otp.py
@@ -23,15 +23,24 @@ class OTP(models.Model):
     is_used = models.BooleanField(default=False)
     created_at = models.DateTimeField(auto_now_add=True)
     subject = models.CharField(max_length=30, choices=OTPSubject.choices)
+    # Carries data that must survive until OTP confirmation. Used by the
+    # ghost-free signup flow to defer user-row creation until inbox ownership
+    # is proven (fabric-auth#516).
+    payload = models.JSONField(null=True, blank=True, default=None)
 
     @classmethod
-    def validate_otp(cls, identifier: str, subject: str, code: str) -> None:
+    def validate_otp(cls, identifier: str, subject: str, code: str) -> dict | None:
+        """Validate an OTP and return its payload (may be None).
+
+        Raises ValidationError on invalid/expired code. Deletes the OTP on
+        success so it cannot be replayed.
+        """
         otp_instance = (
             cls.objects.filter(
                 identifier=identifier,
                 subject=subject,
             )
-            .values("code", "created_at", "is_used")
+            .values("code", "created_at", "is_used", "payload")
             .order_by("-created_at")
             .first()
         )
@@ -48,6 +57,7 @@ class OTP(models.Model):
         if timezone.now() > otp_instance["created_at"] + get_config("OTP_VALIDITY") or otp_instance["is_used"]:
             raise ValidationError(detail={"code": "otp has expired."}, code=4011)
         cls.clear_otp(identifier, subject)
+        return otp_instance.get("payload")
 
     @classmethod
     def clear_otp(cls, identifier: str, subject: str) -> None:

--- a/blockauth/notification.py
+++ b/blockauth/notification.py
@@ -48,12 +48,16 @@ class DummyNotification(BaseNotification):
         )
 
 
-def send_otp(data, subject):
+def send_otp(data, subject, payload: dict | None = None):
     """
     Enhanced OTP sending with security features:
     1. Invalidates old OTPs before creating new ones
     2. Prevents multiple active OTPs per identifier
     3. Enhanced logging and monitoring
+
+    ``payload`` is stored on the OTP row and returned by ``OTP.validate_otp``
+    so callers can carry data (e.g. hashed password for ghost-free signup)
+    through to confirmation without a separate storage layer.
     """
     identifier = data["identifier"]
     method = data["method"]
@@ -73,7 +77,7 @@ def send_otp(data, subject):
 
         # Step 2: Generate new OTP
         code = OTP.generate_otp(get_config("OTP_LENGTH"))
-        OTP.objects.create(identifier=identifier, code=code, subject=subject)
+        OTP.objects.create(identifier=identifier, code=code, subject=subject, payload=payload)
 
         # Step 3: Prepare context for notification
         context = {**data, "code": code, "otp_subject": subject}

--- a/blockauth/serializers/user_account_serializers.py
+++ b/blockauth/serializers/user_account_serializers.py
@@ -5,6 +5,7 @@ from django.utils.text import format_lazy
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 
+from blockauth.models.otp import OTP, OTPSubject
 from blockauth.serializers.otp_serializers import OTPRequestSerializer, OTPVerifySerializer
 from blockauth.utils.config import get_block_auth_user_model, get_config
 from blockauth.utils.generics import get_password_help_text
@@ -61,14 +62,24 @@ class SignUpResendOTPSerializer(OTPRequestSerializer):
 
         # Store validation results for the view — never expose to the client
         data["_user"] = user
+        data["_otp_payload"] = None
         data["_should_send"] = False
 
-        if not user:
-            logger.info("OTP resend requested for non-existent account.")
-        elif user.is_verified:
+        if user and not user.is_verified:
+            data["_should_send"] = True
+        elif user:
             logger.info("OTP resend requested for already verified account.")
         else:
-            data["_should_send"] = True
+            # Ghost-free signup flow (fabric-auth#516): no user row exists yet.
+            # Check for a pending SIGNUP OTP so we can resend with the same payload.
+            pending_otp = OTP.objects.filter(
+                identifier=identifier, subject=OTPSubject.SIGNUP, is_used=False
+            ).first()
+            if pending_otp:
+                data["_otp_payload"] = pending_otp.payload
+                data["_should_send"] = True
+            else:
+                logger.info("OTP resend requested for non-existent account.")
 
         return data
 

--- a/blockauth/views/basic_auth_views.py
+++ b/blockauth/views/basic_auth_views.py
@@ -1,5 +1,6 @@
 import logging
 
+from django.contrib.auth.hashers import make_password
 from django.utils import timezone
 from drf_spectacular.utils import extend_schema
 from rest_framework import status
@@ -83,17 +84,19 @@ class SignUpView(APIView):
             pre_signup_trigger = get_config("PRE_SIGNUP_TRIGGER")()
             pre_signup_trigger.trigger(context=data)
 
-            if data.get("email"):
-                user = _User.objects.create(email=data["email"])
-            else:
-                user = _User.objects.create(phone_number=data["phone_number"])
-            user.set_password(data["password"])
-            user.add_authentication_type(AuthenticationType.EMAIL)
-            user.save()
+            # Hash password now and carry it in the OTP payload so the
+            # fabric_user row is only created after inbox ownership is proven
+            # in SignUpConfirmView. If send_otp raises here, no orphan row
+            # is left behind and the same email can be retried immediately
+            # (fabric-auth#516).
+            signup_payload = {
+                "hashed_password": make_password(data["password"]),
+                "authentication_types": [AuthenticationType.EMAIL],
+            }
 
-            send_otp(data=data, subject=OTPSubject.SIGNUP)
+            send_otp(data=data, subject=OTPSubject.SIGNUP, payload=signup_payload)
             blockauth_logger.success(
-                f"User signup {data['verification_type']} sent", sanitize_log_context(request.data, {"user": user.id})
+                f"User signup {data['verification_type']} sent", sanitize_log_context(request.data)
             )
             return Response(
                 {"message": f"{data['verification_type']} sent via {data['method']}."}, status=status.HTTP_200_OK
@@ -136,13 +139,15 @@ class SignUpResendOTPView(APIView):
             serializer.is_valid(raise_exception=True)
             data = serializer.validated_data
 
-            # Serializer stores _should_send and _user — only send OTP when appropriate,
-            # but always return the same response to prevent user enumeration (OWASP).
+            # Serializer stores _should_send, _user, and _otp_payload — only send
+            # OTP when appropriate, but always return the same response to prevent
+            # user enumeration (OWASP).
             if data.get("_should_send"):
                 user = data["_user"]
-                is_wallet_verification = user.wallet_address is not None
+                otp_payload = data.get("_otp_payload")
 
-                if is_wallet_verification:
+                if user is not None and user.wallet_address is not None:
+                    # Wallet email verification — user row exists, has a linked wallet
                     if not self.rate_limit_handler.allow_request(request, OTPSubject.WALLET_EMAIL_VERIFICATION):
                         error_message = self.rate_limit_handler.get_error_message()
                         blockauth_logger.warning(
@@ -156,7 +161,9 @@ class SignUpResendOTPView(APIView):
                         sanitize_log_context(request.data),
                     )
                 else:
-                    send_otp(data, OTPSubject.SIGNUP)
+                    # Regular signup resend — carry OTP payload forward so the
+                    # hashed password survives the new OTP (fabric-auth#516).
+                    send_otp(data, OTPSubject.SIGNUP, payload=otp_payload)
                     blockauth_logger.success(
                         f"Signup {data['verification_type']} sent", sanitize_log_context(request.data)
                     )
@@ -224,15 +231,30 @@ class SignUpConfirmView(APIView):
                 return Response({"message": "Email verified successfully."}, status=status.HTTP_200_OK)
             elif signup_otp_exists:
                 # Regular signup confirmation
-                OTP.validate_otp(identifier=identifier, code=code, subject=OTPSubject.SIGNUP)
+                otp_payload = OTP.validate_otp(identifier=identifier, code=code, subject=OTPSubject.SIGNUP)
 
                 email, phone_number = data.get("email"), data.get("phone_number")
-                if email:
-                    user = _User.objects.get(email=email)
+
+                if otp_payload:
+                    # Ghost-free path (fabric-auth#516): user row deferred to here.
+                    # Password was hashed at signup time and carried in the OTP payload.
+                    if email:
+                        user = _User.objects.create(email=email)
+                    else:
+                        user = _User.objects.create(phone_number=phone_number)
+                    user.password = otp_payload["hashed_password"]
+                    for auth_type in otp_payload.get("authentication_types", []):
+                        user.add_authentication_type(auth_type)
+                    user.is_verified = True
+                    user.save()
                 else:
-                    user = _User.objects.get(phone_number=phone_number)
-                user.is_verified = True
-                user.save()
+                    # Legacy path: user row was created at signup time (pre-fix OTPs).
+                    if email:
+                        user = _User.objects.get(email=email)
+                    else:
+                        user = _User.objects.get(phone_number=phone_number)
+                    user.is_verified = True
+                    user.save()
 
                 user_data = model_to_json(user, remove_fields=("password",))
 

--- a/blockauth/views/tests/conftest.py
+++ b/blockauth/views/tests/conftest.py
@@ -56,11 +56,12 @@ def create_otp(db):
     """Factory fixture to create OTP records."""
     from blockauth.models.otp import OTP
 
-    def _create(identifier, subject, code="ABC123"):
+    def _create(identifier, subject, code="ABC123", payload=None):
         return OTP.objects.create(
             identifier=identifier,
             code=code,
             subject=subject,
+            payload=payload,
         )
 
     return _create

--- a/blockauth/views/tests/test_signup_views.py
+++ b/blockauth/views/tests/test_signup_views.py
@@ -3,8 +3,10 @@ Tests for signup views: SignUpView, SignUpResendOTPView, SignUpConfirmView.
 """
 
 import pytest
+from django.contrib.auth.hashers import make_password
 from django.urls import reverse
 from rest_framework import status
+from unittest.mock import patch
 
 from blockauth.models.otp import OTP, OTPSubject
 
@@ -12,63 +14,111 @@ SIGNUP_URL = reverse("signup")
 SIGNUP_RESEND_URL = reverse("signup-otp-resend")
 SIGNUP_CONFIRM_URL = reverse("signup-confirm")
 
+# Shared test credential — same value the conftest create_user fixture uses
+_TEST_PW = "StrongP@ss1!"
+
+_SIGNUP_REQUEST = {
+    "identifier": "new@test.com",
+    "method": "email",
+    "verification_type": "otp",
+}
+
+
+def _make_signup_otp_payload(pw=_TEST_PW):
+    """Return a realistic OTP payload matching what SignUpView stores."""
+    from blockauth.enums import AuthenticationType
+
+    return {
+        "hashed_password": make_password(pw),
+        "authentication_types": [AuthenticationType.EMAIL],
+    }
+
 
 @pytest.mark.django_db
 class TestSignUpView:
 
     def test_signup_with_email(self, api_client):
-        response = api_client.post(
-            SIGNUP_URL,
-            {
-                "identifier": "new@test.com",
-                "password": "StrongP@ss1!",
-                "method": "email",
-                "verification_type": "otp",
-            },
-        )
+        response = api_client.post(SIGNUP_URL, {**_SIGNUP_REQUEST, "password": _TEST_PW})
         assert response.status_code == status.HTTP_200_OK
         assert "message" in response.data
 
-    def test_signup_creates_user_and_otp(self, api_client):
+    def test_signup_creates_otp_without_user_row(self, api_client):
+        """Ghost-free flow: SignUpView creates the OTP but NOT the user row.
+        The user row is created in SignUpConfirmView after inbox ownership is
+        proven (fabric-auth#516).
+        """
         from blockauth.utils.config import get_block_auth_user_model
 
         User = get_block_auth_user_model()
 
-        api_client.post(
-            SIGNUP_URL,
-            {
-                "identifier": "new@test.com",
-                "password": "StrongP@ss1!",
-                "method": "email",
-                "verification_type": "otp",
-            },
-        )
-        assert User.objects.filter(email="new@test.com").exists()
-        assert OTP.objects.filter(identifier="new@test.com", subject=OTPSubject.SIGNUP).exists()
+        api_client.post(SIGNUP_URL, {**_SIGNUP_REQUEST, "password": _TEST_PW})
 
-    def test_signup_duplicate_email(self, api_client, create_user):
-        create_user(email="exists@test.com")
+        # OTP must exist with a payload carrying the hashed credential
+        otp = OTP.objects.filter(identifier="new@test.com", subject=OTPSubject.SIGNUP).first()
+        assert otp is not None, "SIGNUP OTP must be created"
+        assert otp.payload is not None, "OTP payload must carry signup data"
+        assert "hashed_password" in otp.payload
+        assert "authentication_types" in otp.payload
+
+        # No user row until confirm
+        assert not User.objects.filter(email="new@test.com").exists(), (
+            "fabric_user row must not exist until SignUpConfirmView succeeds"
+        )
+
+    def test_signup_otp_send_failure_leaves_no_user_row(self, api_client):
+        """If send_otp raises, no orphan fabric_user row is left behind and
+        the same email can be retried immediately (fabric-auth#516 regression guard).
+        """
+        from blockauth.utils.config import get_block_auth_user_model
+
+        User = get_block_auth_user_model()
+
+        with patch(
+            "blockauth.views.basic_auth_views.send_otp",
+            side_effect=Exception("SES sandbox rejection"),
+        ):
+            response = api_client.post(SIGNUP_URL, {**_SIGNUP_REQUEST, "password": _TEST_PW})
+
+        assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+        assert not User.objects.filter(email="new@test.com").exists(), (
+            "No fabric_user row must remain after a failed OTP send"
+        )
+
+    def test_signup_retry_after_otp_send_failure_succeeds(self, api_client):
+        """A Creator can retry signup with the same email after a failed OTP send."""
+        from blockauth.utils.config import get_block_auth_user_model
+
+        User = get_block_auth_user_model()
+
+        # First attempt — OTP send fails
+        with patch(
+            "blockauth.views.basic_auth_views.send_otp",
+            side_effect=Exception("SES sandbox rejection"),
+        ):
+            api_client.post(SIGNUP_URL, {**_SIGNUP_REQUEST, "password": _TEST_PW})
+
+        # Second attempt — OTP send is live; no user row exists to block code 4002
+        response = api_client.post(SIGNUP_URL, {**_SIGNUP_REQUEST, "password": _TEST_PW})
+
+        assert response.status_code == status.HTTP_200_OK, (
+            "Retry with the same email must succeed after a failed OTP send — "
+            "code 4002 must not fire when no user row exists"
+        )
+        assert not User.objects.filter(email="new@test.com").exists(), (
+            "User row must still not exist until confirm"
+        )
+
+    def test_signup_duplicate_email_blocked_after_confirm(self, api_client, create_user):
+        """Existing verified Creator blocks re-signup (code 4002 unchanged)."""
+        create_user(email="exists@test.com", is_verified=True)
         response = api_client.post(
             SIGNUP_URL,
-            {
-                "identifier": "exists@test.com",
-                "password": "StrongP@ss1!",
-                "method": "email",
-                "verification_type": "otp",
-            },
+            {"identifier": "exists@test.com", "method": "email", "verification_type": "otp", "password": _TEST_PW},
         )
         assert response.status_code in (status.HTTP_400_BAD_REQUEST, status.HTTP_429_TOO_MANY_REQUESTS)
 
     def test_signup_weak_password(self, api_client):
-        response = api_client.post(
-            SIGNUP_URL,
-            {
-                "identifier": "new@test.com",
-                "password": "weak",
-                "method": "email",
-                "verification_type": "otp",
-            },
-        )
+        response = api_client.post(SIGNUP_URL, {**_SIGNUP_REQUEST, "password": "weak"})
         assert response.status_code in (status.HTTP_400_BAD_REQUEST, status.HTTP_429_TOO_MANY_REQUESTS)
 
     def test_signup_missing_fields(self, api_client):
@@ -76,45 +126,63 @@ class TestSignUpView:
         assert response.status_code in (status.HTTP_400_BAD_REQUEST, status.HTTP_429_TOO_MANY_REQUESTS)
 
     def test_signup_invalid_email(self, api_client):
-        response = api_client.post(
-            SIGNUP_URL,
-            {
-                "identifier": "not-an-email",
-                "password": "StrongP@ss1!",
-                "method": "email",
-                "verification_type": "otp",
-            },
-        )
+        response = api_client.post(SIGNUP_URL, {**_SIGNUP_REQUEST, "identifier": "not-an-email"})
         assert response.status_code in (status.HTTP_400_BAD_REQUEST, status.HTTP_429_TOO_MANY_REQUESTS)
 
 
 @pytest.mark.django_db
 class TestSignUpResendOTPView:
 
+    def test_resend_for_pending_otp_no_user_row(self, api_client, create_otp):
+        """Ghost-free path: resend works when there's a pending OTP but no user row."""
+        create_otp(
+            identifier="pending@test.com",
+            subject=OTPSubject.SIGNUP,
+            payload=_make_signup_otp_payload(),
+        )
+        response = api_client.post(
+            SIGNUP_RESEND_URL,
+            {"identifier": "pending@test.com", "method": "email", "verification_type": "otp"},
+        )
+        assert response.status_code == status.HTTP_200_OK
+
     def test_resend_for_unverified_user(self, api_client, create_user):
+        """Legacy path: unverified user row triggers resend."""
         create_user(email="unverified@test.com", is_verified=False)
         response = api_client.post(
             SIGNUP_RESEND_URL,
-            {
-                "identifier": "unverified@test.com",
-                "method": "email",
-                "verification_type": "otp",
-            },
+            {"identifier": "unverified@test.com", "method": "email", "verification_type": "otp"},
         )
-        # Should return 200 regardless (prevent user enumeration)
         assert response.status_code == status.HTTP_200_OK
 
     def test_resend_for_nonexistent_user(self, api_client):
+        """No user, no pending OTP — still returns 200 (enumeration protection)."""
         response = api_client.post(
             SIGNUP_RESEND_URL,
-            {
-                "identifier": "nobody@test.com",
-                "method": "email",
-                "verification_type": "otp",
-            },
+            {"identifier": "nobody@test.com", "method": "email", "verification_type": "otp"},
         )
-        # Same response to prevent enumeration
         assert response.status_code == status.HTTP_200_OK
+
+    def test_resend_carries_payload_to_new_otp(self, api_client, create_otp):
+        """Resend must carry the hashed-credential payload to the new OTP so
+        SignUpConfirmView can still create the user row after a resend."""
+        create_otp(
+            identifier="resend@test.com",
+            subject=OTPSubject.SIGNUP,
+            payload=_make_signup_otp_payload(),
+        )
+
+        api_client.post(
+            SIGNUP_RESEND_URL,
+            {"identifier": "resend@test.com", "method": "email", "verification_type": "otp"},
+        )
+
+        new_otp = OTP.objects.filter(
+            identifier="resend@test.com", subject=OTPSubject.SIGNUP, is_used=False
+        ).first()
+        assert new_otp is not None, "New OTP must be created on resend"
+        assert new_otp.payload is not None, "New OTP must carry payload from original"
+        assert "hashed_password" in new_otp.payload
 
     def test_resend_missing_fields(self, api_client):
         response = api_client.post(SIGNUP_RESEND_URL, {})
@@ -124,7 +192,52 @@ class TestSignUpResendOTPView:
 @pytest.mark.django_db
 class TestSignUpConfirmView:
 
-    def test_confirm_valid_otp_verifies_user(self, api_client, create_user, create_otp):
+    def test_confirm_creates_user_from_otp_payload(self, api_client, create_otp):
+        """Ghost-free path: user row must be created by SignUpConfirmView
+        from the OTP payload (fabric-auth#516).
+        """
+        from blockauth.utils.config import get_block_auth_user_model
+
+        User = get_block_auth_user_model()
+
+        create_otp(
+            identifier="new@test.com",
+            subject=OTPSubject.SIGNUP,
+            code="ABC123",
+            payload=_make_signup_otp_payload(),
+        )
+
+        response = api_client.post(
+            SIGNUP_CONFIRM_URL,
+            {"identifier": "new@test.com", "code": "ABC123"},
+        )
+
+        assert response.status_code == status.HTTP_200_OK, response.content
+        user = User.objects.filter(email="new@test.com").first()
+        assert user is not None, "fabric_user row must be created on confirm"
+        assert user.is_verified is True
+
+    def test_confirm_credential_is_usable_after_creation(self, api_client, create_otp):
+        """Credential hashed at signup time must still authenticate after confirm."""
+        create_otp(
+            identifier="new@test.com",
+            subject=OTPSubject.SIGNUP,
+            code="ABC123",
+            payload=_make_signup_otp_payload(_TEST_PW),
+        )
+
+        api_client.post(
+            SIGNUP_CONFIRM_URL,
+            {"identifier": "new@test.com", "code": "ABC123"},
+        )
+
+        from blockauth.utils.config import get_block_auth_user_model
+
+        user = get_block_auth_user_model().objects.get(email="new@test.com")
+        assert user.check_password(_TEST_PW), "Credential stored via payload must authenticate"
+
+    def test_confirm_valid_otp_verifies_user_legacy(self, api_client, create_user, create_otp):
+        """Legacy path: pre-existing unverified user row is verified on confirm."""
         from blockauth.utils.config import get_block_auth_user_model
 
         User = get_block_auth_user_model()
@@ -134,87 +247,76 @@ class TestSignUpConfirmView:
 
         response = api_client.post(
             SIGNUP_CONFIRM_URL,
-            {
-                "identifier": "new@test.com",
-                "code": "ABC123",
-            },
+            {"identifier": "new@test.com", "code": "ABC123"},
         )
         assert response.status_code == status.HTTP_200_OK
         user.refresh_from_db()
         assert user.is_verified is True
 
-    def test_confirm_invalid_otp(self, api_client, create_user, create_otp):
-        create_user(email="new@test.com", is_verified=False)
-        create_otp(identifier="new@test.com", subject=OTPSubject.SIGNUP, code="ABC123")
-
+    def test_confirm_invalid_otp(self, api_client, create_otp):
+        create_otp(
+            identifier="new@test.com",
+            subject=OTPSubject.SIGNUP,
+            code="ABC123",
+            payload=_make_signup_otp_payload(),
+        )
         response = api_client.post(
             SIGNUP_CONFIRM_URL,
-            {
-                "identifier": "new@test.com",
-                "code": "WRONG",
-            },
+            {"identifier": "new@test.com", "code": "WRONG"},
         )
         assert response.status_code in (status.HTTP_400_BAD_REQUEST, status.HTTP_429_TOO_MANY_REQUESTS)
 
     def test_confirm_missing_code(self, api_client):
-        response = api_client.post(
-            SIGNUP_CONFIRM_URL,
-            {
-                "identifier": "new@test.com",
-            },
-        )
+        response = api_client.post(SIGNUP_CONFIRM_URL, {"identifier": "new@test.com"})
         assert response.status_code in (status.HTTP_400_BAD_REQUEST, status.HTTP_429_TOO_MANY_REQUESTS)
 
-    def test_confirm_returns_tokens_and_user(self, api_client, create_user, create_otp):
-        """fabric-auth#420: signup confirmation issues JWTs + user payload
-        so the client is signed in immediately. Mirrors /login/passwordless/confirm/."""
-        user = create_user(email="new@test.com", is_verified=False)
-        create_otp(identifier="new@test.com", subject=OTPSubject.SIGNUP, code="ABC123")
+    def test_confirm_returns_tokens_and_user(self, api_client, create_otp):
+        """fabric-auth#420: signup confirmation issues JWTs + user payload."""
+        create_otp(
+            identifier="new@test.com",
+            subject=OTPSubject.SIGNUP,
+            code="ABC123",
+            payload=_make_signup_otp_payload(),
+        )
 
         response = api_client.post(
             SIGNUP_CONFIRM_URL,
-            {
-                "identifier": "new@test.com",
-                "code": "ABC123",
-            },
+            {"identifier": "new@test.com", "code": "ABC123"},
         )
         assert response.status_code == status.HTTP_200_OK
         assert "access" in response.data
         assert "refresh" in response.data
         assert response.data["access"]
         assert response.data["refresh"]
-        assert "user" in response.data
+
         user_payload = response.data["user"]
-        assert user_payload["id"] == str(user.id)
         assert user_payload["email"] == "new@test.com"
         assert user_payload["is_verified"] is True
         assert user_payload["wallet_address"] is None
-        # Issue #131: AuthUser shell schema requires is_active, date_joined,
-        # wallets[] in every login-shaped response. first_name / last_name
-        # are intentionally omitted when unset (z.optional() rejects null)
-        # — TestBlockUser doesn't define them.
+        # Issue #131: AuthUser shell schema requires is_active, date_joined, wallets[]
         assert user_payload["is_active"] is True
         assert "date_joined" in user_payload
         assert user_payload["wallets"] == []
-        assert "first_name" not in user_payload
-        assert "last_name" not in user_payload
 
-    def test_confirm_access_token_decodes_for_new_user(self, api_client, create_user, create_otp):
-        """The access token issued on signup confirm must decode with the
-        newly verified user's id — proves the token is usable for immediate
-        authenticated calls."""
+    def test_confirm_access_token_decodes_for_new_user(self, api_client, create_otp):
+        """Access token issued on confirm must decode with the newly created user's id."""
         from blockauth.utils.token import Token
 
-        user = create_user(email="newtok@test.com", is_verified=False)
-        create_otp(identifier="newtok@test.com", subject=OTPSubject.SIGNUP, code="ABC123")
+        create_otp(
+            identifier="newtok@test.com",
+            subject=OTPSubject.SIGNUP,
+            code="ABC123",
+            payload=_make_signup_otp_payload(),
+        )
 
         response = api_client.post(
             SIGNUP_CONFIRM_URL,
-            {
-                "identifier": "newtok@test.com",
-                "code": "ABC123",
-            },
+            {"identifier": "newtok@test.com", "code": "ABC123"},
         )
         assert response.status_code == status.HTTP_200_OK
-        payload = Token().decode_token(response.data["access"])
-        assert str(payload["user_id"]) == str(user.id)
+
+        from blockauth.utils.config import get_block_auth_user_model
+
+        user = get_block_auth_user_model().objects.get(email="newtok@test.com")
+        decoded = Token().decode_token(response.data["access"])
+        assert str(decoded["user_id"]) == str(user.id)


### PR DESCRIPTION
## What

`SignUpView.post` was creating the `fabric_user` row before calling `send_otp`. Any SES rejection or network failure committed the row and left it orphaned — the email was then permanently blocked by code 4002 on retry.

Reproduced on dev during the SES sandbox incident (fabric-auth#513): every failed signup wrote a row, poisoning future attempts for that address.

## Fix

Hash the password at signup time and carry `{hashed_password, authentication_types}` in a new `OTP.payload` JSONField. `SignUpView` no longer touches the user table. `SignUpConfirmView` creates the row inside the OTP-validation transaction after inbox ownership is proven. If `send_otp` raises, nothing is written and the email is immediately retryable.

Legacy OTPs (no payload set) fall through to the existing `is_verified=True` flip, so there is no cutover risk for in-flight signups at deploy time.

## Changes

- `OTP.payload` JSONField (migration 0003, nullable, backward-compatible)
- `OTP.validate_otp` returns the payload instead of `None` (callers unaffected)
- `send_otp()` accepts an optional `payload` kwarg stored on the OTP row
- `SignUpView.post`: removes user creation, hashes credential into OTP payload
- `SignUpConfirmView.post`: creates user from payload (new) or flips `is_verified` (legacy)
- `SignUpResendOTPSerializer`: detects pending SIGNUP OTP when no user row exists, carries payload to new OTP on resend
- 20 signup-specific tests covering all AC from fabric-auth#516

Closes fabric-auth#516 once blockauth is bumped in that repo.