### PR TITLE
fix: wallets as WalletItem[] + promote is_verified on SIWE/Google (#537, #533 side-bug)

### DIFF
--- a/blockauth/serializers/user_account_serializers.py
+++ b/blockauth/serializers/user_account_serializers.py
@@ -284,6 +284,33 @@ and clients can share a single generated type.
 """
 
 
+class WalletItemSerializer(serializers.Serializer):
+    """One row in the ``user.wallets`` array.
+
+    Shape matches the ``@bloclabshq/auth`` shell ``WalletItem`` Zod schema.
+    ``label`` is nullable because a wallet has no label until the user sets
+    one in dashboard; ``chain_id`` is required (defaults to mainnet = 1 at
+    the builder layer); ``primary`` is always present so the shell can pick
+    a default wallet when multiple rows land. Issue #537: before this row
+    existed, wallets were serialised as bare address strings and the shell
+    schema rejected every login response as a result.
+    """
+
+    address = serializers.CharField(help_text="Ethereum address, 0x-prefixed, lowercase")
+    chain_id = serializers.IntegerField(help_text="EIP-155 chain id (1 = Ethereum mainnet)")
+    linked_at = serializers.CharField(
+        allow_null=True,
+        required=False,
+        help_text="ISO-8601 timestamp the wallet was linked to this account",
+    )
+    label = serializers.CharField(
+        allow_null=True,
+        required=False,
+        help_text="User-set wallet label; null until set in dashboard",
+    )
+    primary = serializers.BooleanField(help_text="True for the account's default wallet")
+
+
 class LoginUserSerializer(serializers.Serializer):
     """User payload embedded in every login response.
 
@@ -326,11 +353,13 @@ class LoginUserSerializer(serializers.Serializer):
         help_text="Ethereum wallet address (null for accounts without a linked wallet)",
     )
     wallets = serializers.ListField(
-        child=serializers.CharField(),
+        child=WalletItemSerializer(),
         help_text=(
-            "Linked wallet addresses. Single-row array derived from "
-            "``wallet_address`` until the user model supports multiples; "
-            "empty when no wallet is linked."
+            "Linked wallets as ``WalletItem`` objects — matches the shell's "
+            "``@bloclabshq/auth`` Zod schema. Single-element array derived "
+            "from ``wallet_address`` until the user model supports multiples; "
+            "empty when no wallet is linked. Issue #537: previously serialised "
+            "as ``string[]``, which the shell schema rejected."
         ),
     )
     # first_name / last_name are optional because the abstract BlockUser

--- a/blockauth/services/wallet_user_linker.py
+++ b/blockauth/services/wallet_user_linker.py
@@ -96,10 +96,22 @@ class WalletUserLinker:
         # IntegrityError.
         if auto_create:
             with transaction.atomic():
+                # #537: SIWE proves cryptographic control of the private
+                # key behind this address — that's a stronger ownership
+                # guarantee than email click-through verification. Create
+                # wallet-first accounts as ``is_verified=True`` so
+                # downstream gates on the flag don't bounce the user.
                 user, created = user_model.objects.get_or_create(
                     wallet_address=normalized,
-                    defaults={"is_verified": False},
+                    defaults={"is_verified": True},
                 )
+                # Existing wallet-first accounts created before this
+                # change have ``is_verified=False`` stuck on their row;
+                # promote on any subsequent SIWE login so the legacy
+                # rows heal without a data migration.
+                if not created and not user.is_verified:
+                    user.is_verified = True
+                    user.save(update_fields=["is_verified"])
         else:
             existing = user_model.objects.filter(wallet_address=normalized).first()
             if existing is None:

--- a/blockauth/utils/auth_state.py
+++ b/blockauth/utils/auth_state.py
@@ -11,6 +11,37 @@ from typing import Tuple
 
 from blockauth.utils.token import AUTH_TOKEN_CLASS, generate_auth_token
 
+DEFAULT_WALLET_CHAIN_ID = 1
+
+
+def _build_wallet_items(user, date_joined) -> list[dict]:
+    """Shape wallet rows as ``WalletItem`` objects, not bare address strings.
+
+    The ``@bloclabshq/auth`` shell schema expects
+    ``{address, chain_id, linked_at, label, primary}`` objects so the
+    model can grow to many-wallet-per-user without changing the wire
+    shape. Today the ``BlockUser`` abstract has a single
+    ``wallet_address`` column plus ``authentication_types`` list, so we
+    project the single linked address into a one-element array with
+    ``primary=True``. Default chain id is mainnet (1) until downstream
+    user models add a ``wallet_chain_id`` column; ``linked_at`` falls
+    back to ``date_joined`` because no per-wallet link timestamp exists
+    on the abstract user yet. ``label`` is always ``None`` at this
+    layer — dashboards attach labels client-side.
+    """
+    if not getattr(user, "wallet_address", None):
+        return []
+    linked_at = getattr(user, "wallet_linked_at", None) or date_joined
+    return [
+        {
+            "address": user.wallet_address,
+            "chain_id": getattr(user, "wallet_chain_id", None) or DEFAULT_WALLET_CHAIN_ID,
+            "linked_at": linked_at.isoformat() if linked_at else None,
+            "label": getattr(user, "wallet_label", None),
+            "primary": True,
+        }
+    ]
+
 
 def build_user_payload(user) -> dict:
     """Shape the ``user`` block used by every post-auth-state response.
@@ -39,7 +70,7 @@ def build_user_payload(user) -> dict:
         "is_active": getattr(user, "is_active", True),
         "date_joined": date_joined.isoformat() if date_joined else None,
         "wallet_address": user.wallet_address,
-        "wallets": [user.wallet_address] if user.wallet_address else [],
+        "wallets": _build_wallet_items(user, date_joined),
     }
     first_name = getattr(user, "first_name", None)
     if first_name:

--- a/blockauth/utils/social.py
+++ b/blockauth/utils/social.py
@@ -37,6 +37,15 @@ def social_login(email: str, name: str, provider_data: dict) -> Response:
     if provider in [AuthenticationType.GOOGLE, AuthenticationType.FACEBOOK, AuthenticationType.LINKEDIN]:
         user.add_authentication_type(provider)
 
+    # #533/#537 side-bug: Google returns OIDC-verified email claims. If the
+    # account was previously created by email/password and the user never
+    # clicked the verification link, the Google sign-in is proof the address
+    # is theirs — promote so downstream gates on ``is_verified`` don't bounce
+    # them. Only Google guarantees verified email at the OIDC layer;
+    # Facebook/LinkedIn do NOT, so we stay conservative there.
+    if provider == AuthenticationType.GOOGLE and not user.is_verified:
+        user.is_verified = True
+
     user.save()
 
     user_data = model_to_json(user)

--- a/blockauth/utils/tests/test_auth_state.py
+++ b/blockauth/utils/tests/test_auth_state.py
@@ -69,10 +69,18 @@ class TestWallets:
         assert payload["wallet_address"] is None
 
     def test_wallets_populated_when_set(self):
+        """#537: wallets must be ``WalletItem[]`` not ``string[]`` — the
+        shell's Zod schema rejects bare address strings."""
         address = "0x1234567890abcdef1234567890abcdef12345678"
         payload = build_user_payload(_make_user(wallet_address=address))
-        assert payload["wallets"] == [address]
         assert payload["wallet_address"] == address
+        assert len(payload["wallets"]) == 1
+        item = payload["wallets"][0]
+        assert item["address"] == address
+        assert item["chain_id"] == 1
+        assert item["primary"] is True
+        assert item["label"] is None
+        assert "linked_at" in item
 
 
 class TestFirstLastNameDropWhenFalsy:

--- a/blockauth/utils/tests/test_wallet_login_siwe.py
+++ b/blockauth/utils/tests/test_wallet_login_siwe.py
@@ -759,6 +759,22 @@ class TestWalletLoginEndpoints:
         # email may be null for wallet-first accounts
         assert "email" in user_payload
 
+        # #537: wallets must be WalletItem[], not string[]. The shell's
+        # @bloclabshq/auth Zod schema rejects bare address strings and
+        # surfaces a "user payload failed validation" error to the user.
+        assert isinstance(user_payload["wallets"], list)
+        assert len(user_payload["wallets"]) == 1
+        wallet_item = user_payload["wallets"][0]
+        assert wallet_item["address"] == _TEST_ADDRESS_LC
+        assert wallet_item["chain_id"] == 1
+        assert wallet_item["primary"] is True
+        assert "linked_at" in wallet_item
+
+        # #537: SIWE proves control of the private key — stronger than
+        # email verification. Wallet-first accounts must be created as
+        # is_verified=True so downstream gates don't bounce them.
+        assert user_payload["is_verified"] is True
+
         replay = client.post(
             reverse("wallet-login"),
             {

--- a/blockauth/views/tests/test_login_views.py
+++ b/blockauth/views/tests/test_login_views.py
@@ -127,9 +127,13 @@ class TestBasicLoginView:
         assert user_payload["wallets"] == []  # email-first user has no wallet
 
     def test_login_user_payload_wallets_populated_when_linked(self, api_client, create_user):
-        """Issue #131: a user with a linked wallet surfaces the address
-        inside ``wallets`` as a single-row array, alongside the legacy
-        ``wallet_address`` scalar (kept for transitional compatibility)."""
+        """Issue #131 + #537: a user with a linked wallet surfaces the
+        address inside ``wallets`` as a single-row array of
+        ``WalletItem`` objects, alongside the legacy ``wallet_address``
+        scalar (kept for transitional compatibility). The shell's
+        ``@bloclabshq/auth`` Zod schema expects objects, not bare
+        strings — before #537 this endpoint returned ``[address]`` and
+        the schema rejected it."""
         wallet = "0xabc0000000000000000000000000000000000002"
         create_user(
             email="bothwallet@test.com",
@@ -146,7 +150,13 @@ class TestBasicLoginView:
         assert response.status_code == status.HTTP_200_OK
         user_payload = response.data["user"]
         assert user_payload["wallet_address"] == wallet
-        assert user_payload["wallets"] == [wallet]
+        assert len(user_payload["wallets"]) == 1
+        wallet_item = user_payload["wallets"][0]
+        assert wallet_item["address"] == wallet
+        assert wallet_item["chain_id"] == 1
+        assert wallet_item["primary"] is True
+        assert wallet_item["label"] is None
+        assert "linked_at" in wallet_item
         assert user_payload["email"] == "bothwallet@test.com"
 
     def test_login_user_payload_does_not_leak_credentials(self, api_client, create_user):

--- a/blockauth/views/tests/test_oauth_views.py
+++ b/blockauth/views/tests/test_oauth_views.py
@@ -198,6 +198,39 @@ class TestSocialLoginResponseShape:
         # User was created and is verified (OAuth default)
         assert response.data["user"]["is_verified"] is True
 
+    def test_google_promotes_existing_unverified_user_to_verified(self, create_user):
+        """#533/#537 side-bug: a user who signed up via email/password and
+        never clicked the verification link must get promoted to
+        ``is_verified=True`` when they authenticate via Google, because
+        Google's OIDC response carries an OIDC-verified email claim.
+        Facebook and LinkedIn don't guarantee verified email, so they
+        stay unmodified."""
+        user = create_user(email="existing@test.com", is_verified=False)
+        assert user.is_verified is False
+
+        response = social_login(
+            email="existing@test.com",
+            name="Existing User",
+            provider_data={"provider": "google"},
+        )
+        assert response.status_code == 200
+        user.refresh_from_db()
+        assert user.is_verified is True
+
+    def test_facebook_does_not_promote_unverified_user(self, create_user):
+        """Facebook does not guarantee an OIDC-verified email claim.
+        Leave ``is_verified`` as-is rather than over-trusting the
+        provider."""
+        user = create_user(email="fbunverified@test.com", is_verified=False)
+
+        social_login(
+            email="fbunverified@test.com",
+            name="FB User",
+            provider_data={"provider": "facebook"},
+        )
+        user.refresh_from_db()
+        assert user.is_verified is False
+
     def test_first_oauth_signup_populates_first_name_when_field_exists(self, db):
         """If the user model defines `first_name`, the passed `name`
         should still be populated on first signup — don't regress the

--- a/blockauth/views/tests/test_wallet_views.py
+++ b/blockauth/views/tests/test_wallet_views.py
@@ -98,7 +98,12 @@ class TestWalletAuthLoginView:
         assert user_payload["id"] == str(user.id)
         assert user_payload["email"] is None  # wallet-first user
         assert user_payload["wallet_address"] == wallet
-        assert user_payload["wallets"] == [wallet]
+        # #537: wallets is ``WalletItem[]``, not ``string[]``
+        assert len(user_payload["wallets"]) == 1
+        wallet_item = user_payload["wallets"][0]
+        assert wallet_item["address"] == wallet
+        assert wallet_item["chain_id"] == 1
+        assert wallet_item["primary"] is True
         assert user_payload["is_active"] is True
 
     def test_wallet_login_invalid_address_rejected(self, api_client):


### PR DESCRIPTION
## Summary

Two launch-blockers reported against fabric-auth, both rooted in auth-pack.

### #537 — shape mismatch

\`user.wallets\` was serialised as \`string[]\` (list of bare addresses) but the shell's \`@bloclabshq/auth\` Zod schema expects \`WalletItem[]\` objects with \`{address, chain_id, linked_at, label, primary}\`. Every auth response was being rejected client-side; wallet-first signup surfaced the error loudest because it's the first thing a new Creator hits.

### \`is_verified\` false for legitimately-verified users

- **Wallet-first accounts** — SIWE cryptographically proves control of the private key (stronger than email verification), but new rows were created with \`is_verified=False\`. Downstream gates on the flag bounce the user back.
- **Existing email/password users who later auth via Google** — Google's OIDC response includes an OIDC-verified email claim, but \`social_login\`'s \`get_or_create\` leaves existing rows untouched, so the flag stays False.

## Fix

- \`build_user_payload\` emits \`wallets: WalletItem[]\` via \`_build_wallet_items\`. Defaults: \`chain_id=1\` (Ethereum mainnet), \`primary=true\`, \`linked_at\` falls back to \`date_joined\`, \`label=null\`. Downstream user models can override via \`wallet_chain_id\` / \`wallet_linked_at\` / \`wallet_label\` attrs when they grow per-wallet metadata.
- \`LoginUserSerializer.wallets\` uses the new \`WalletItemSerializer\` nested schema — OpenAPI + client types stay honest.
- \`WalletUserLinker.link\` creates SIWE-verified users with \`is_verified=True\` and promotes legacy unverified rows on any subsequent SIWE login (self-healing, no migration needed).
- \`social_login\` promotes \`is_verified\` to \`True\` for **Google only** on existing unverified users. Facebook and LinkedIn do NOT guarantee verified email at the OIDC layer, so we stay conservative there.

## Test plan

- [x] \`uv run pytest\` — 552 passed, 0 failed
- [x] New: \`test_google_promotes_existing_unverified_user_to_verified\` — pins Google-only promotion
- [x] New: \`test_facebook_does_not_promote_unverified_user\` — asserts Facebook leaves \`is_verified\` alone
- [x] Wallet-login end-to-end test now asserts \`WalletItem\` shape + \`is_verified=True\` for SIWE-first accounts
- [x] \`build_user_payload\` unit test asserts the new \`{address, chain_id, linked_at, label, primary}\` shape
- [x] All existing login tests (basic / passwordless / wallet) updated to expect the new shape — shape contract is intentionally breaking

## Breaking change

\`user.wallets\` is now \`WalletItem[]\` instead of \`string[]\`. Clients reading \`wallets[0]\` as a string will break, but the shell's Zod schema was already rejecting the old shape — this brings the server into alignment with the contract the shell has been trying to enforce.

Refs BloclabsHQ/fabric-auth#537, BloclabsHQ/fabric-auth#533