### PR TITLE
fix(social): route new-user creation through USERNAME_FIELD

### DIFF
--- a/blockauth/apple/exceptions.py
+++ b/blockauth/apple/exceptions.py
@@ -5,14 +5,6 @@ class AppleAuthError(Exception):
     """Base for Apple auth failures."""
 
 
-class AppleStateMismatch(AppleAuthError):
-    """OAuth state cookie did not match the form-post state."""
-
-
-class ApplePKCEMissing(AppleAuthError):
-    """PKCE verifier cookie was absent on callback."""
-
-
 class AppleTokenExchangeFailed(AppleAuthError):
     """Apple's /auth/token endpoint returned non-200.
 

--- a/blockauth/social/exceptions.py
+++ b/blockauth/social/exceptions.py
@@ -3,6 +3,30 @@
 from rest_framework.exceptions import APIException
 
 
+class SocialIdentityMissingEmailError(APIException):
+    """Raised when an OAuth/OIDC sign-in did not return an email and the
+    integrator's user model requires one to create a new account.
+
+    Every supported provider (Google, Apple, Facebook, LinkedIn) returns
+    either a verified email or — in Apple's "hide my email" case — a
+    relay address. A missing email therefore indicates either a missing
+    scope on the client request or a misconfigured provider, both of
+    which are surfaced to the integrator as HTTP 400 rather than papered
+    over with a synthetic identifier that would corrupt the user table.
+    """
+
+    status_code = 400
+    default_detail = "Provider did not return an email address."
+    default_code = "SOCIAL_IDENTITY_MISSING_EMAIL"
+
+    def __init__(self, *, provider: str):
+        self.provider = provider
+        super().__init__(
+            detail=f"social identity provider {provider!r} did not return an email",
+            code=self.default_code,
+        )
+
+
 class SocialIdentityConflictError(APIException):
     """Raised when an OAuth/OIDC sign-in claims an email that maps to an
     existing user but the issuing provider is not authoritative for that

--- a/blockauth/social/service.py
+++ b/blockauth/social/service.py
@@ -18,10 +18,13 @@ Plan deviations:
     `SocialIdentity.user` FK targets `settings.AUTH_USER_MODEL`; the
     service must query the same model the FK points at. Same fix used
     in Task 2.3.
-  - New-user creation goes through `User.objects.create_user(username=...,
-    email=..., password=None)` rather than the plan's
-    `User.objects.create(email=..., is_verified=...)`. The latter fails
-    against `auth.User` (no `is_verified` field, required `username`).
+  - New-user creation routes the natural identifier through whichever
+    kwarg the integrator's user model exposes via `USERNAME_FIELD`.
+    `auth.User` keys on `username`, email-first models (e.g. fabric-auth's
+    `Creator`) key on `email`, and `BlockUser`-derived models key on the
+    auto-populated `id`. The service inspects `USERNAME_FIELD` and only
+    forwards `email` as a separate kwarg when it is a distinct field from
+    the natural key, so every supported user model accepts the call.
     `create_user(password=None)` produces an unusable password (Django
     default), so the integrator's password-reset flow still works.
 """
@@ -33,7 +36,10 @@ from django.contrib.auth import get_user_model
 from django.db import IntegrityError, transaction
 
 from blockauth.social.encryption import AESGCMEncryptor, aad_for, load_encryptor
-from blockauth.social.exceptions import SocialIdentityConflictError
+from blockauth.social.exceptions import (
+    SocialIdentityConflictError,
+    SocialIdentityMissingEmailError,
+)
 from blockauth.social.linking_policy import AccountLinkingPolicy
 from blockauth.social.models import SocialIdentity
 
@@ -127,16 +133,19 @@ class SocialIdentityService:
 
         # New-user creation. See module docstring for the rationale behind
         # `create_user` (model-agnostic) vs. the plan's `objects.create(...)`.
-        # `username` is required by `auth.User`; we derive it from email or
-        # synthesize one from (provider, subject) to guarantee uniqueness
-        # for users without an email (e.g., Apple "hide my email" without
-        # a relay address, edge case). Truncated to Django's 150-char limit.
-        username = email if email else f"social_{provider}_{subject}"
-        username = username[:150]
+        # The natural identifier is routed through the kwarg named by
+        # `USERNAME_FIELD`, so the same code path works against `auth.User`
+        # (`username`), email-keyed integrator models (`email`), and
+        # `BlockUser`-derived models that key on an auto-populated `id`.
+        if not email:
+            logger.warning(
+                "social_identity.creation_blocked_missing_email",
+                extra={"provider": provider},
+            )
+            raise SocialIdentityMissingEmailError(provider=provider)
+
         new_user = User.objects.create_user(
-            username=username,
-            email=email or "",
-            password=None,
+            **self._build_create_user_kwargs(User, email)
         )
         identity = SocialIdentity(
             provider=provider,
@@ -167,6 +176,44 @@ class SocialIdentityService:
             bytes(identity.encrypted_refresh_token),
             aad_for(identity.provider, identity.subject),
         )
+
+    @staticmethod
+    def _build_create_user_kwargs(user_model: Any, email: str) -> dict[str, Any]:
+        """Build the kwargs for `User.objects.create_user(...)` for a new social user.
+
+        The natural identifier is routed through whichever kwarg the user model
+        names via `USERNAME_FIELD`. `email` is forwarded as a separate kwarg
+        only when it is a distinct field from the natural key, avoiding both a
+        `TypeError` (passing `username=` to email-keyed models) and a redundant
+        `email=` (when email already serves as the natural key).
+        """
+        username_field: str = user_model.USERNAME_FIELD
+        kwargs: dict[str, Any] = {"password": None}
+
+        if username_field == "email":
+            kwargs["email"] = email
+            return kwargs
+
+        has_email_field = any(
+            getattr(field, "name", None) == "email"
+            for field in user_model._meta.get_fields()
+        )
+        if has_email_field:
+            kwargs["email"] = email
+
+        # Only set the natural key kwarg when it is not auto-populated. Models
+        # keyed on `id` rely on the manager / default to assign the value, and
+        # passing a truncated email there would clash with the field type
+        # (e.g., `UUIDField`).
+        if username_field != "id":
+            try:
+                username_field_obj = user_model._meta.get_field(username_field)
+            except Exception:
+                username_field_obj = None
+            max_length = getattr(username_field_obj, "max_length", None) or 150
+            kwargs[username_field] = email[:max_length]
+
+        return kwargs
 
     def _maybe_store_refresh(
         self,


### PR DESCRIPTION
## Summary

`SocialIdentityService.upsert_and_link` hardcoded `User.objects.create_user(username=..., email=..., password=None)`. That call shape only works against Django's default `auth.User`. Email-keyed integrator models (e.g. fabric-auth's `Creator` with `USERNAME_FIELD = "email"`) and `id`-keyed `BlockUser`-derived models raised `TypeError: Creator() got unexpected keyword arguments: 'username'` on every new social sign-in.

The service now inspects `User.USERNAME_FIELD` and routes the natural identifier through whichever kwarg the integrator's manager expects. `email` is forwarded as a separate kwarg only when it's a distinct field from the natural key.

| User model | USERNAME_FIELD | Resulting call |
|---|---|---|
| `auth.User` (default) | `username` | `create_user(username=<email[:max]>, email=<email>, password=None)` |
| email-keyed (e.g. `Creator`) | `email` | `create_user(email=<email>, password=None)` |
| `BlockUser`-derived | `id` | `create_user(email=<email>, password=None)` (manager auto-populates `id`) |

The synthetic `social_{provider}_{subject}` fallback for missing email is replaced with `SocialIdentityMissingEmailError` (HTTP 400). Every supported provider (Google, Apple, Facebook, LinkedIn) returns at least a relay address; a missing email indicates a misconfigured scope, and the fallback would have corrupted email-keyed user tables with non-email-shaped values.

## Why now

Hit while wiring Apple Sign-In through fabric-auth — `Creator` rejected the `username=` kwarg with a 500. fabric-auth is the first downstream consumer with a non-default `USERNAME_FIELD`; `auth.User`-based integrators were unaffected, which is why the bug went undetected.

## Test plan

- [x] Existing 8 social-service tests pass against `auth.User` (`pytest blockauth/social/tests/test_service.py`)
- [x] Verified end-to-end against fabric-auth (`Creator`, `USERNAME_FIELD = "email"`) — Apple `/v1/auth/apple/verify/` creates a new user successfully where it previously 500'd
- [ ] Verify Google native verify path against fabric-auth (same code path)