### PR TITLE
feat(oauth): data-returning social_login + integrator hook + env-driven state cookie

### DIFF
--- a/blockauth/utils/oauth_state.py
+++ b/blockauth/utils/oauth_state.py
@@ -3,8 +3,10 @@ OAuth 2.0 `state` parameter helpers — CSRF protection for social-auth flows.
 
 Per RFC 6749 §10.12, every OAuth init MUST bind the callback to the browser
 session that started the flow. We do this by generating a cryptographically
-random token at init time, setting it as an HttpOnly / Secure / SameSite=Lax
-cookie, and mirroring it in the `state=` query param to the authorize URL.
+random token at init time, setting it as an HttpOnly cookie (Secure /
+SameSite are env-driven; defaults are the strictest values that work for
+deployed TLS), and mirroring it in the `state=` query param to the authorize
+URL.
 
 On callback, the view compares the cookie and the query param with
 `hmac.compare_digest` (constant-time) and rejects mismatches with 400 before
@@ -17,6 +19,20 @@ Why a cookie (rather than a server-side session store):
     OAuth state is heavier than a scoped, short-lived cookie.
   - Short TTL (10 min) + HttpOnly + SameSite=Lax + compare_digest is the
     pattern documented by OWASP for browser-initiated OAuth flows.
+
+Why Secure and SameSite are configurable:
+  - Local dev over plain `http://localhost` cannot set Secure cookies in
+    production-equivalent mode — Chrome treats localhost as secure, but
+    Firefox doesn't. A hardcoded `secure=True` locks out Firefox-based
+    local dev entirely.
+  - Tailscale hosts on `*.fabric.test` typically run http until an operator
+    provisions a local TLS cert.
+  - Deployed envs run TLS end-to-end and want `Secure=True` + the
+    strictest SameSite policy the callback hop permits.
+
+Read overrides from `BLOCK_AUTH_SETTINGS["OAUTH_STATE_COOKIE_SECURE"]` and
+`["OAUTH_STATE_COOKIE_SAMESITE"]` so integrators can set one value per
+environment via env vars without patching this file.
 """
 
 import hmac
@@ -29,6 +45,37 @@ OAUTH_STATE_COOKIE_MAX_AGE = 600  # 10 minutes — covers human consent screens
 OAUTH_STATE_TOKEN_BYTES = 32
 
 
+def _get_setting(key: str, default):
+    """Read a cookie-policy override from `BLOCK_AUTH_SETTINGS`.
+
+    Local import so this module stays usable in non-Django contexts
+    (unit tests, scripts) — `django.conf.settings` is only touched when
+    the helper is actually called at request time.
+    """
+    try:
+        from django.conf import settings as _settings
+
+        block_settings = getattr(_settings, "BLOCK_AUTH_SETTINGS", {}) or {}
+    except Exception:
+        block_settings = {}
+    return block_settings.get(key, default)
+
+
+def _cookie_secure() -> bool:
+    """True unless explicitly disabled for local http dev."""
+    return bool(_get_setting("OAUTH_STATE_COOKIE_SECURE", True))
+
+
+def _cookie_samesite() -> str:
+    """`Lax` by default — Lax permits the Google→callback top-level GET
+    while still blocking CSRF via cross-site subresource requests.
+    `Strict` would actually break the callback (cross-site navigation
+    doesn't send Strict cookies). Keep Lax unless an integrator knows
+    their topology permits Strict (e.g. same-origin callback).
+    """
+    return str(_get_setting("OAUTH_STATE_COOKIE_SAMESITE", "Lax"))
+
+
 def generate_state() -> str:
     """Cryptographically random, URL-safe state token."""
     return secrets.token_urlsafe(OAUTH_STATE_TOKEN_BYTES)
@@ -37,17 +84,18 @@ def generate_state() -> str:
 def set_state_cookie(response, state: str) -> None:
     """Bind the state token to the browser session via a short-lived cookie.
 
-    SameSite=Lax is required: the provider redirects back via a top-level
-    navigation (GET), which Lax permits while still blocking cross-site
-    subresource requests that could leak/replay the cookie.
+    Secure / SameSite are read from `BLOCK_AUTH_SETTINGS` so deployments
+    can downgrade to `secure=False` for http-only local dev without
+    patching the library. HttpOnly stays on always — there is no JS
+    reason to read state; the check is entirely server-side.
     """
     response.set_cookie(
         OAUTH_STATE_COOKIE_NAME,
         state,
         max_age=OAUTH_STATE_COOKIE_MAX_AGE,
         httponly=True,
-        secure=True,
-        samesite="Lax",
+        secure=_cookie_secure(),
+        samesite=_cookie_samesite(),
     )
 
 
@@ -72,7 +120,8 @@ def verify_state(request) -> None:
 def clear_state_cookie(response) -> None:
     """Clear the state cookie on the outbound response.
 
-    Must match the `samesite` attribute used at set time so browsers treat
-    the delete as applying to the same cookie (Set-Cookie with Max-Age=0).
+    Must match the `samesite` attribute used at set time so browsers
+    treat the delete as applying to the same cookie (Set-Cookie with
+    Max-Age=0).
     """
-    response.delete_cookie(OAUTH_STATE_COOKIE_NAME, samesite="Lax")
+    response.delete_cookie(OAUTH_STATE_COOKIE_NAME, samesite=_cookie_samesite())

--- a/blockauth/utils/social.py
+++ b/blockauth/utils/social.py
@@ -1,3 +1,19 @@
+"""Social-login funnel used by the Google / Facebook / LinkedIn callbacks.
+
+`social_login_data()` is the core: it upserts the user, fires triggers,
+mints tokens, and returns the raw `(user, access, refresh)` tuple so
+callers can decide the wire shape (JSON body, redirect + cookie, etc).
+
+`social_login()` wraps that data into the legacy JSON response so existing
+callers that expect a DRF ``Response`` back continue to work unchanged.
+Integrators who want to BFF-ify the OAuth callback (set HttpOnly cookies +
+302 to the shell — fabric-auth#533) subclass the view and use
+`social_login_data()` directly.
+"""
+
+from dataclasses import dataclass
+from typing import Any
+
 from django.utils import timezone
 from rest_framework import status
 from rest_framework.response import Response
@@ -11,6 +27,23 @@ from blockauth.utils.generics import model_to_json
 _User = get_block_auth_user_model()
 
 
+@dataclass(frozen=True)
+class SocialLoginResult:
+    """Outcome of a social-login attempt.
+
+    Carries the raw user model + freshly-issued token pair so callers
+    can build whatever response shape their integration needs:
+    - legacy JSON body (via ``social_login()``)
+    - BFF cookie + redirect (fabric-auth#533)
+    - popup + postMessage
+    """
+
+    user: Any
+    access_token: str
+    refresh_token: str
+    created: bool
+
+
 def _user_model_has_field(field_name: str) -> bool:
     """True if the configured user model declares `field_name`. Cached
     result is fine — we never swap the user model mid-process."""
@@ -21,7 +54,14 @@ def _user_model_has_field(field_name: str) -> bool:
         return False
 
 
-def social_login(email: str, name: str, provider_data: dict) -> Response:
+def social_login_data(email: str, name: str, provider_data: dict) -> SocialLoginResult:
+    """Core social-login pipeline — returns data, not a Response.
+
+    Upserts the user, tags the authentication type, promotes
+    `is_verified` to True for Google (OIDC-verified email claim — see
+    #533 side-bug), fires post-signup / post-login triggers, and mints a
+    fresh access/refresh pair. The caller decides the response shape.
+    """
     # Only include `first_name` in defaults if the configured user model
     # actually defines it. Otherwise get_or_create raises FieldError on
     # the create path (first OAuth signup for a new email). See #109.
@@ -59,15 +99,31 @@ def social_login(email: str, name: str, provider_data: dict) -> Response:
     post_login_trigger.trigger(context=context)
 
     access_token, refresh_token = issue_auth_tokens(user)
+    return SocialLoginResult(
+        user=user,
+        access_token=access_token,
+        refresh_token=refresh_token,
+        created=created,
+    )
+
+
+def social_login(email: str, name: str, provider_data: dict) -> Response:
+    """Legacy JSON-body wrapper around ``social_login_data``.
+
+    Kept so existing integrators that expect a ``Response`` back don't
+    break during the BFF-cookie migration (fabric-auth#533). New code
+    should call ``social_login_data()`` directly.
+    """
+    result = social_login_data(email=email, name=name, provider_data=provider_data)
     # api-optimization: return the full {access, refresh, user} tuple so
     # OAuth-signup clients don't have to issue a follow-up /me/ to hydrate
     # profile state. Mirrors the shape returned by /login/basic/,
     # /login/passwordless/confirm/, and /login/wallet/.
     response_serializer = AuthStateResponseSerializer(
         {
-            "access": access_token,
-            "refresh": refresh_token,
-            "user": build_user_payload(user),
+            "access": result.access_token,
+            "refresh": result.refresh_token,
+            "user": build_user_payload(result.user),
         }
     )
     return Response(data=response_serializer.data, status=status.HTTP_200_OK)

--- a/blockauth/views/facebook_auth_views.py
+++ b/blockauth/views/facebook_auth_views.py
@@ -19,7 +19,10 @@ from blockauth.utils.config import get_block_auth_user_model, get_config
 from blockauth.utils.generics import sanitize_log_context
 from blockauth.utils.logger import blockauth_logger
 from blockauth.utils.oauth_state import clear_state_cookie, generate_state, set_state_cookie, verify_state
-from blockauth.utils.social import social_login
+from blockauth.utils.social import SocialLoginResult, social_login_data
+from blockauth.serializers.user_account_serializers import AuthStateResponseSerializer
+from blockauth.utils.auth_state import build_user_payload
+from rest_framework import status as drf_status
 
 logger = logging.getLogger(__name__)
 _User = get_block_auth_user_model()
@@ -61,10 +64,29 @@ class FacebookAuthLoginView(APIView):
 class FacebookAuthCallbackView(APIView):
     """
     Handles Facebook OAuth2 callback, exchanges the code for a Facebook token, and returns JWT tokens.
+
+    Subclass and override :meth:`build_success_response` to ship tokens
+    via HttpOnly cookies + a 302 to the shell origin (BFF, fabric-auth#533).
     """
 
     permission_classes = (AllowAny,)
     authentication_classes = []
+
+    def build_success_response(self, request, result: SocialLoginResult) -> Response:
+        """Default: return the ``{access, refresh, user}`` JSON body.
+
+        See :meth:`GoogleAuthCallbackView.build_success_response` for the
+        integrator-override contract; same hook surface so fabric-auth
+        can share one BFF mixin across Google / Facebook / LinkedIn.
+        """
+        response_serializer = AuthStateResponseSerializer(
+            {
+                "access": result.access_token,
+                "refresh": result.refresh_token,
+                "user": build_user_payload(result.user),
+            }
+        )
+        return Response(data=response_serializer.data, status=drf_status.HTTP_200_OK)
 
     @extend_schema(**facebook_auth_callback_schema)
     def get(self, request):
@@ -132,7 +154,8 @@ class FacebookAuthCallbackView(APIView):
             blockauth_logger.success(
                 "Facebook login successful", {"user_id": user_info.get("id"), "email": email, "name": name}
             )
-            response = social_login(email=email, name=name, provider_data=provider_data)
+            result = social_login_data(email=email, name=name, provider_data=provider_data)
+            response = self.build_success_response(request, result)
             clear_state_cookie(response)
             return response
         except ValidationError as ve:

--- a/blockauth/views/google_auth_views.py
+++ b/blockauth/views/google_auth_views.py
@@ -19,7 +19,10 @@ from blockauth.utils.config import get_block_auth_user_model, get_config
 from blockauth.utils.generics import sanitize_log_context
 from blockauth.utils.logger import blockauth_logger
 from blockauth.utils.oauth_state import clear_state_cookie, generate_state, set_state_cookie, verify_state
-from blockauth.utils.social import social_login
+from blockauth.utils.social import SocialLoginResult, social_login_data
+from blockauth.serializers.user_account_serializers import AuthStateResponseSerializer
+from blockauth.utils.auth_state import build_user_payload
+from rest_framework import status as drf_status
 
 logger = logging.getLogger(__name__)
 _User = get_block_auth_user_model()
@@ -60,10 +63,32 @@ class GoogleAuthLoginView(APIView):
 class GoogleAuthCallbackView(APIView):
     """
     Handles Google OAuth2 callback, exchanges the code for a Google token, and returns JWT tokens.
+
+    Subclass and override :meth:`build_success_response` to ship
+    tokens via HttpOnly cookies + a 302 to the shell origin instead of
+    the default JSON body (BFF pattern — fabric-auth#533).
     """
 
     permission_classes = (AllowAny,)
     authentication_classes = []
+
+    def build_success_response(self, request, result: SocialLoginResult) -> Response:
+        """Default: return the `{access, refresh, user}` JSON body.
+
+        Integrator override (fabric-auth): set HttpOnly cookies carrying
+        the JWTs and return a redirect to the shell origin, so tokens
+        never reach JavaScript or the URL bar. The base implementation
+        is kept for backwards compatibility and for deployments where
+        the callback is consumed programmatically (e.g. mobile SDK).
+        """
+        response_serializer = AuthStateResponseSerializer(
+            {
+                "access": result.access_token,
+                "refresh": result.refresh_token,
+                "user": build_user_payload(result.user),
+            }
+        )
+        return Response(data=response_serializer.data, status=drf_status.HTTP_200_OK)
 
     @extend_schema(**google_auth_callback_schema)
     def get(self, request):
@@ -128,7 +153,8 @@ class GoogleAuthCallbackView(APIView):
         try:
             provider_data = {"provider": "google", "user_info": user_info}
             blockauth_logger.success("Google login successful", {"email": email, "name": name})
-            response = social_login(email=email, name=name, provider_data=provider_data)
+            result = social_login_data(email=email, name=name, provider_data=provider_data)
+            response = self.build_success_response(request, result)
             clear_state_cookie(response)
             return response
         except ValidationError as ve:

--- a/blockauth/views/linkedin_auth_views.py
+++ b/blockauth/views/linkedin_auth_views.py
@@ -19,7 +19,10 @@ from blockauth.utils.config import get_block_auth_user_model, get_config
 from blockauth.utils.generics import sanitize_log_context
 from blockauth.utils.logger import blockauth_logger
 from blockauth.utils.oauth_state import clear_state_cookie, generate_state, set_state_cookie, verify_state
-from blockauth.utils.social import social_login
+from blockauth.utils.social import SocialLoginResult, social_login_data
+from blockauth.serializers.user_account_serializers import AuthStateResponseSerializer
+from blockauth.utils.auth_state import build_user_payload
+from rest_framework import status as drf_status
 
 logger = logging.getLogger(__name__)
 _User = get_block_auth_user_model()
@@ -59,10 +62,28 @@ class LinkedInAuthLoginView(APIView):
 class LinkedInAuthCallbackView(APIView):
     """
     Handles LinkedIn OAuth2 callback, exchanges the code for a LinkedIn token, and returns JWT tokens.
+
+    Subclass and override :meth:`build_success_response` to ship tokens
+    via HttpOnly cookies + a 302 to the shell origin (BFF, fabric-auth#533).
     """
 
     permission_classes = (AllowAny,)
     authentication_classes = []
+
+    def build_success_response(self, request, result: SocialLoginResult) -> Response:
+        """Default: return the ``{access, refresh, user}`` JSON body.
+
+        See :meth:`GoogleAuthCallbackView.build_success_response` for the
+        integrator-override contract.
+        """
+        response_serializer = AuthStateResponseSerializer(
+            {
+                "access": result.access_token,
+                "refresh": result.refresh_token,
+                "user": build_user_payload(result.user),
+            }
+        )
+        return Response(data=response_serializer.data, status=drf_status.HTTP_200_OK)
 
     @extend_schema(**linkedin_auth_callback_schema)
     def get(self, request):
@@ -122,7 +143,8 @@ class LinkedInAuthCallbackView(APIView):
         try:
             provider_data = {"provider": "linkedin", "user_info": user_info}
             blockauth_logger.success("LinkedIn login successful", {"email": email, "name": name})
-            response = social_login(email=email, name=name, provider_data=provider_data)
+            result = social_login_data(email=email, name=name, provider_data=provider_data)
+            response = self.build_success_response(request, result)
             clear_state_cookie(response)
             return response
         except ValidationError as ve:

--- a/blockauth/views/tests/test_oauth_views.py
+++ b/blockauth/views/tests/test_oauth_views.py
@@ -61,10 +61,10 @@ class TestGoogleAuthLoginView:
 @pytest.mark.django_db
 class TestGoogleAuthCallbackView:
 
-    @patch("blockauth.views.google_auth_views.social_login")
+    @patch("blockauth.views.google_auth_views.social_login_data")
     @patch("blockauth.views.google_auth_views.requests.get")
     @patch("blockauth.views.google_auth_views.requests.post")
-    def test_callback_returns_tokens(self, mock_post, mock_get, mock_social_login, api_client):
+    def test_callback_returns_tokens(self, mock_post, mock_get, mock_social_login_data, api_client):
         mock_post.return_value = MagicMock(
             status_code=200,
             json=lambda: {"access_token": "google-token"},
@@ -73,11 +73,21 @@ class TestGoogleAuthCallbackView:
             status_code=200,
             json=lambda: {"email": "google@test.com", "name": "Google User"},
         )
-        from rest_framework.response import Response
 
-        mock_social_login.return_value = Response(
-            {"access": "test-access", "refresh": "test-refresh"},
-            status=200,
+        from blockauth.utils.social import SocialLoginResult
+
+        mock_user = MagicMock()
+        mock_user.id = "01936f4e-1234-7abc-8def-0123456789ab"
+        mock_user.email = "google@test.com"
+        mock_user.is_verified = True
+        mock_user.is_active = True
+        mock_user.wallet_address = None
+        mock_user.date_joined = None
+        mock_social_login_data.return_value = SocialLoginResult(
+            user=mock_user,
+            access_token="test-access",
+            refresh_token="test-refresh",
+            created=False,
         )
         state = _prime_state(api_client)
 
@@ -88,7 +98,7 @@ class TestGoogleAuthCallbackView:
         assert response.status_code == status.HTTP_200_OK
         assert "access" in response.data
         assert "refresh" in response.data
-        mock_social_login.assert_called_once()
+        mock_social_login_data.assert_called_once()
         # Success clears the state cookie so it can't be replayed.
         cleared = response.cookies.get(OAUTH_STATE_COOKIE_NAME)
         assert cleared is not None
@@ -164,18 +174,27 @@ class TestFacebookAuthLoginView:
 @pytest.mark.django_db
 class TestFacebookAuthCallbackView:
 
-    @patch("blockauth.views.facebook_auth_views.social_login")
+    @patch("blockauth.views.facebook_auth_views.social_login_data")
     @patch("blockauth.views.facebook_auth_views.requests.get")
-    def test_callback_returns_tokens(self, mock_get, mock_social_login, api_client):
+    def test_callback_returns_tokens(self, mock_get, mock_social_login_data, api_client):
         mock_get.side_effect = [
             MagicMock(status_code=200, json=lambda: {"access_token": "fb-token"}),
             MagicMock(status_code=200, json=lambda: {"email": "fb@test.com", "name": "FB User"}),
         ]
-        from rest_framework.response import Response
+        from blockauth.utils.social import SocialLoginResult
 
-        mock_social_login.return_value = Response(
-            {"access": "test-access", "refresh": "test-refresh"},
-            status=200,
+        mock_user = MagicMock()
+        mock_user.id = "01936f4e-1234-7abc-8def-0123456789ab"
+        mock_user.email = "fb@test.com"
+        mock_user.is_verified = False
+        mock_user.is_active = True
+        mock_user.wallet_address = None
+        mock_user.date_joined = None
+        mock_social_login_data.return_value = SocialLoginResult(
+            user=mock_user,
+            access_token="test-access",
+            refresh_token="test-refresh",
+            created=False,
         )
         state = _prime_state(api_client)
 
@@ -217,10 +236,10 @@ class TestLinkedInAuthLoginView:
 @pytest.mark.django_db
 class TestLinkedInAuthCallbackView:
 
-    @patch("blockauth.views.linkedin_auth_views.social_login")
+    @patch("blockauth.views.linkedin_auth_views.social_login_data")
     @patch("blockauth.views.linkedin_auth_views.requests.get")
     @patch("blockauth.views.linkedin_auth_views.requests.post")
-    def test_callback_returns_tokens(self, mock_post, mock_get, mock_social_login, api_client):
+    def test_callback_returns_tokens(self, mock_post, mock_get, mock_social_login_data, api_client):
         mock_post.return_value = MagicMock(
             status_code=200,
             json=lambda: {"access_token": "li-token"},
@@ -229,11 +248,20 @@ class TestLinkedInAuthCallbackView:
             status_code=200,
             json=lambda: {"email": "li@test.com", "name": "LI User"},
         )
-        from rest_framework.response import Response
+        from blockauth.utils.social import SocialLoginResult
 
-        mock_social_login.return_value = Response(
-            {"access": "test-access", "refresh": "test-refresh"},
-            status=200,
+        mock_user = MagicMock()
+        mock_user.id = "01936f4e-1234-7abc-8def-0123456789ab"
+        mock_user.email = "li@test.com"
+        mock_user.is_verified = False
+        mock_user.is_active = True
+        mock_user.wallet_address = None
+        mock_user.date_joined = None
+        mock_social_login_data.return_value = SocialLoginResult(
+            user=mock_user,
+            access_token="test-access",
+            refresh_token="test-refresh",
+            created=False,
         )
         state = _prime_state(api_client)
 
@@ -253,6 +281,99 @@ class TestLinkedInAuthCallbackView:
         )
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         mock_post.assert_not_called()
+
+
+@pytest.mark.django_db
+class TestCallbackSuccessResponseHook:
+    """The BFF-cookie integration (fabric-auth#533) subclasses these
+    callback views and overrides ``build_success_response`` to ship tokens
+    via HttpOnly cookies + a 302 to the shell origin, instead of the
+    default JSON body. These tests pin the hook surface so the override
+    point doesn't silently disappear in a future refactor.
+    """
+
+    @patch("blockauth.views.google_auth_views.social_login_data")
+    @patch("blockauth.views.google_auth_views.requests.get")
+    @patch("blockauth.views.google_auth_views.requests.post")
+    def test_integrator_override_receives_result_and_request(
+        self, mock_post, mock_get, mock_social_login_data, api_client
+    ):
+        """``build_success_response(request, result)`` must receive the
+        full ``SocialLoginResult`` so integrators can read user + tokens
+        and build whatever response shape they need."""
+        from blockauth.utils.social import SocialLoginResult
+        from blockauth.views.google_auth_views import GoogleAuthCallbackView
+
+        mock_post.return_value = MagicMock(status_code=200, json=lambda: {"access_token": "t"})
+        mock_get.return_value = MagicMock(
+            status_code=200, json=lambda: {"email": "g@test.com", "name": "Google User"}
+        )
+        mock_user = MagicMock(id="01936f4e-0000-7abc-8def-000000000001", email="g@test.com")
+        mock_social_login_data.return_value = SocialLoginResult(
+            user=mock_user,
+            access_token="override-access",
+            refresh_token="override-refresh",
+            created=False,
+        )
+
+        captured = {}
+        original = GoogleAuthCallbackView.build_success_response
+
+        def override(self, request, result):
+            captured["result"] = result
+            captured["request"] = request
+            from django.http import HttpResponseRedirect
+
+            return HttpResponseRedirect("https://shell.example/auth/callback")
+
+        GoogleAuthCallbackView.build_success_response = override
+        try:
+            state = _prime_state(api_client)
+            response = api_client.get(
+                reverse("google-login-callback"),
+                {"code": "c", "state": state},
+            )
+        finally:
+            GoogleAuthCallbackView.build_success_response = original
+
+        assert response.status_code == 302
+        assert response.url == "https://shell.example/auth/callback"
+        assert captured["result"].access_token == "override-access"
+        assert captured["result"].refresh_token == "override-refresh"
+        # The override is a good place to attach cookies — confirm the
+        # state cookie still gets cleared by the view wrapper after the
+        # override returns (belt-and-braces).
+        cleared = response.cookies.get(OAUTH_STATE_COOKIE_NAME)
+        assert cleared is not None
+        assert cleared["max-age"] == 0
+
+
+@pytest.mark.django_db
+class TestStateCookiePolicyConfigurable:
+    """``set_state_cookie`` reads ``BLOCK_AUTH_SETTINGS['OAUTH_STATE_COOKIE_SECURE']``
+    and ``['OAUTH_STATE_COOKIE_SAMESITE']`` so integrators can run over
+    plain http in local dev without patching the library. Defaults stay
+    secure (``secure=True``, ``samesite=Lax``) for deployed TLS envs.
+    """
+
+    def test_default_secure_and_samesite(self, api_client):
+        response = api_client.get(reverse("google-login"))
+        cookie = response.cookies[OAUTH_STATE_COOKIE_NAME]
+        assert cookie["secure"]
+        assert cookie["samesite"].lower() == "lax"
+
+    def test_local_dev_can_disable_secure(self, api_client, settings):
+        """Firefox doesn't treat ``http://localhost`` as a secure context,
+        so hardcoded ``secure=True`` breaks local dev on non-Chromium.
+        ``OAUTH_STATE_COOKIE_SECURE=False`` in ``BLOCK_AUTH_SETTINGS``
+        downgrades the cookie for that env."""
+        settings.BLOCK_AUTH_SETTINGS = {
+            **settings.BLOCK_AUTH_SETTINGS,
+            "OAUTH_STATE_COOKIE_SECURE": False,
+        }
+        response = api_client.get(reverse("google-login"))
+        cookie = response.cookies[OAUTH_STATE_COOKIE_NAME]
+        assert not cookie["secure"]
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Prep for the BFF cookie pattern in BloclabsHQ/fabric-auth#533 (launch-blocker: Google OAuth callback leaks JWTs into the browser page + URL bar + access logs).

Replaces #140 (auto-closed when the base branch \`fix/oauth-state-csrf\` merged into \`dev\`). Rebased cleanly onto \`dev\`, no conflicts.

## The seam

fabric-auth needs to override the OAuth success path to ship tokens via HttpOnly cookies + a 302 to the shell origin. Today the callback hardcodes a JSON \`{access, refresh, user}\` response body. This PR exposes a clean hook without breaking existing integrators or forking the view.

## Changes

- **New \`social_login_data()\`** returns \`SocialLoginResult(user, access, refresh, created)\` — data only, no Response. Legacy \`social_login()\` stays as a thin wrapper for anyone expecting the JSON-body Response back.
- **New view method \`build_success_response(request, result) -> Response\`** on Google/Facebook/LinkedIn callback views. Default impl returns the legacy JSON body so current consumers are unchanged. Integrators (fabric-auth) subclass and override to return a redirect + cookies.
- **Env-driven state cookie policy** — \`set_state_cookie\` / \`clear_state_cookie\` read \`BLOCK_AUTH_SETTINGS[\"OAUTH_STATE_COOKIE_SECURE\"]\` and \`[\"OAUTH_STATE_COOKIE_SAMESITE\"]\`. Fixes a bug from #138 where \`secure=True\` was hardcoded — breaks Firefox local dev on \`http://localhost\` (Chrome treats localhost as secure, Firefox doesn't). Defaults stay strict (\`secure=True\`, \`samesite=Lax\`).

## Test plan

- [x] \`uv run pytest\` — 563 passed
- [x] Existing callback tests migrated to \`patch('...social_login_data')\`
- [x] New \`TestCallbackSuccessResponseHook\` pins the integrator override contract
- [x] New \`TestStateCookiePolicyConfigurable\` pins env-driven secure / samesite knobs

Refs BloclabsHQ/fabric-auth#533