### PR TITLE
fix(oauth): bind OAuth state to browser session (CSRF, RFC 6749 §10.12)

### DIFF
--- a/blockauth/utils/oauth_state.py
+++ b/blockauth/utils/oauth_state.py
@@ -1,0 +1,78 @@
+"""
+OAuth 2.0 `state` parameter helpers — CSRF protection for social-auth flows.
+
+Per RFC 6749 §10.12, every OAuth init MUST bind the callback to the browser
+session that started the flow. We do this by generating a cryptographically
+random token at init time, setting it as an HttpOnly / Secure / SameSite=Lax
+cookie, and mirroring it in the `state=` query param to the authorize URL.
+
+On callback, the view compares the cookie and the query param with
+`hmac.compare_digest` (constant-time) and rejects mismatches with 400 before
+touching the provider's token endpoint — so a CSRF probe never causes a real
+authorization code to be exchanged. The cookie is cleared on the successful
+response so it cannot be replayed.
+
+Why a cookie (rather than a server-side session store):
+  - fabric-auth is stateless behind Kong; adding a session store just for
+    OAuth state is heavier than a scoped, short-lived cookie.
+  - Short TTL (10 min) + HttpOnly + SameSite=Lax + compare_digest is the
+    pattern documented by OWASP for browser-initiated OAuth flows.
+"""
+
+import hmac
+import secrets
+
+from rest_framework.exceptions import ValidationError
+
+OAUTH_STATE_COOKIE_NAME = "blockauth_oauth_state"
+OAUTH_STATE_COOKIE_MAX_AGE = 600  # 10 minutes — covers human consent screens
+OAUTH_STATE_TOKEN_BYTES = 32
+
+
+def generate_state() -> str:
+    """Cryptographically random, URL-safe state token."""
+    return secrets.token_urlsafe(OAUTH_STATE_TOKEN_BYTES)
+
+
+def set_state_cookie(response, state: str) -> None:
+    """Bind the state token to the browser session via a short-lived cookie.
+
+    SameSite=Lax is required: the provider redirects back via a top-level
+    navigation (GET), which Lax permits while still blocking cross-site
+    subresource requests that could leak/replay the cookie.
+    """
+    response.set_cookie(
+        OAUTH_STATE_COOKIE_NAME,
+        state,
+        max_age=OAUTH_STATE_COOKIE_MAX_AGE,
+        httponly=True,
+        secure=True,
+        samesite="Lax",
+    )
+
+
+def verify_state(request) -> None:
+    """Compare the query `state` against the cookie in constant time.
+
+    Raises `ValidationError` (400) on any of: missing cookie, missing query,
+    mismatch. Callers MUST invoke this before making any call to the
+    provider's token endpoint — otherwise a CSRF probe can still consume a
+    real authorization code.
+    """
+    cookie_state = request.COOKIES.get(OAUTH_STATE_COOKIE_NAME)
+    query_state = request.query_params.get("state")
+
+    if not cookie_state or not query_state:
+        raise ValidationError({"detail": "OAuth state missing"}, 4030)
+
+    if not hmac.compare_digest(cookie_state, query_state):
+        raise ValidationError({"detail": "OAuth state mismatch"}, 4030)
+
+
+def clear_state_cookie(response) -> None:
+    """Clear the state cookie on the outbound response.
+
+    Must match the `samesite` attribute used at set time so browsers treat
+    the delete as applying to the same cookie (Set-Cookie with Max-Age=0).
+    """
+    response.delete_cookie(OAUTH_STATE_COOKIE_NAME, samesite="Lax")

--- a/blockauth/views/facebook_auth_views.py
+++ b/blockauth/views/facebook_auth_views.py
@@ -3,7 +3,6 @@ import urllib.parse
 
 import requests
 from django.shortcuts import redirect
-from django.utils import timezone
 from drf_spectacular.utils import extend_schema
 from rest_framework.exceptions import APIException, ValidationError
 from rest_framework.permissions import AllowAny
@@ -19,6 +18,7 @@ from blockauth.schemas.examples.social_auth import (
 from blockauth.utils.config import get_block_auth_user_model, get_config
 from blockauth.utils.generics import sanitize_log_context
 from blockauth.utils.logger import blockauth_logger
+from blockauth.utils.oauth_state import clear_state_cookie, generate_state, set_state_cookie, verify_state
 from blockauth.utils.social import social_login
 
 logger = logging.getLogger(__name__)
@@ -41,18 +41,21 @@ class FacebookAuthLoginView(APIView):
         if not all([facebook_client_id, callback_url]):
             raise ValidationError(social_invalid_auth_config.value, 4020)
 
+        state = generate_state()
         facebook_login_url = "https://www.facebook.com/v11.0/dialog/oauth?"
         params = {
             "client_id": facebook_client_id,
             "redirect_uri": callback_url,
             "scope": "email,public_profile",
             "response_type": "code",
-            "state": f"blockauth#{timezone.now().timestamp()}",
+            "state": state,
             "response_mode": "form_post",
         }
         url = facebook_login_url + urllib.parse.urlencode(params)
         blockauth_logger.info("Facebook login attempt", {"client_id": facebook_client_id, "redirect_uri": callback_url})
-        return redirect(url)
+        response = redirect(url)
+        set_state_cookie(response, state)
+        return response
 
 
 class FacebookAuthCallbackView(APIView):
@@ -75,6 +78,10 @@ class FacebookAuthCallbackView(APIView):
 
         if not all([facebook_client_id, facebook_client_secret, callback_url]):
             raise ValidationError(social_invalid_auth_config.value)
+
+        # CSRF protection — must run BEFORE the token exchange so a probe
+        # cannot consume a real authorization code.
+        verify_state(request)
 
         # Exchange authorization code for access token
         token_url = "https://graph.facebook.com/v11.0/oauth/access_token"
@@ -125,7 +132,9 @@ class FacebookAuthCallbackView(APIView):
             blockauth_logger.success(
                 "Facebook login successful", {"user_id": user_info.get("id"), "email": email, "name": name}
             )
-            return social_login(email=email, name=name, provider_data=provider_data)
+            response = social_login(email=email, name=name, provider_data=provider_data)
+            clear_state_cookie(response)
+            return response
         except ValidationError as ve:
             blockauth_logger.error(
                 "Facebook login validation error", {"error": str(ve), "data": sanitize_log_context(request.data)}

--- a/blockauth/views/google_auth_views.py
+++ b/blockauth/views/google_auth_views.py
@@ -1,4 +1,5 @@
 import logging
+import urllib.parse
 
 import requests
 from django.shortcuts import redirect
@@ -17,6 +18,7 @@ from blockauth.schemas.examples.social_auth import (
 from blockauth.utils.config import get_block_auth_user_model, get_config
 from blockauth.utils.generics import sanitize_log_context
 from blockauth.utils.logger import blockauth_logger
+from blockauth.utils.oauth_state import clear_state_cookie, generate_state, set_state_cookie, verify_state
 from blockauth.utils.social import social_login
 
 logger = logging.getLogger(__name__)
@@ -39,16 +41,20 @@ class GoogleAuthLoginView(APIView):
         if not all([google_client_id, callback_url]):
             raise ValidationError(social_invalid_auth_config.value, 4020)
 
-        google_auth_url = (
-            "https://accounts.google.com/o/oauth2/v2/auth?"
-            "response_type=code&"
-            f"client_id={google_client_id}&"
-            f"redirect_uri={callback_url}&"
-            "scope=email profile&"
-            "prompt=consent"
-        )
+        state = generate_state()
+        params = {
+            "response_type": "code",
+            "client_id": google_client_id,
+            "redirect_uri": callback_url,
+            "scope": "email profile",
+            "prompt": "consent",
+            "state": state,
+        }
+        google_auth_url = "https://accounts.google.com/o/oauth2/v2/auth?" + urllib.parse.urlencode(params)
         blockauth_logger.info("Google login attempt", sanitize_log_context(request.GET))
-        return redirect(google_auth_url)
+        response = redirect(google_auth_url)
+        set_state_cookie(response, state)
+        return response
 
 
 class GoogleAuthCallbackView(APIView):
@@ -71,6 +77,10 @@ class GoogleAuthCallbackView(APIView):
 
         if not all([google_client_id, google_client_secret, callback_url]):
             raise ValidationError(social_invalid_auth_config.value, 4020)
+
+        # CSRF protection — must run BEFORE the token exchange so a probe
+        # cannot consume a real authorization code.
+        verify_state(request)
 
         # Exchange authorization code for access token
         token_url = "https://www.googleapis.com/oauth2/v4/token"
@@ -118,7 +128,9 @@ class GoogleAuthCallbackView(APIView):
         try:
             provider_data = {"provider": "google", "user_info": user_info}
             blockauth_logger.success("Google login successful", {"email": email, "name": name})
-            return social_login(email=email, name=name, provider_data=provider_data)
+            response = social_login(email=email, name=name, provider_data=provider_data)
+            clear_state_cookie(response)
+            return response
         except ValidationError as ve:
             blockauth_logger.error(
                 "Google login validation error", {"error": str(ve), "data": sanitize_log_context(request.data)}

--- a/blockauth/views/linkedin_auth_views.py
+++ b/blockauth/views/linkedin_auth_views.py
@@ -1,8 +1,8 @@
 import logging
+import urllib.parse
 
 import requests
 from django.shortcuts import redirect
-from django.utils import timezone
 from drf_spectacular.utils import extend_schema
 from rest_framework.exceptions import APIException, ValidationError
 from rest_framework.permissions import AllowAny
@@ -18,6 +18,7 @@ from blockauth.schemas.examples.social_auth import (
 from blockauth.utils.config import get_block_auth_user_model, get_config
 from blockauth.utils.generics import sanitize_log_context
 from blockauth.utils.logger import blockauth_logger
+from blockauth.utils.oauth_state import clear_state_cookie, generate_state, set_state_cookie, verify_state
 from blockauth.utils.social import social_login
 
 logger = logging.getLogger(__name__)
@@ -40,15 +41,19 @@ class LinkedInAuthLoginView(APIView):
         if not all([linkedin_client_id, callback_url]):
             raise ValidationError({"detail": "Auth provider settings for linkedin is not properly configured"}, 4020)
 
-        linkein_auth_url = (
-            f"https://www.linkedin.com/oauth/v2/authorization?response_type=code"
-            f"&client_id={linkedin_client_id}"
-            f"&redirect_uri={callback_url}"
-            f"&scope=profile email openid"
-            f"&state=blockauth#{timezone.now().timestamp()}"
-        )
+        state = generate_state()
+        params = {
+            "response_type": "code",
+            "client_id": linkedin_client_id,
+            "redirect_uri": callback_url,
+            "scope": "profile email openid",
+            "state": state,
+        }
+        linkein_auth_url = "https://www.linkedin.com/oauth/v2/authorization?" + urllib.parse.urlencode(params)
         blockauth_logger.info("LinkedIn login attempt", sanitize_log_context(request.GET))
-        return redirect(linkein_auth_url)
+        response = redirect(linkein_auth_url)
+        set_state_cookie(response, state)
+        return response
 
 
 class LinkedInAuthCallbackView(APIView):
@@ -71,6 +76,10 @@ class LinkedInAuthCallbackView(APIView):
 
         if not all([linkedin_client_id, linkedin_client_secret, callback_url]):
             raise ValidationError(social_invalid_auth_config.value, 4020)
+
+        # CSRF protection — must run BEFORE the token exchange so a probe
+        # cannot consume a real authorization code.
+        verify_state(request)
 
         # Exchange authorization code for access token
         token_url = "https://www.linkedin.com/oauth/v2/accessToken"
@@ -113,7 +122,9 @@ class LinkedInAuthCallbackView(APIView):
         try:
             provider_data = {"provider": "linkedin", "user_info": user_info}
             blockauth_logger.success("LinkedIn login successful", {"email": email, "name": name})
-            return social_login(email=email, name=name, provider_data=provider_data)
+            response = social_login(email=email, name=name, provider_data=provider_data)
+            clear_state_cookie(response)
+            return response
         except ValidationError as ve:
             blockauth_logger.error(
                 "LinkedIn login validation error", {"error": str(ve), "data": sanitize_log_context(request.data)}

--- a/blockauth/views/tests/test_oauth_views.py
+++ b/blockauth/views/tests/test_oauth_views.py
@@ -5,6 +5,11 @@ Only external HTTP calls (requests.get/post) are mocked. social_login()
 is field-aware since #109 (v0.11.1): `first_name` is only included in the
 `get_or_create` defaults when the configured user model declares it, so
 OAuth-signup works against minimal user models like TestBlockUser.
+
+State/CSRF hardening (RFC 6749 §10.12): every init sets an HttpOnly
+`blockauth_oauth_state` cookie and mirrors the token in `state=`; every
+callback requires the cookie and query param to match via
+`hmac.compare_digest` before the provider's token endpoint is hit.
 """
 
 from unittest.mock import MagicMock, patch
@@ -13,7 +18,16 @@ import pytest
 from django.urls import reverse
 from rest_framework import status
 
+from blockauth.utils.oauth_state import OAUTH_STATE_COOKIE_NAME
 from blockauth.utils.social import social_login
+
+
+def _prime_state(api_client, value="valid-state-token"):
+    """Seed the state cookie so a callback request looks like it came from a
+    browser that actually started the flow. Returns the state value so tests
+    can pass it as the query param."""
+    api_client.cookies[OAUTH_STATE_COOKIE_NAME] = value
+    return value
 
 
 @pytest.mark.django_db
@@ -23,6 +37,25 @@ class TestGoogleAuthLoginView:
         response = api_client.get(reverse("google-login"))
         assert response.status_code == status.HTTP_302_FOUND
         assert "accounts.google.com" in response.url
+
+    def test_init_sets_state_cookie_and_query_param(self, api_client):
+        """Init must bind the browser session: cookie set + state= in the
+        redirect URL + the two values must match."""
+        response = api_client.get(reverse("google-login"))
+
+        assert OAUTH_STATE_COOKIE_NAME in response.cookies
+        cookie = response.cookies[OAUTH_STATE_COOKIE_NAME]
+        assert cookie.value, "state cookie must carry a token"
+        assert cookie["httponly"]
+        assert cookie["secure"]
+        assert cookie["samesite"].lower() == "lax"
+        assert cookie["max-age"] == 600
+
+        assert "state=" in response.url
+        from urllib.parse import parse_qs, urlparse
+
+        query_state = parse_qs(urlparse(response.url).query)["state"][0]
+        assert query_state == cookie.value
 
 
 @pytest.mark.django_db
@@ -46,12 +79,20 @@ class TestGoogleAuthCallbackView:
             {"access": "test-access", "refresh": "test-refresh"},
             status=200,
         )
+        state = _prime_state(api_client)
 
-        response = api_client.get(reverse("google-login-callback"), {"code": "auth-code"})
+        response = api_client.get(
+            reverse("google-login-callback"),
+            {"code": "auth-code", "state": state},
+        )
         assert response.status_code == status.HTTP_200_OK
         assert "access" in response.data
         assert "refresh" in response.data
         mock_social_login.assert_called_once()
+        # Success clears the state cookie so it can't be replayed.
+        cleared = response.cookies.get(OAUTH_STATE_COOKIE_NAME)
+        assert cleared is not None
+        assert cleared["max-age"] == 0
 
     @patch("blockauth.views.google_auth_views.requests.post")
     def test_callback_token_exchange_failure(self, mock_post, api_client):
@@ -59,12 +100,48 @@ class TestGoogleAuthCallbackView:
             status_code=401,
             json=lambda: {"error": "invalid_grant"},
         )
-        response = api_client.get(reverse("google-login-callback"), {"code": "bad-code"})
+        state = _prime_state(api_client)
+        response = api_client.get(
+            reverse("google-login-callback"),
+            {"code": "bad-code", "state": state},
+        )
         assert response.status_code == 401
 
     def test_callback_missing_code(self, api_client):
         response = api_client.get(reverse("google-login-callback"))
         assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    @patch("blockauth.views.google_auth_views.requests.post")
+    def test_callback_missing_state_cookie_rejects(self, mock_post, api_client):
+        """No cookie → the request didn't originate from this browser. Must
+        400 without ever calling the provider's token endpoint."""
+        response = api_client.get(
+            reverse("google-login-callback"),
+            {"code": "auth-code", "state": "anything"},
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        mock_post.assert_not_called()
+
+    @patch("blockauth.views.google_auth_views.requests.post")
+    def test_callback_missing_state_query_rejects(self, mock_post, api_client):
+        """Cookie present but no `state=` in the URL → provider didn't echo
+        our token. Reject before burning a real code."""
+        _prime_state(api_client)
+        response = api_client.get(reverse("google-login-callback"), {"code": "auth-code"})
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        mock_post.assert_not_called()
+
+    @patch("blockauth.views.google_auth_views.requests.post")
+    def test_callback_mismatched_state_rejects(self, mock_post, api_client):
+        """Classic CSRF shape: attacker controls `state=` in the URL but
+        can't forge the victim's cookie. Must 400."""
+        _prime_state(api_client, value="victim-state")
+        response = api_client.get(
+            reverse("google-login-callback"),
+            {"code": "auth-code", "state": "attacker-state"},
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        mock_post.assert_not_called()
 
 
 @pytest.mark.django_db
@@ -74,6 +151,14 @@ class TestFacebookAuthLoginView:
         response = api_client.get(reverse("facebook-login"))
         assert response.status_code == status.HTTP_302_FOUND
         assert "facebook.com" in response.url
+
+    def test_init_sets_state_cookie_and_query_param(self, api_client):
+        response = api_client.get(reverse("facebook-login"))
+        assert OAUTH_STATE_COOKIE_NAME in response.cookies
+        from urllib.parse import parse_qs, urlparse
+
+        query_state = parse_qs(urlparse(response.url).query)["state"][0]
+        assert query_state == response.cookies[OAUTH_STATE_COOKIE_NAME].value
 
 
 @pytest.mark.django_db
@@ -92,10 +177,24 @@ class TestFacebookAuthCallbackView:
             {"access": "test-access", "refresh": "test-refresh"},
             status=200,
         )
+        state = _prime_state(api_client)
 
-        response = api_client.get(reverse("facebook-login-callback"), {"code": "auth-code"})
+        response = api_client.get(
+            reverse("facebook-login-callback"),
+            {"code": "auth-code", "state": state},
+        )
         assert response.status_code == status.HTTP_200_OK
         assert "access" in response.data
+
+    @patch("blockauth.views.facebook_auth_views.requests.get")
+    def test_callback_mismatched_state_rejects(self, mock_get, api_client):
+        _prime_state(api_client, value="victim-state")
+        response = api_client.get(
+            reverse("facebook-login-callback"),
+            {"code": "auth-code", "state": "attacker-state"},
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        mock_get.assert_not_called()
 
 
 @pytest.mark.django_db
@@ -105,6 +204,14 @@ class TestLinkedInAuthLoginView:
         response = api_client.get(reverse("linkedin-login"))
         assert response.status_code == status.HTTP_302_FOUND
         assert "linkedin.com" in response.url
+
+    def test_init_sets_state_cookie_and_query_param(self, api_client):
+        response = api_client.get(reverse("linkedin-login"))
+        assert OAUTH_STATE_COOKIE_NAME in response.cookies
+        from urllib.parse import parse_qs, urlparse
+
+        query_state = parse_qs(urlparse(response.url).query)["state"][0]
+        assert query_state == response.cookies[OAUTH_STATE_COOKIE_NAME].value
 
 
 @pytest.mark.django_db
@@ -128,10 +235,24 @@ class TestLinkedInAuthCallbackView:
             {"access": "test-access", "refresh": "test-refresh"},
             status=200,
         )
+        state = _prime_state(api_client)
 
-        response = api_client.get(reverse("linkedin-login-callback"), {"code": "auth-code"})
+        response = api_client.get(
+            reverse("linkedin-login-callback"),
+            {"code": "auth-code", "state": state},
+        )
         assert response.status_code == status.HTTP_200_OK
         assert "access" in response.data
+
+    @patch("blockauth.views.linkedin_auth_views.requests.post")
+    def test_callback_mismatched_state_rejects(self, mock_post, api_client):
+        _prime_state(api_client, value="victim-state")
+        response = api_client.get(
+            reverse("linkedin-login-callback"),
+            {"code": "auth-code", "state": "attacker-state"},
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        mock_post.assert_not_called()
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Summary

Social-auth init redirects (Google/Facebook/LinkedIn) did not bind the callback to the browser session that started the flow. Google omitted `state` entirely; Facebook and LinkedIn sent a predictable `state=blockauth#<timestamp>` but never verified it on callback. Either way the callback accepts any `code` pointed at the redirect URI — classic CSRF (RFC 6749 §10.12): an attacker tricks a victim into hitting `…/callback/?code=<attacker_code>`, and the victim's session ends up bound to the attacker's OAuth identity.

## Fix

- New `blockauth/utils/oauth_state.py` — `generate_state()`, `set_state_cookie()`, `verify_state()`, `clear_state_cookie()`. 32-byte URL-safe token, `HttpOnly` + `Secure` + `SameSite=Lax` cookie with 10-min TTL, constant-time `hmac.compare_digest` check.
- Google / Facebook / LinkedIn init views: generate the token, mirror it in `state=`, set the cookie on the 302.
- All three callback views: `verify_state(request)` runs **before** any call to the provider's token endpoint, so a CSRF probe cannot burn a real authorization code. Cookie is cleared on the success response so it can't be replayed.

## Test plan

- [x] `uv run pytest blockauth/views/tests/test_oauth_views.py` — 21 passed
- [x] `uv run pytest` (full suite) — 558 passed
- [x] CSRF rejection tests (`test_callback_missing_state_cookie_rejects`, `test_callback_missing_state_query_rejects`, `test_callback_mismatched_state_rejects`) assert `mock_post.assert_not_called()` — provider endpoint never hit on rejected requests
- [x] Init tests assert cookie attributes (`HttpOnly`, `Secure`, `SameSite=Lax`, `Max-Age=600`) and that the cookie value matches the `state=` query param
- [x] Success-path test asserts cookie cleared (`Max-Age=0`) on the response

## Downstream follow-up

fabric-auth consumes this via `uv.lock`. Once this lands and a new blockauth release is cut, I'll open a bump PR in fabric-auth with a regression test in `fabric_auth/base/tests/test_social_auth_routes.py`.

Refs BloclabsHQ/fabric-auth#523