### PR TITLE
chore(release): 0.13.4

### DIFF
--- a/blockauth/__init__.py
+++ b/blockauth/__init__.py
@@ -28,7 +28,7 @@ Static utilities (no storage needed):
     backup_codes = TOTPService.generate_backup_codes()
 """
 
-__version__ = "0.13.3"
+__version__ = "0.13.4"
 
 # =============================================================================
 # Direct imports (Django-independent, no AppRegistryNotReady errors)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "blockauth"
-version = "0.13.3"
+version = "0.13.4"
 description = "Comprehensive Python authentication package bridging Web2 and Web3"
 authors = [{name = "BloclabsHQ", email = "eng@bloclabs.com"}]
 license = {text = "MIT"}


### PR DESCRIPTION
## Summary
- Bump to 0.13.4 to publish the ghost-user signup fix (#135).
- v0.13.3 tag was already published in a prior release cycle and does not include #135, so we skip straight to 0.13.4.

## Test plan
- [x] `publish.yml` validates tag matches `pyproject.toml`
- [x] CI green on #135 and #136 prior to this bump