### PR TITLE
chore(release): 0.13.3

### DIFF
--- a/blockauth/__init__.py
+++ b/blockauth/__init__.py
@@ -28,7 +28,7 @@ Static utilities (no storage needed):
     backup_codes = TOTPService.generate_backup_codes()
 """
 
-__version__ = "0.13.2"
+__version__ = "0.13.3"
 
 # =============================================================================
 # Direct imports (Django-independent, no AppRegistryNotReady errors)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "blockauth"
-version = "0.13.2"
+version = "0.13.3"
 description = "Comprehensive Python authentication package bridging Web2 and Web3"
 authors = [{name = "BloclabsHQ", email = "eng@bloclabs.com"}]
 license = {text = "MIT"}


### PR DESCRIPTION
## Summary
- Bump version to 0.13.3 (patch)
- Ships the ghost-user signup fix from #135 (Closes fabric-auth#516)

## Test plan
- [x] `publish.yml` workflow validates tag matches `pyproject.toml`
- [x] CI green on #135 prior to merge