### PR TITLE
fix(social): sync user.email from id_token on existing-identity sign-in

### DIFF
--- a/blockauth/social/service.py
+++ b/blockauth/social/service.py
@@ -2,7 +2,10 @@
 
 Single entrypoint `upsert_and_link` consolidates the four cases an OAuth/OIDC
 sign-in can produce:
-  1. Existing (provider, subject) — return the linked user.
+  1. Existing (provider, subject) — return the linked user. The user's
+     canonical email is also resynced from the id_token when the IdP returns
+     a different verified address (drives the Apple "Hide My Email" ->
+     "Share My Email" transition; see `_sync_user_email_from_provider`).
   2. New (provider, subject), email matches existing User, policy permits — link.
   3. New (provider, subject), email matches existing User, policy rejects — raise.
   4. No email match — create a new User.
@@ -67,6 +70,12 @@ class SocialIdentityService:
             SocialIdentity.objects.select_related("user").filter(provider=provider, subject=subject).first()
         )
         if existing_identity is not None:
+            self._sync_user_email_from_provider(
+                user=existing_identity.user,
+                provider=provider,
+                email=email,
+                email_verified=email_verified,
+            )
             refresh_changed = self._maybe_store_refresh(existing_identity, refresh_token, provider, subject)
             update_fields = ["last_used_at"]
             if refresh_changed:
@@ -176,6 +185,83 @@ class SocialIdentityService:
             bytes(identity.encrypted_refresh_token),
             aad_for(identity.provider, identity.subject),
         )
+
+    @staticmethod
+    def _sync_user_email_from_provider(
+        *,
+        user: Any,
+        provider: str,
+        email: str | None,
+        email_verified: bool,
+    ) -> bool:
+        """Update `user.email` when the IdP returns a verified email that differs
+        from the stored value. Returns True iff `user.email` was written.
+
+        Trust model: the caller has already verified the IdP's id_token, which
+        proves the (provider, subject) pair belongs to this user. The email
+        claim attached to that token is therefore authoritative for THIS user
+        even when `AccountLinkingPolicy` forbids auto-linking by email at
+        signup time (a different question — "trust the email enough to merge
+        with a separate account").
+
+        Drives the Apple "Hide My Email" -> "Share My Email" transition: the
+        relay address the user first signed up with is replaced with the real
+        address as soon as the user revokes + re-consents and picks Share.
+        Same mechanism keeps Google / Facebook / LinkedIn email up to date if
+        the upstream account email changes.
+
+        Skipped (no write, logged) when:
+          - IdP did not return an email                         → no signal
+          - IdP returned an unverified email                    → spoofable
+          - new email matches the stored one (case-insensitive) → no-op
+          - new email collides with another User row            → would silently
+            merge two distinct accounts; surface as a log line so the
+            integrator can decide (manual merge, account migration, etc.)
+        """
+        if not email:
+            return False
+        if not email_verified:
+            logger.info(
+                "social_identity.email_sync_skipped_unverified",
+                extra={"provider": provider, "user_id": str(user.id)},
+            )
+            return False
+
+        current_email = (user.email or "")
+        if email.lower() == current_email.lower():
+            return False
+
+        user_model = type(user)
+        collision = (
+            user_model._default_manager.filter(email__iexact=email)
+            .exclude(pk=user.pk)
+            .order_by("pk")
+            .first()
+        )
+        if collision is not None:
+            logger.warning(
+                "social_identity.email_sync_skipped_collision",
+                extra={
+                    "provider": provider,
+                    "user_id": str(user.id),
+                    "colliding_user_id": str(collision.pk),
+                    "email_domain_only": email.rsplit("@", 1)[-1],
+                },
+            )
+            return False
+
+        user.email = email
+        user.save(update_fields=["email"])
+        logger.info(
+            "social_identity.email_synced",
+            extra={
+                "provider": provider,
+                "user_id": str(user.id),
+                "email_domain_only": email.rsplit("@", 1)[-1],
+                "previous_was_apple_relay": current_email.endswith("@privaterelay.appleid.com"),
+            },
+        )
+        return True
 
     @staticmethod
     def _build_create_user_kwargs(user_model: Any, email: str) -> dict[str, Any]:

--- a/blockauth/social/tests/test_service.py
+++ b/blockauth/social/tests/test_service.py
@@ -219,4 +219,129 @@ def test_link_uses_case_insensitive_email_match():
     )
 
     assert returned_user.id == user.id
-    assert identity.provider == "google"
+
+
+@pytest.mark.django_db
+def test_existing_identity_syncs_changed_verified_email():
+    """Apple Hide -> Share (and similar IdP-side email changes) overwrite the
+    stored email on an already-linked identity. Pins the
+    `_sync_user_email_from_provider` behavior — the bug was that subsequent
+    sign-ins kept the relay address even after the user re-consented to share
+    the real one.
+    """
+    user = User.objects.create_user(
+        username="apple_relay_user",
+        email="abc123@privaterelay.appleid.com",
+        password="pw",
+    )
+    SocialIdentity.objects.create(
+        provider="apple",
+        subject="a_sub_relay",
+        user=user,
+        email_at_link="abc123@privaterelay.appleid.com",
+        email_verified_at_link=True,
+    )
+
+    SocialIdentityService().upsert_and_link(
+        provider="apple",
+        subject="a_sub_relay",
+        email="real.user@example.com",
+        email_verified=True,
+        extra_claims={"is_private_email": False},
+    )
+
+    user.refresh_from_db()
+    assert user.email == "real.user@example.com"
+
+
+@pytest.mark.django_db
+def test_existing_identity_keeps_email_when_unchanged():
+    """No-op when the IdP returns the same email (modulo case). Avoids a
+    needless write on every sign-in."""
+    user = User.objects.create_user(
+        username="stable_email_user",
+        email="stable@example.com",
+        password="pw",
+    )
+    SocialIdentity.objects.create(
+        provider="google",
+        subject="g_stable",
+        user=user,
+        email_at_link="stable@example.com",
+        email_verified_at_link=True,
+    )
+
+    SocialIdentityService().upsert_and_link(
+        provider="google",
+        subject="g_stable",
+        email="STABLE@example.com",
+        email_verified=True,
+        extra_claims={},
+    )
+
+    user.refresh_from_db()
+    assert user.email == "stable@example.com"
+
+
+@pytest.mark.django_db
+def test_existing_identity_skips_email_sync_when_unverified():
+    """Don't overwrite a verified email with an unverified one — the unverified
+    address could be spoofed and the user could lose access to the account."""
+    user = User.objects.create_user(
+        username="unverified_signin_user",
+        email="trusted@example.com",
+        password="pw",
+    )
+    SocialIdentity.objects.create(
+        provider="facebook",
+        subject="fb_sub",
+        user=user,
+        email_at_link="trusted@example.com",
+        email_verified_at_link=True,
+    )
+
+    SocialIdentityService().upsert_and_link(
+        provider="facebook",
+        subject="fb_sub",
+        email="attacker@example.com",
+        email_verified=False,
+        extra_claims={},
+    )
+
+    user.refresh_from_db()
+    assert user.email == "trusted@example.com"
+
+
+@pytest.mark.django_db
+def test_existing_identity_skips_email_sync_on_collision():
+    """Refusing the sync when the new email already belongs to another user
+    prevents a silent merge of two distinct accounts. The integrator gets a
+    warning log and can decide on a manual remediation path."""
+    user_a = User.objects.create_user(
+        username="user_a",
+        email="abc123@privaterelay.appleid.com",
+        password="pw",
+    )
+    User.objects.create_user(
+        username="user_b",
+        email="real.user@example.com",
+        password="pw",
+    )
+    SocialIdentity.objects.create(
+        provider="apple",
+        subject="a_sub_collision",
+        user=user_a,
+        email_at_link="abc123@privaterelay.appleid.com",
+        email_verified_at_link=True,
+    )
+
+    SocialIdentityService().upsert_and_link(
+        provider="apple",
+        subject="a_sub_collision",
+        email="real.user@example.com",
+        email_verified=True,
+        extra_claims={"is_private_email": False},
+    )
+
+    user_a.refresh_from_db()
+    assert user_a.email == "abc123@privaterelay.appleid.com"


### PR DESCRIPTION
## Summary

`SocialIdentityService.upsert_and_link` returned the existing user without ever updating `User.email` after the initial link. The user-visible bug surfaced with Apple's privacy toggle:

1. User signs up with Apple, picks **Hide My Email** -> `<random>@privaterelay.appleid.com` is stored.
2. User revokes the app on appleid.apple.com, re-consents, and picks **Share My Email** -> Apple now returns the real address in the id_token.
3. The service matches the existing `(provider, subject)` row (Apple keeps `sub` stable per app even after revoke) and returns the user — but the stored email never updates. The relay sticks forever.

Same gap affects Google / Facebook / LinkedIn whenever the upstream account email changes.

## Fix

New helper `_sync_user_email_from_provider` is called on the existing-identity branch. The trust model is intentionally separate from `AccountLinkingPolicy`:

| Question | Trust gate |
|---|---|
| "Trust this email enough to merge with a separate pre-existing account?" (initial-link) | `AccountLinkingPolicy.can_link_to_existing_user` — Apple = NO |
| "Trust this email enough to update the email of the identity we just authenticated?" (refresh) | id_token verification + `email_verified=true` + no collision — Apple = YES |

Apple's "never auto-link by email" rule at signup is preserved; the sync only updates the email of the identity Apple just authenticated.

### Skip paths (no write, logged)

| Condition | Log key |
|---|---|
| IdP returned no email | (no log — no signal to act on) |
| IdP returned an unverified email | `social_identity.email_sync_skipped_unverified` |
| New email matches stored (case-insensitive) | (no log — common case) |
| New email collides with another User row | `social_identity.email_sync_skipped_collision` (warning) |
| Successful refresh | `social_identity.email_synced` (info) |

The collision case is surfaced as a warning so an integrator can decide on a manual remediation path (account merge, user notification) rather than silently merging two distinct accounts.

## Test plan

- [x] `test_existing_identity_syncs_changed_verified_email` — Apple Hide -> Share path
- [x] `test_existing_identity_keeps_email_when_unchanged` — case-insensitive no-op
- [x] `test_existing_identity_skips_email_sync_when_unverified` — verified-email gate
- [x] `test_existing_identity_skips_email_sync_on_collision` — preserves stored email when new one is taken
- [x] All 8 pre-existing social-service tests still pass (12 total)
- [ ] Verify against fabric-auth Creator (`USERNAME_FIELD = "email"`) — fabric-auth bumps to this commit and the relay stored from the previous test gets replaced with the real email on the next sign-in