### PR TITLE
Harden Apple notification handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,23 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — pre-1
 
 ---
 
+## [0.16.2] - 2026-05-01
+
+### Added
+
+- Added package-level per-IP throttles for Apple web callback, native verify, and server-to-server notification endpoints with overridable `BLOCK_AUTH_SETTINGS` rate tuples.
+
+### Changed
+
+- Apple server-to-server notifications now reject stale or future `event_time` values and suppress replayed notifications before mutating `SocialIdentity` rows or running `APPLE_NOTIFICATION_TRIGGER`.
+- Apple server-to-server notifications now use Apple's documented `account-deleted` event type.
+
+### Fixed
+
+- Apple server-to-server notification triggers now call the package's public `BaseTrigger.trigger(context)` method, with the previous `run(context)` shape kept as a fallback for compatibility.
+
+---
+
 ## [0.16.1] - 2026-04-29
 
 ### Changed
@@ -41,7 +58,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — pre-1
   - `POST /apple/callback/` form_post callback (state + PKCE verify, id_token verify with conditional nonce, SocialIdentity link, blockauth JWT).
   - `POST /apple/verify/` native id_token verify for iOS/macOS clients (optional `authorization_code` redemption for refresh-token-at-rest).
   - `pre_delete` signal that revokes Apple refresh tokens at `/auth/revoke` when an integrator deletes a user (App Store Review Guideline 5.1.1(v)).
-  - `POST /apple/notifications/` server-to-server webhook (Korean SIWA mandate effective 2026-01-01) handling `consent-revoked`, `account-delete`, `email-disabled`, `email-enabled` events. Trigger hook receives `{event_type, sub, event_time}` only — full JWT claims are NOT exposed (PII safety).
+  - `POST /apple/notifications/` server-to-server webhook (Korean SIWA mandate effective 2026-01-01) handling `consent-revoked`, `account-deleted`, `email-disabled`, `email-enabled` events. Trigger hook receives `{event_type, sub, event_time}` only — full JWT claims are NOT exposed (PII safety).
 - **Google native id_token verify** — `POST /google/native/verify/` for Android Credential Manager, iOS Google Sign-In SDK, and Web One Tap. Audience set is `BLOCK_AUTH_SETTINGS["GOOGLE_NATIVE_AUDIENCES"]` (the integrator's web/server client IDs).
 - **Generic `OIDCTokenVerifier`** (`blockauth.utils.jwt`) reused by every OIDC provider:
   - JWKSCache with TTL + rotation-on-kid-miss refetch + transient-failure preservation (a 5xx from the IdP no longer wipes a working cache).

--- a/blockauth/__init__.py
+++ b/blockauth/__init__.py
@@ -28,7 +28,7 @@ Static utilities (no storage needed):
     backup_codes = TOTPService.generate_backup_codes()
 """
 
-__version__ = "0.16.1"
+__version__ = "0.16.2"
 
 # =============================================================================
 # Direct imports (Django-independent, no AppRegistryNotReady errors)

--- a/blockauth/apple/constants.py
+++ b/blockauth/apple/constants.py
@@ -25,6 +25,8 @@ class AppleClaimKeys:
 
 class AppleNotificationEvents:
     CONSENT_REVOKED = "consent-revoked"
-    ACCOUNT_DELETE = "account-delete"
+    ACCOUNT_DELETED = "account-deleted"
+    # Deprecated compatibility alias; use ACCOUNT_DELETED.
+    ACCOUNT_DELETE = ACCOUNT_DELETED
     EMAIL_DISABLED = "email-disabled"
     EMAIL_ENABLED = "email-enabled"

--- a/blockauth/apple/id_token_verifier.py
+++ b/blockauth/apple/id_token_verifier.py
@@ -8,7 +8,7 @@ Wraps the generic OIDCTokenVerifier with Apple-specific claim handling:
     absent, we skip nonce verification (older devices).
   - `verify_raw` is a thin convenience for the S2S notification path, which
     has a different audience expectation, no nonce, AND no email claim
-    requirement (Apple's `consent-revoked` / `account-delete` events do not
+    requirement (Apple's `consent-revoked` / `account-deleted` events do not
     carry an `email` field).
 
 Verifier instances are cached per (audiences, require_email_claim) tuple at
@@ -79,7 +79,7 @@ def _build_verifier(audiences: tuple[str, ...], *, require_email_claim: bool = T
 
     `require_email_claim` defaults True for the standard sign-in flow (Apple
     always returns an email — relay or real). Set False for the S2S
-    notification path: events like `consent-revoked` and `account-delete`
+    notification path: events like `consent-revoked` and `account-deleted`
     do NOT carry an email claim.
     """
     cache_key = (audiences, require_email_claim)
@@ -153,7 +153,7 @@ class AppleIdTokenVerifier:
 
     def verify_raw(self, id_token: str, audiences: tuple[str, ...]) -> dict[str, Any]:
         # require_email_claim=False because Apple S2S notification events
-        # (consent-revoked, account-delete) do NOT carry an `email` field.
+        # (consent-revoked, account-deleted) do NOT carry an `email` field.
         verifier = _build_verifier(audiences, require_email_claim=False)
         try:
             return verifier.verify(id_token, expected_nonce=None)

--- a/blockauth/apple/notification_service.py
+++ b/blockauth/apple/notification_service.py
@@ -9,13 +9,13 @@ object (newer). We parse defensively.
 
 Event handling:
   - consent-revoked -> drop the SocialIdentity for (apple, sub)
-  - account-delete  -> if user has no other social identities, delete the
+  - account-deleted -> if user has no other social identities, delete the
     SocialIdentity and then delete the User
   - email-disabled / email-enabled -> log only
 
 Trigger contract (APPLE_NOTIFICATION_TRIGGER):
   Integrators receive a trimmed dict containing `event_type`, `sub`,
-  `event_time`, and `user_id` — NOT the full decoded JWT claims. The
+  normalized `event_time`, and `user_id` — NOT the full decoded JWT claims. The
   payload is intentionally minimal to reduce the surface for accidental
   PII leaks if the integrator logs it. `user_id` is the integrator's own
   user identifier (resolved from the SocialIdentity before the affected
@@ -25,20 +25,27 @@ Trigger contract (APPLE_NOTIFICATION_TRIGGER):
   matched the (apple, sub) pair.
 """
 
+import hashlib
 import json
 import logging
+import math
+import time
 from dataclasses import dataclass
 from typing import Any
 
+from django.core.cache import cache as default_cache
 from django.db import transaction
 
 from blockauth.apple._settings import apple_setting
 from blockauth.apple.constants import AppleClaimKeys, AppleNotificationEvents
+from blockauth.apple.exceptions import AppleNotificationVerificationFailed
 from blockauth.apple.id_token_verifier import AppleIdTokenVerifier
 from blockauth.social.models import SocialIdentity
 from blockauth.utils.generics import import_string_or_none
 
 logger = logging.getLogger(__name__)
+
+_REPLAY_CACHE_KEY_PREFIX = "blockauth:apple_notification_replay:"
 
 
 @dataclass(frozen=True)
@@ -55,6 +62,82 @@ def _parse_events_claim(raw: Any) -> dict[str, Any]:
     raise TypeError(f"Unexpected events claim type: {type(raw)!r}")
 
 
+def _event_time_seconds(value: Any) -> float:
+    try:
+        event_time = float(value)
+    except (TypeError, ValueError) as exc:
+        raise AppleNotificationVerificationFailed("Apple notification event_time is missing or invalid") from exc
+    # Apple's public examples use Unix seconds. Some older field reports used
+    # milliseconds, so accept both and normalize before freshness checks.
+    if event_time > 9_999_999_999:
+        event_time = event_time / 1000
+    if not math.isfinite(event_time):
+        raise AppleNotificationVerificationFailed("Apple notification event_time is not finite")
+    return event_time
+
+
+def _int_setting(key: str, default: int, *, minimum: int) -> int:
+    try:
+        value = int(apple_setting(key, default))
+    except (TypeError, ValueError) as exc:
+        raise RuntimeError(f"{key} must be an integer") from exc
+    if value < minimum:
+        raise RuntimeError(f"{key} must be >= {minimum} (got {value})")
+    return value
+
+
+def _max_age_seconds() -> int:
+    return _int_setting("APPLE_NOTIFICATION_MAX_AGE_SECONDS", 300, minimum=1)
+
+
+def _future_leeway_seconds() -> int:
+    return _int_setting("APPLE_NOTIFICATION_FUTURE_LEEWAY_SECONDS", 60, minimum=0)
+
+
+def _normalized_event_time_value(event_time: float) -> int | float:
+    return int(event_time) if event_time.is_integer() else event_time
+
+
+def _stable_event_time_identity(event_time: int | float) -> str:
+    return f"{float(event_time):.6f}".rstrip("0").rstrip(".")
+
+
+def _validate_event_time_fresh(events: dict[str, Any]) -> int | float:
+    event_time = _event_time_seconds(events.get("event_time"))
+    now = time.time()
+    max_age = _max_age_seconds()
+    leeway = _future_leeway_seconds()
+    if event_time < now - max_age:
+        raise AppleNotificationVerificationFailed("Apple notification event_time is stale")
+    if event_time > now + leeway:
+        raise AppleNotificationVerificationFailed("Apple notification event_time is in the future")
+    return _normalized_event_time_value(event_time)
+
+
+def _replay_cache_key(claims: dict[str, Any], events: dict[str, Any], event_time: int | float) -> str:
+    jti = claims.get("jti")
+    if jti:
+        replay_identity = {"aud": claims.get("aud"), "jti": str(jti)}
+    else:
+        replay_identity = {
+            "aud": claims.get("aud"),
+            "event_time": _stable_event_time_identity(event_time),
+            "event_type": events.get("type"),
+            "sub": events.get("sub"),
+        }
+    digest = hashlib.sha256(
+        json.dumps(replay_identity, default=str, separators=(",", ":"), sort_keys=True).encode()
+    ).hexdigest()
+    return f"{_REPLAY_CACHE_KEY_PREFIX}{digest}"
+
+
+def _reserve_replay(claims: dict[str, Any], events: dict[str, Any], event_time: int | float) -> tuple[str, bool]:
+    ttl_seconds = _max_age_seconds() + _future_leeway_seconds()
+    cache_key = _replay_cache_key(claims, events, event_time)
+    already_seen = not default_cache.add(cache_key, True, timeout=ttl_seconds)
+    return cache_key, already_seen
+
+
 class AppleNotificationService:
     def dispatch(self, payload_jwt: str) -> AppleNotificationDispatchResult:
         services_id = apple_setting("APPLE_SERVICES_ID")
@@ -63,50 +146,67 @@ class AppleNotificationService:
 
         claims = AppleIdTokenVerifier().verify_raw(payload_jwt, audiences=(services_id,))
         events = _parse_events_claim(claims.get(AppleClaimKeys.EVENTS))
+        event_time = _validate_event_time_fresh(events)
         event_type = str(events.get("type") or "")
         sub = str(events.get("sub") or "")
-        logger.info("apple.notification.received", extra={"event_type": event_type})
+        replay_cache_key, replayed = _reserve_replay(claims, events, event_time)
+        if replayed:
+            logger.info("apple.notification.replay_suppressed", extra={"event_type": event_type or "<empty>"})
+            return AppleNotificationDispatchResult(event_type=event_type, handled=False)
+        try:
+            logger.info("apple.notification.received", extra={"event_type": event_type})
 
-        # Pre-resolve the affected user_id so the post-handler trigger can
-        # still reference it after consent-revoked / account-delete have
-        # mutated state. Returning the id alongside the boolean keeps the
-        # handler API minimal and avoids a second lookup against rows the
-        # handler may have just deleted.
-        handled = False
-        affected_user_id: str | None = None
-        if event_type == AppleNotificationEvents.CONSENT_REVOKED:
-            handled, affected_user_id = self._handle_consent_revoked(sub)
-        elif event_type == AppleNotificationEvents.ACCOUNT_DELETE:
-            handled, affected_user_id = self._handle_account_delete(sub)
-        elif event_type in (AppleNotificationEvents.EMAIL_DISABLED, AppleNotificationEvents.EMAIL_ENABLED):
-            handled = True
-            affected_user_id = self._lookup_user_id_for_subject(sub)
-        else:
-            # Unknown / unsupported event type. Log so integrators see new
-            # event types Apple may add in the future without crashing.
-            logger.warning(
-                "apple.notification.unknown_event_type",
-                extra={"event_type": event_type or "<empty>"},
-            )
+            # Pre-resolve the affected user_id so the post-handler trigger can
+            # still reference it after consent-revoked / account-deleted have
+            # mutated state. Returning the id alongside the boolean keeps the
+            # handler API minimal and avoids a second lookup against rows the
+            # handler may have just deleted.
+            handled = False
+            affected_user_id: str | None = None
+            if event_type == AppleNotificationEvents.CONSENT_REVOKED:
+                handled, affected_user_id = self._handle_consent_revoked(sub)
+            elif event_type == AppleNotificationEvents.ACCOUNT_DELETED:
+                handled, affected_user_id = self._handle_account_delete(sub)
+            elif event_type in (AppleNotificationEvents.EMAIL_DISABLED, AppleNotificationEvents.EMAIL_ENABLED):
+                handled = True
+                affected_user_id = self._lookup_user_id_for_subject(sub)
+            else:
+                # Unknown / unsupported event type. Log so integrators see new
+                # event types Apple may add in the future without crashing.
+                logger.warning(
+                    "apple.notification.unknown_event_type",
+                    extra={"event_type": event_type or "<empty>"},
+                )
 
-        trigger_path = apple_setting("APPLE_NOTIFICATION_TRIGGER")
-        trigger = import_string_or_none(trigger_path) if trigger_path else None
-        if trigger:
-            try:
-                # Trim the trigger payload to event_type/sub/event_time/user_id.
-                # The full JWT claims are NOT passed — see module docstring.
-                trigger().run(
-                    {
+            trigger_path = apple_setting("APPLE_NOTIFICATION_TRIGGER")
+            trigger = import_string_or_none(trigger_path) if trigger_path else None
+            if trigger:
+                try:
+                    # Trim the trigger payload to event_type/sub/event_time/user_id.
+                    # The full JWT claims are NOT passed — see module docstring.
+                    payload = {
                         "event_type": event_type,
                         "sub": sub,
-                        "event_time": events.get("event_time"),
+                        "event_time": event_time,
                         "user_id": affected_user_id,
                     }
-                )
-            except Exception as exc:  # never let an integrator hook bring down the webhook
-                logger.error("apple.notification.trigger_failed", extra={"error_class": exc.__class__.__name__})
+                    trigger_instance = trigger()
+                    trigger_method = getattr(trigger_instance, "trigger", None)
+                    if callable(trigger_method) and not getattr(trigger_method, "__isabstractmethod__", False):
+                        trigger_method(payload)
+                    else:
+                        run_method = getattr(trigger_instance, "run")
+                        run_method(payload)
+                except Exception as exc:  # never let an integrator hook bring down the webhook
+                    logger.exception(
+                        "apple.notification.trigger_failed",
+                        extra={"error_class": exc.__class__.__name__},
+                    )
 
-        return AppleNotificationDispatchResult(event_type=event_type, handled=handled)
+            return AppleNotificationDispatchResult(event_type=event_type, handled=handled)
+        except Exception:
+            default_cache.delete(replay_cache_key)
+            raise
 
     @staticmethod
     @transaction.atomic

--- a/blockauth/apple/tests/test_id_token_verifier.py
+++ b/blockauth/apple/tests/test_id_token_verifier.py
@@ -111,7 +111,7 @@ def test_verify_raw_rejects_token_with_wrong_audience(configured_settings, build
 
 
 def test_verify_raw_accepts_s2s_token_without_email(configured_settings, build_id_token, jwks_response):
-    """Apple S2S notifications (consent-revoked, account-delete) do NOT carry
+    """Apple S2S notifications (consent-revoked, account-deleted) do NOT carry
     an `email` claim. verify_raw must succeed even when email is absent.
     The bug this guards: OIDCVerifierConfig defaults require_email_claim=True,
     so without an explicit override RequiredClaimMissing would silently fail
@@ -121,7 +121,7 @@ def test_verify_raw_accepts_s2s_token_without_email(configured_settings, build_i
         "aud": "com.example.services",
         "sub": "001234.abcdef.1234",
         # NOTE: no `email`, no `email_verified` — this is what Apple sends
-        # for consent-revoked / account-delete events.
+        # for consent-revoked / account-deleted events.
         "events": "consent-revoked-payload",
     }
     token = build_id_token(claims)

--- a/blockauth/apple/tests/test_notification_service.py
+++ b/blockauth/apple/tests/test_notification_service.py
@@ -6,12 +6,16 @@ either a JSON string (legacy) or a JSON object (newer).
 """
 
 import json
+import time
 from unittest.mock import MagicMock, patch
 
 import pytest
 from django.contrib.auth import get_user_model
+from django.core.cache import cache
 from django.test import override_settings
 
+from blockauth.apple.constants import AppleNotificationEvents
+from blockauth.apple.exceptions import AppleNotificationVerificationFailed
 from blockauth.apple.id_token_verifier import _reset_verifier_cache
 from blockauth.apple.notification_service import AppleNotificationService
 from blockauth.social.models import SocialIdentity
@@ -21,8 +25,10 @@ User = get_user_model()
 
 @pytest.fixture(autouse=True)
 def _clear_verifier_cache():
+    cache.clear()
     _reset_verifier_cache()
     yield
+    cache.clear()
     _reset_verifier_cache()
 
 
@@ -47,6 +53,14 @@ def jwks_response(jwks_payload_bytes):
     return response
 
 
+def _fresh_event_time() -> int:
+    return int(time.time())
+
+
+def test_account_delete_constant_is_deprecated_alias():
+    assert AppleNotificationEvents.ACCOUNT_DELETE == AppleNotificationEvents.ACCOUNT_DELETED
+
+
 @pytest.mark.django_db
 def test_consent_revoked_deletes_social_identity_only(apple_settings, build_id_token, jwks_response):
     user = User.objects.create_user(username="alice_user", email="alice@example.com", password="pw")
@@ -63,7 +77,9 @@ def test_consent_revoked_deletes_social_identity_only(apple_settings, build_id_t
             "iss": "https://appleid.apple.com",
             "aud": "com.example.services",
             "sub": "apple-server",
-            "events": json.dumps({"type": "consent-revoked", "sub": "001234.consent", "event_time": 1700000000}),
+            "events": json.dumps(
+                {"type": "consent-revoked", "sub": "001234.consent", "event_time": _fresh_event_time()}
+            ),
         }
     )
 
@@ -75,7 +91,7 @@ def test_consent_revoked_deletes_social_identity_only(apple_settings, build_id_t
 
 
 @pytest.mark.django_db
-def test_account_delete_with_only_apple_link_deletes_user(apple_settings, build_id_token, jwks_response):
+def test_account_deleted_with_only_apple_link_deletes_user(apple_settings, build_id_token, jwks_response):
     user = User.objects.create_user(username="bob_user", email="bob@example.com", password="pw")
     SocialIdentity.objects.create(
         provider="apple",
@@ -90,7 +106,7 @@ def test_account_delete_with_only_apple_link_deletes_user(apple_settings, build_
             "iss": "https://appleid.apple.com",
             "aud": "com.example.services",
             "sub": "apple-server",
-            "events": {"type": "account-delete", "sub": "001234.acct", "event_time": 1700000001},
+            "events": {"type": "account-deleted", "sub": "001234.acct", "event_time": _fresh_event_time()},
         }
     )
 
@@ -102,7 +118,7 @@ def test_account_delete_with_only_apple_link_deletes_user(apple_settings, build_
 
 
 @pytest.mark.django_db
-def test_account_delete_removes_identity_when_user_delete_does_not_cascade(
+def test_account_deleted_removes_identity_when_user_delete_does_not_cascade(
     apple_settings, build_id_token, jwks_response
 ):
     user = User.objects.create_user(username="soft_user", email="soft@example.com", password="pw")
@@ -119,7 +135,7 @@ def test_account_delete_removes_identity_when_user_delete_does_not_cascade(
             "iss": "https://appleid.apple.com",
             "aud": "com.example.services",
             "sub": "apple-server",
-            "events": {"type": "account-delete", "sub": "001234.soft", "event_time": 1700000005},
+            "events": {"type": "account-deleted", "sub": "001234.soft", "event_time": _fresh_event_time()},
         }
     )
 
@@ -134,7 +150,7 @@ def test_account_delete_removes_identity_when_user_delete_does_not_cascade(
 
 
 @pytest.mark.django_db
-def test_account_delete_with_other_links_keeps_user(apple_settings, build_id_token, jwks_response):
+def test_account_deleted_with_other_links_keeps_user(apple_settings, build_id_token, jwks_response):
     user = User.objects.create_user(username="carol_user", email="carol@example.com", password="pw")
     SocialIdentity.objects.create(
         provider="apple",
@@ -156,7 +172,7 @@ def test_account_delete_with_other_links_keeps_user(apple_settings, build_id_tok
             "iss": "https://appleid.apple.com",
             "aud": "com.example.services",
             "sub": "apple-server",
-            "events": {"type": "account-delete", "sub": "001234.dual", "event_time": 1700000002},
+            "events": {"type": "account-deleted", "sub": "001234.dual", "event_time": _fresh_event_time()},
         }
     )
 
@@ -166,6 +182,38 @@ def test_account_delete_with_other_links_keeps_user(apple_settings, build_id_tok
     assert User.objects.filter(id=user.id).exists()
     assert not SocialIdentity.objects.filter(provider="apple", subject="001234.dual").exists()
     assert SocialIdentity.objects.filter(provider="google", subject="g_dual").exists()
+
+
+@pytest.mark.django_db
+def test_account_deleted_event_type_deletes_user(apple_settings, build_id_token, jwks_response):
+    user = User.objects.create_user(username="official_delete_user", email="official-delete@example.com", password="pw")
+    SocialIdentity.objects.create(
+        provider="apple",
+        subject="001234.official-delete",
+        user=user,
+        email_at_link=None,
+        email_verified_at_link=False,
+    )
+
+    payload_jwt = build_id_token(
+        {
+            "iss": "https://appleid.apple.com",
+            "aud": "com.example.services",
+            "sub": "apple-server",
+            "events": {
+                "type": "account-deleted",
+                "sub": "001234.official-delete",
+                "event_time": _fresh_event_time(),
+            },
+        }
+    )
+
+    with patch("blockauth.utils.jwt.jwks_cache.requests.get", return_value=jwks_response):
+        result = AppleNotificationService().dispatch(payload_jwt)
+
+    assert result.handled is True
+    assert not User.objects.filter(id=user.id).exists()
+    assert not SocialIdentity.objects.filter(provider="apple", subject="001234.official-delete").exists()
 
 
 @pytest.mark.django_db
@@ -184,7 +232,7 @@ def test_email_disabled_is_logged_only(apple_settings, build_id_token, jwks_resp
             "iss": "https://appleid.apple.com",
             "aud": "com.example.services",
             "sub": "apple-server",
-            "events": {"type": "email-disabled", "sub": "001234.email", "event_time": 1700000003},
+            "events": {"type": "email-disabled", "sub": "001234.email", "event_time": _fresh_event_time()},
         }
     )
 
@@ -219,7 +267,7 @@ def test_email_enabled_is_logged_only(apple_settings, build_id_token, jwks_respo
             "iss": "https://appleid.apple.com",
             "aud": "com.example.services",
             "sub": "apple-server",
-            "events": {"type": "email-enabled", "sub": "001234.enabled", "event_time": 1700000010},
+            "events": {"type": "email-enabled", "sub": "001234.enabled", "event_time": _fresh_event_time()},
         }
     )
 
@@ -231,8 +279,8 @@ def test_email_enabled_is_logged_only(apple_settings, build_id_token, jwks_respo
 
 
 @pytest.mark.django_db
-def test_account_delete_for_unknown_sub_returns_handled_false(apple_settings, build_id_token, jwks_response):
-    """account-delete for a sub with no matching SocialIdentity returns
+def test_account_deleted_for_unknown_sub_returns_handled_false(apple_settings, build_id_token, jwks_response):
+    """account-deleted for a sub with no matching SocialIdentity returns
     handled=False without raising. Apple may deliver a stale notification
     after the integrator already cleaned up; the handler must be idempotent."""
     payload_jwt = build_id_token(
@@ -240,7 +288,7 @@ def test_account_delete_for_unknown_sub_returns_handled_false(apple_settings, bu
             "iss": "https://appleid.apple.com",
             "aud": "com.example.services",
             "sub": "apple-server",
-            "events": {"type": "account-delete", "sub": "001234.unknown.sub", "event_time": 1700000011},
+            "events": {"type": "account-deleted", "sub": "001234.unknown.sub", "event_time": _fresh_event_time()},
         }
     )
 
@@ -266,13 +314,14 @@ def test_trigger_hook_called_with_trimmed_payload(apple_settings, build_id_token
         email_at_link=None,
         email_verified_at_link=False,
     )
+    event_time = _fresh_event_time()
 
     payload_jwt = build_id_token(
         {
             "iss": "https://appleid.apple.com",
             "aud": "com.example.services",
             "sub": "apple-server",
-            "events": {"type": "consent-revoked", "sub": "001234.trigger", "event_time": 1700000020},
+            "events": {"type": "consent-revoked", "sub": "001234.trigger", "event_time": event_time},
         }
     )
 
@@ -301,13 +350,61 @@ def test_trigger_hook_called_with_trimmed_payload(apple_settings, build_id_token
     assert captured == {
         "event_type": "consent-revoked",
         "sub": "001234.trigger",
-        "event_time": 1700000020,
+        "event_time": event_time,
         "user_id": str(user.pk),
     }
     # Critically: the full JWT claims (iss, aud, etc.) must NOT be in the
     # payload — that's the PII-leak defense the trigger trim implements.
     assert "claims" not in captured
     assert "iss" not in captured
+
+
+@pytest.mark.django_db
+def test_trigger_hook_uses_base_trigger_method(apple_settings, build_id_token, jwks_response):
+    user = User.objects.create_user(username="base_trigger_user", email="base-trigger@example.com", password="pw")
+    SocialIdentity.objects.create(
+        provider="apple",
+        subject="001234.base-trigger",
+        user=user,
+        email_at_link=None,
+        email_verified_at_link=False,
+    )
+    payload_jwt = build_id_token(
+        {
+            "iss": "https://appleid.apple.com",
+            "aud": "com.example.services",
+            "sub": "apple-server",
+            "events": {
+                "type": "email-enabled",
+                "sub": "001234.base-trigger",
+                "event_time": _fresh_event_time(),
+            },
+        }
+    )
+    captured: dict = {}
+
+    class _BaseStyleTrigger:
+        def trigger(self, payload):
+            captured.update(payload)
+
+    with (
+        patch(
+            "blockauth.apple.notification_service.import_string_or_none",
+            return_value=_BaseStyleTrigger,
+        ),
+        patch(
+            "blockauth.apple.notification_service.apple_setting",
+            side_effect=lambda key, default=None: {
+                "APPLE_SERVICES_ID": "com.example.services",
+                "APPLE_NOTIFICATION_TRIGGER": "_test._BaseStyleTrigger",
+            }.get(key, default),
+        ),
+        patch("blockauth.utils.jwt.jwks_cache.requests.get", return_value=jwks_response),
+    ):
+        AppleNotificationService().dispatch(payload_jwt)
+
+    assert captured["event_type"] == "email-enabled"
+    assert captured["user_id"] == str(user.pk)
 
 
 @pytest.mark.django_db
@@ -328,7 +425,7 @@ def test_trigger_hook_exception_is_swallowed(apple_settings, build_id_token, jwk
             "iss": "https://appleid.apple.com",
             "aud": "com.example.services",
             "sub": "apple-server",
-            "events": {"type": "consent-revoked", "sub": "001234.boom", "event_time": 1700000030},
+            "events": {"type": "consent-revoked", "sub": "001234.boom", "event_time": _fresh_event_time()},
         }
     )
 
@@ -361,6 +458,291 @@ def test_trigger_hook_exception_is_swallowed(apple_settings, build_id_token, jwk
 
 
 @pytest.mark.django_db
+def test_stale_notification_is_rejected_before_mutation_or_trigger(apple_settings, build_id_token, jwks_response):
+    user = User.objects.create_user(username="stale_user", email="stale@example.com", password="pw")
+    SocialIdentity.objects.create(
+        provider="apple",
+        subject="001234.stale",
+        user=user,
+        email_at_link=None,
+        email_verified_at_link=False,
+    )
+
+    payload_jwt = build_id_token(
+        {
+            "iss": "https://appleid.apple.com",
+            "aud": "com.example.services",
+            "sub": "apple-server",
+            "events": {"type": "consent-revoked", "sub": "001234.stale", "event_time": 1},
+        }
+    )
+
+    trigger = MagicMock()
+    with (
+        patch(
+            "blockauth.apple.notification_service.import_string_or_none",
+            return_value=lambda: trigger,
+        ),
+        patch(
+            "blockauth.apple.notification_service.apple_setting",
+            side_effect=lambda key, default=None: {
+                "APPLE_SERVICES_ID": "com.example.services",
+                "APPLE_NOTIFICATION_TRIGGER": "_test._CaptureTrigger",
+                "APPLE_NOTIFICATION_MAX_AGE_SECONDS": 300,
+            }.get(key, default),
+        ),
+        patch("blockauth.utils.jwt.jwks_cache.requests.get", return_value=jwks_response),
+    ):
+        with pytest.raises(AppleNotificationVerificationFailed):
+            AppleNotificationService().dispatch(payload_jwt)
+
+    assert SocialIdentity.objects.filter(provider="apple", subject="001234.stale").exists()
+    trigger.run.assert_not_called()
+    trigger.trigger.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_future_notification_uses_apple_notification_leeway(apple_settings, build_id_token, jwks_response):
+    payload_jwt = build_id_token(
+        {
+            "iss": "https://appleid.apple.com",
+            "aud": "com.example.services",
+            "sub": "apple-server",
+            "events": {
+                "type": "email-enabled",
+                "sub": "001234.future",
+                "event_time": int(time.time()) + 30,
+            },
+        }
+    )
+
+    with (
+        patch(
+            "blockauth.apple.notification_service.apple_setting",
+            side_effect=lambda key, default=None: {
+                "APPLE_SERVICES_ID": "com.example.services",
+                "APPLE_NOTIFICATION_MAX_AGE_SECONDS": 300,
+                "APPLE_NOTIFICATION_FUTURE_LEEWAY_SECONDS": 5,
+            }.get(key, default),
+        ),
+        patch("blockauth.utils.jwt.jwks_cache.requests.get", return_value=jwks_response),
+    ):
+        with pytest.raises(AppleNotificationVerificationFailed):
+            AppleNotificationService().dispatch(payload_jwt)
+
+
+@pytest.mark.django_db
+def test_invalid_notification_time_setting_is_runtime_error(apple_settings, build_id_token, jwks_response):
+    payload_jwt = build_id_token(
+        {
+            "iss": "https://appleid.apple.com",
+            "aud": "com.example.services",
+            "sub": "apple-server",
+            "events": {"type": "email-enabled", "sub": "001234.bad-config", "event_time": _fresh_event_time()},
+        }
+    )
+
+    with (
+        patch(
+            "blockauth.apple.notification_service.apple_setting",
+            side_effect=lambda key, default=None: {
+                "APPLE_SERVICES_ID": "com.example.services",
+                "APPLE_NOTIFICATION_MAX_AGE_SECONDS": "not-an-int",
+            }.get(key, default),
+        ),
+        patch("blockauth.utils.jwt.jwks_cache.requests.get", return_value=jwks_response),
+    ):
+        with pytest.raises(RuntimeError, match="APPLE_NOTIFICATION_MAX_AGE_SECONDS must be an integer"):
+            AppleNotificationService().dispatch(payload_jwt)
+
+
+@pytest.mark.django_db
+def test_replayed_notification_is_suppressed_before_second_trigger(apple_settings, build_id_token, jwks_response):
+    user = User.objects.create_user(username="replay_user", email="replay@example.com", password="pw")
+    SocialIdentity.objects.create(
+        provider="apple",
+        subject="001234.replay",
+        user=user,
+        email_at_link=None,
+        email_verified_at_link=False,
+    )
+    event_time = _fresh_event_time()
+    payload_jwt = build_id_token(
+        {
+            "iss": "https://appleid.apple.com",
+            "aud": "com.example.services",
+            "sub": "apple-server",
+            "jti": "apple-s2s-event-replay-1",
+            "events": {"type": "email-enabled", "sub": "001234.replay", "event_time": event_time},
+        }
+    )
+    captured: list[dict] = []
+
+    class _CaptureTrigger:
+        def trigger(self, payload):
+            captured.append(payload)
+
+    with (
+        patch(
+            "blockauth.apple.notification_service.import_string_or_none",
+            return_value=_CaptureTrigger,
+        ),
+        patch(
+            "blockauth.apple.notification_service.apple_setting",
+            side_effect=lambda key, default=None: {
+                "APPLE_SERVICES_ID": "com.example.services",
+                "APPLE_NOTIFICATION_TRIGGER": "_test._CaptureTrigger",
+                "APPLE_NOTIFICATION_MAX_AGE_SECONDS": 300,
+                "APPLE_NOTIFICATION_FUTURE_LEEWAY_SECONDS": 60,
+            }.get(key, default),
+        ),
+        patch("blockauth.utils.jwt.jwks_cache.requests.get", return_value=jwks_response),
+    ):
+        first_result = AppleNotificationService().dispatch(payload_jwt)
+        second_result = AppleNotificationService().dispatch(payload_jwt)
+
+    assert first_result.handled is True
+    assert second_result.event_type == "email-enabled"
+    assert second_result.handled is False
+    assert captured == [
+        {
+            "event_type": "email-enabled",
+            "sub": "001234.replay",
+            "event_time": event_time,
+            "user_id": str(user.pk),
+        }
+    ]
+
+
+@pytest.mark.django_db
+def test_replay_key_normalizes_event_time_without_jti(apple_settings, build_id_token, jwks_response):
+    user = User.objects.create_user(username="normalized_replay_user", email="normalized-replay@example.com", password="pw")
+    SocialIdentity.objects.create(
+        provider="apple",
+        subject="001234.normalized-replay",
+        user=user,
+        email_at_link=None,
+        email_verified_at_link=False,
+    )
+    event_time = _fresh_event_time()
+    payload_jwt = build_id_token(
+        {
+            "iss": "https://appleid.apple.com",
+            "aud": "com.example.services",
+            "sub": "apple-server",
+            "events": {
+                "type": "email-enabled",
+                "sub": "001234.normalized-replay",
+                "event_time": event_time * 1000,
+            },
+        }
+    )
+    equivalent_payload_jwt = build_id_token(
+        {
+            "iss": "https://appleid.apple.com",
+            "aud": "com.example.services",
+            "sub": "apple-server",
+            "events": {
+                "type": "email-enabled",
+                "sub": "001234.normalized-replay",
+                "event_time": event_time,
+            },
+        }
+    )
+    captured: list[dict] = []
+
+    class _CaptureTrigger:
+        def trigger(self, payload):
+            captured.append(payload)
+
+    with (
+        patch(
+            "blockauth.apple.notification_service.import_string_or_none",
+            return_value=_CaptureTrigger,
+        ),
+        patch(
+            "blockauth.apple.notification_service.apple_setting",
+            side_effect=lambda key, default=None: {
+                "APPLE_SERVICES_ID": "com.example.services",
+                "APPLE_NOTIFICATION_TRIGGER": "_test._CaptureTrigger",
+                "APPLE_NOTIFICATION_MAX_AGE_SECONDS": 300,
+                "APPLE_NOTIFICATION_FUTURE_LEEWAY_SECONDS": 60,
+            }.get(key, default),
+        ),
+        patch("blockauth.utils.jwt.jwks_cache.requests.get", return_value=jwks_response),
+    ):
+        first_result = AppleNotificationService().dispatch(payload_jwt)
+        second_result = AppleNotificationService().dispatch(equivalent_payload_jwt)
+
+    assert first_result.handled is True
+    assert second_result.event_type == "email-enabled"
+    assert second_result.handled is False
+    assert captured == [
+        {
+            "event_type": "email-enabled",
+            "sub": "001234.normalized-replay",
+            "event_time": event_time,
+            "user_id": str(user.pk),
+        }
+    ]
+
+
+@pytest.mark.django_db
+def test_replay_marker_is_cleared_when_dispatch_side_effect_fails(apple_settings, build_id_token, jwks_response):
+    user = User.objects.create_user(username="retry_user", email="retry@example.com", password="pw")
+    SocialIdentity.objects.create(
+        provider="apple",
+        subject="001234.retry",
+        user=user,
+        email_at_link=None,
+        email_verified_at_link=False,
+    )
+    payload_jwt = build_id_token(
+        {
+            "iss": "https://appleid.apple.com",
+            "aud": "com.example.services",
+            "sub": "apple-server",
+            "jti": "apple-s2s-event-retry-1",
+            "events": {
+                "type": "consent-revoked",
+                "sub": "001234.retry",
+                "event_time": _fresh_event_time(),
+            },
+        }
+    )
+    service = AppleNotificationService()
+
+    with (
+        patch("blockauth.utils.jwt.jwks_cache.requests.get", return_value=jwks_response),
+        patch.object(service, "_handle_consent_revoked", side_effect=RuntimeError("database unavailable")),
+    ):
+        with pytest.raises(RuntimeError):
+            service.dispatch(payload_jwt)
+
+    with patch("blockauth.utils.jwt.jwks_cache.requests.get", return_value=jwks_response):
+        result = AppleNotificationService().dispatch(payload_jwt)
+
+    assert result.handled is True
+    assert not SocialIdentity.objects.filter(provider="apple", subject="001234.retry").exists()
+
+
+@pytest.mark.django_db
+def test_non_finite_event_time_is_rejected(apple_settings, build_id_token, jwks_response):
+    payload_jwt = build_id_token(
+        {
+            "iss": "https://appleid.apple.com",
+            "aud": "com.example.services",
+            "sub": "apple-server",
+            "events": {"type": "email-enabled", "sub": "001234.nan", "event_time": "nan"},
+        }
+    )
+
+    with patch("blockauth.utils.jwt.jwks_cache.requests.get", return_value=jwks_response):
+        with pytest.raises(AppleNotificationVerificationFailed):
+            AppleNotificationService().dispatch(payload_jwt)
+
+
+@pytest.mark.django_db
 def test_notification_endpoint_returns_200_on_valid_payload(apple_settings, build_id_token, jwks_response, client):
     user = User.objects.create_user(username="end_user", email="end@example.com", password="pw")
     SocialIdentity.objects.create(
@@ -376,7 +758,7 @@ def test_notification_endpoint_returns_200_on_valid_payload(apple_settings, buil
             "iss": "https://appleid.apple.com",
             "aud": "com.example.services",
             "sub": "apple-server",
-            "events": {"type": "consent-revoked", "sub": "001234.endpoint", "event_time": 1700000004},
+            "events": {"type": "consent-revoked", "sub": "001234.endpoint", "event_time": _fresh_event_time()},
         }
     )
 

--- a/blockauth/apple/tests/test_view_throttles.py
+++ b/blockauth/apple/tests/test_view_throttles.py
@@ -1,0 +1,54 @@
+"""Apple endpoint throttling tests."""
+
+import pytest
+from django.core.cache import cache
+from django.test import override_settings
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    cache.clear()
+    yield
+    cache.clear()
+
+
+@pytest.fixture
+def apple_throttle_settings():
+    with override_settings(
+        BLOCK_AUTH_SETTINGS={
+            "APPLE_SERVICES_ID": "com.example.services",
+            "APPLE_BUNDLE_IDS": ("com.example.app",),
+            "FEATURES": {"APPLE_LOGIN": True, "SOCIAL_AUTH": True},
+            "APPLE_NATIVE_VERIFY_RATE_LIMIT": (1, 60),
+            "APPLE_WEB_CALLBACK_RATE_LIMIT": (1, 60),
+            "APPLE_NOTIFICATION_RATE_LIMIT": (1, 60),
+        }
+    ):
+        yield
+
+
+@pytest.mark.django_db
+def test_native_verify_is_throttled_by_ip_before_validation(apple_throttle_settings, client):
+    first = client.post("/apple/verify/", data={"id_token": "invalid"}, content_type="application/json")
+    second = client.post("/apple/verify/", data={"id_token": "invalid"}, content_type="application/json")
+
+    assert first.status_code == 400
+    assert second.status_code == 429
+
+
+@pytest.mark.django_db
+def test_web_callback_is_throttled_by_ip_before_validation(apple_throttle_settings, client):
+    first = client.post("/apple/callback/", data={"state": "missing-code"})
+    second = client.post("/apple/callback/", data={"state": "missing-code"})
+
+    assert first.status_code == 400
+    assert second.status_code == 429
+
+
+@pytest.mark.django_db
+def test_notifications_are_throttled_by_ip_before_validation(apple_throttle_settings, client):
+    first = client.post("/apple/notifications/", data={}, content_type="application/json")
+    second = client.post("/apple/notifications/", data={}, content_type="application/json")
+
+    assert first.status_code == 400
+    assert second.status_code == 429

--- a/blockauth/apple/throttles.py
+++ b/blockauth/apple/throttles.py
@@ -1,0 +1,104 @@
+"""Rate limits for public Apple Sign-In endpoints."""
+
+import time
+
+from django.core.cache import cache as default_cache
+from rest_framework.throttling import BaseThrottle
+
+from blockauth.apple._settings import apple_setting
+from blockauth.utils.generics import sanitize_log_context
+from blockauth.utils.logger import blockauth_logger
+from blockauth.utils.rate_limiter import get_client_ip
+
+
+def _rate_tuple(setting_name: str, default: tuple[int, int]) -> tuple[int, int]:
+    raw = apple_setting(setting_name, default)
+    if isinstance(raw, (list, tuple)) and len(raw) == 2:
+        try:
+            requests, seconds = int(raw[0]), int(raw[1])
+        except (TypeError, ValueError):
+            return default
+        if requests > 0 and seconds > 0:
+            return requests, seconds
+    return default
+
+
+class AppleEndpointThrottle(BaseThrottle):
+    """Per-IP throttle for public Apple endpoints.
+
+    Apple endpoints are intentionally `AllowAny`: the Apple-signed JWT or
+    id_token is the auth material. Throttling happens before serializer and
+    signature work so invalid floods cannot burn verifier CPU indefinitely.
+    """
+
+    cache = default_cache
+    timer = time.time
+    scope = "apple"
+    setting_name = ""
+    default_rate: tuple[int, int] = (30, 60)
+
+    def __init__(self):
+        self.num_requests, self.duration = _rate_tuple(self.setting_name, self.default_rate)
+        self.now = self.timer()
+        self.window_started_at = self._window_started_at(self.now)
+
+    def _window_started_at(self, timestamp: float) -> float:
+        return timestamp - (timestamp % self.duration)
+
+    def get_cache_key(self, request) -> str:
+        ip = get_client_ip(request) or "unknown"
+        window = int(self.now // self.duration)
+        return f"apple_throttle_{self.scope}_{ip}_{window}"
+
+    def _increment_request_count(self, key: str) -> int:
+        if self.cache.add(key, 1, self.duration):
+            return 1
+        try:
+            return self.cache.incr(key)
+        except ValueError:
+            if self.cache.add(key, 1, self.duration):
+                return 1
+            return self.cache.incr(key)
+
+    def allow_request(self, request, view) -> bool:
+        self.now = self.timer()
+        self.window_started_at = self._window_started_at(self.now)
+        key = self.get_cache_key(request)
+        request_count = self._increment_request_count(key)
+
+        if request_count > self.num_requests:
+            blockauth_logger.warning(
+                "Apple endpoint throttle exceeded",
+                sanitize_log_context(
+                    {
+                        "scope": self.scope,
+                        "ip": get_client_ip(request),
+                        "limit": self.num_requests,
+                        "duration": self.duration,
+                    }
+                ),
+            )
+            return False
+
+        return True
+
+    def wait(self):  # pragma: no cover - DRF interface
+        return max(0, self.duration - (self.now - self.window_started_at))
+
+
+class AppleWebCallbackThrottle(AppleEndpointThrottle):
+    scope = "apple_web_callback"
+    setting_name = "APPLE_WEB_CALLBACK_RATE_LIMIT"
+    default_rate = (30, 60)
+
+
+class AppleNativeVerifyThrottle(AppleEndpointThrottle):
+    scope = "apple_native_verify"
+    setting_name = "APPLE_NATIVE_VERIFY_RATE_LIMIT"
+    default_rate = (30, 60)
+
+
+class AppleNotificationThrottle(AppleEndpointThrottle):
+    scope = "apple_notification"
+    setting_name = "APPLE_NOTIFICATION_RATE_LIMIT"
+    default_rate = (60, 60)

--- a/blockauth/apple/views.py
+++ b/blockauth/apple/views.py
@@ -53,6 +53,11 @@ from blockauth.apple.serializers import (
     AppleNativeVerifyRequestSerializer,
     AppleServerToServerNotificationRequestSerializer,
 )
+from blockauth.apple.throttles import (
+    AppleNativeVerifyThrottle,
+    AppleNotificationThrottle,
+    AppleWebCallbackThrottle,
+)
 from blockauth.docs.apple_docs import (
     apple_authorize_schema,
     apple_callback_schema,
@@ -154,6 +159,7 @@ class AppleWebAuthorizeView(APIView):
 class AppleWebCallbackView(APIView):
     permission_classes = (AllowAny,)
     authentication_classes = ()
+    throttle_classes = [AppleWebCallbackThrottle]
 
     def handle_exception(self, exc):
         # Any error path must clear the state/PKCE/nonce cookies; otherwise
@@ -289,6 +295,7 @@ class AppleNativeVerifyView(APIView):
 
     permission_classes = (AllowAny,)
     authentication_classes = ()
+    throttle_classes = [AppleNativeVerifyThrottle]
 
     @extend_schema(**apple_native_verify_schema)
     def post(self, request):
@@ -392,14 +399,16 @@ class AppleServerToServerNotificationView(APIView):
     """POST /apple/notifications/ — Apple's server-to-server webhook.
 
     Apple sends {"payload": "<JWT>"} for events like consent-revoked,
-    account-delete, email-disabled, email-enabled. We verify the JWT
+    account-deleted, email-disabled, email-enabled. We verify the JWT
     inside AppleNotificationService.dispatch and let it apply state
-    changes; on any verification or parse failure, we return 400 with
-    code 4056 so Apple's retry logic gets a meaningful signal.
+    changes; duplicate fresh notifications are idempotently suppressed. On any
+    verification or parse failure, we return 400 with code 4056 so Apple's retry
+    logic gets a meaningful signal.
     """
 
     permission_classes = (AllowAny,)
     authentication_classes = ()
+    throttle_classes = [AppleNotificationThrottle]
 
     @extend_schema(**apple_notifications_schema)
     def post(self, request):

--- a/blockauth/conf.py
+++ b/blockauth/conf.py
@@ -78,6 +78,11 @@ DEFAULTS = {
     "APPLE_REDIRECT_URI": None,
     "APPLE_NOTIFICATION_TRIGGER": None,  # optional integrator hook for S2S notifications
     "APPLE_CALLBACK_COOKIE_SAMESITE": "None",  # form_post requires SameSite=None+Secure on deployed TLS
+    "APPLE_NOTIFICATION_MAX_AGE_SECONDS": 300,  # reject stale S2S event_time values
+    "APPLE_NOTIFICATION_FUTURE_LEEWAY_SECONDS": 60,  # tolerate small Apple/server clock skew
+    "APPLE_WEB_CALLBACK_RATE_LIMIT": (30, 60),  # per-IP (requests, seconds)
+    "APPLE_NATIVE_VERIFY_RATE_LIMIT": (30, 60),  # per-IP (requests, seconds)
+    "APPLE_NOTIFICATION_RATE_LIMIT": (60, 60),  # per-IP (requests, seconds)
     # Google native id_token verify
     "GOOGLE_NATIVE_AUDIENCES": (),  # tuple of web client IDs accepted in id_token.aud
     # Generic OIDC verifier

--- a/blockauth/docs/apple_docs.py
+++ b/blockauth/docs/apple_docs.py
@@ -447,7 +447,7 @@ apple_notifications_schema = {
         "\n"
         "**Supported Event Types:**\n"
         "- `consent-revoked`: user revoked Sign in with Apple for the integrator's app\n"
-        "- `account-delete`: user deleted their Apple ID — wipe linked SocialIdentity\n"
+        "- `account-deleted`: user deleted their Apple ID — wipe linked SocialIdentity\n"
         "- `email-disabled`: private-relay email forwarding stopped for this user\n"
         "- `email-enabled`: private-relay email forwarding resumed\n"
         "\n"

--- a/docs/guides/apple-sign-in-setup.md
+++ b/docs/guides/apple-sign-in-setup.md
@@ -16,6 +16,11 @@ The Apple sub-package reads these keys from `BLOCK_AUTH_SETTINGS`:
 | `APPLE_BUNDLE_IDS` | native only | List of bundle IDs accepted as `aud` on id_tokens; native authorization-code redemption uses this audience as Apple `client_id` |
 | `APPLE_NOTIFICATION_TRIGGER` | S2S notifications | Dotted path to a `BaseTrigger` subclass invoked on Apple webhook events |
 | `APPLE_CALLBACK_COOKIE_SAMESITE` | optional | Override SameSite on state/PKCE/nonce cookies (default `None` for cross-site form_post) |
+| `APPLE_NOTIFICATION_MAX_AGE_SECONDS` | S2S notifications | Maximum accepted age of Apple `event_time` values (default 300 seconds) |
+| `APPLE_NOTIFICATION_FUTURE_LEEWAY_SECONDS` | S2S notifications | Allowed future clock skew for Apple `event_time` values (default 60 seconds) |
+| `APPLE_WEB_CALLBACK_RATE_LIMIT` | web callback | Per-IP `(max_requests, window_seconds)` rate limit for `/apple/callback/` |
+| `APPLE_NATIVE_VERIFY_RATE_LIMIT` | native verify | Per-IP `(max_requests, window_seconds)` rate limit for `/apple/verify/` |
+| `APPLE_NOTIFICATION_RATE_LIMIT` | S2S notifications | Per-IP `(max_requests, window_seconds)` rate limit for `/apple/notifications/` |
 
 OIDC verification also reads `OIDC_JWKS_CACHE_TTL_SECONDS` and `OIDC_VERIFIER_LEEWAY_SECONDS` (shared with Google native).
 
@@ -95,7 +100,7 @@ The `.p8` contents (the entire PEM block including `-----BEGIN PRIVATE KEY-----`
 
 Apple sends webhooks when a user:
 - Disables Sign in with Apple in iCloud settings (`consent-revoked`)
-- Permanently deletes their Apple ID (`account-delete`)
+- Permanently deletes their Apple ID (`account-deleted`)
 - Changes the email address backing their Apple ID (`email-disabled`, `email-enabled`)
 
 Without S2S notifications, you'll keep stale `SocialIdentity` rows for users who revoked access. With them, the configured trigger fires and you can clean up downstream state.
@@ -128,11 +133,12 @@ Implement the trigger:
 from blockauth.triggers import BaseTrigger
 
 class AppleNotificationTrigger(BaseTrigger):
-    def fire(self, context: dict) -> None:
-        # context contains: event_type, sub (Apple user id), email (if any),
-        # event_time, plus identity_id if we matched a SocialIdentity row.
+    def trigger(self, context: dict) -> None:
+        # context contains: event_type, sub (Apple user id), event_time
+        # (normalized Unix seconds),
+        # and user_id if BlockAuth matched a SocialIdentity row.
         event = context["event_type"]
-        if event in ("account-delete", "consent-revoked"):
+        if event in ("account-deleted", "consent-revoked"):
             # delete or disable the linked account
             ...
         elif event in ("email-disabled", "email-enabled"):
@@ -140,7 +146,9 @@ class AppleNotificationTrigger(BaseTrigger):
             ...
 ```
 
-The endpoint is **safe to expose without further auth** — the request body is a JWT signed by Apple and validated against Apple's published JWKS before the trigger fires. Requests with bad signatures return 401 and the trigger never runs.
+The endpoint is **safe to expose without further auth** — the request body is a JWT signed by Apple and validated against Apple's published JWKS before the trigger fires. BlockAuth also rejects stale or future `event_time` values, suppresses replayed notifications before mutation or trigger dispatch, and applies a per-IP throttle to malformed or excessive traffic.
+
+Use a shared Django cache backend such as Redis or Memcached in production. Django's local-memory cache is process-local, so it is not sufficient for cluster-wide Apple notification replay suppression or per-IP throttling across multiple workers.
 
 ---
 
@@ -177,6 +185,11 @@ BLOCK_AUTH_SETTINGS = {
 
     # Optional S2S notifications
     "APPLE_NOTIFICATION_TRIGGER": "myapp.triggers.AppleNotificationTrigger",
+    "APPLE_NOTIFICATION_MAX_AGE_SECONDS": 300,
+    "APPLE_NOTIFICATION_FUTURE_LEEWAY_SECONDS": 60,
+    "APPLE_NOTIFICATION_RATE_LIMIT": (60, 60),
+    "APPLE_NATIVE_VERIFY_RATE_LIMIT": (30, 60),
+    "APPLE_WEB_CALLBACK_RATE_LIMIT": (30, 60),
 }
 ```
 

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -41,6 +41,25 @@ All settings are configured in `BLOCK_AUTH_SETTINGS` in your Django settings mod
 |---------|---------|-------------|
 | `WALLET_MESSAGE_TTL` | `300` | Signed wallet message expiry in seconds (5 minutes) |
 
+## Apple Sign-In
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `APPLE_TEAM_ID` | `None` | Apple Developer Team ID used to build the client secret |
+| `APPLE_KEY_ID` | `None` | Sign in with Apple key ID used to build the client secret |
+| `APPLE_PRIVATE_KEY_PEM` | `None` | PEM contents for the Sign in with Apple private key |
+| `APPLE_PRIVATE_KEY_PATH` | `None` | Path to the Sign in with Apple `.p8` private key |
+| `APPLE_SERVICES_ID` | `None` | Services ID used as web OAuth client ID and S2S notification audience |
+| `APPLE_BUNDLE_IDS` | `()` | Native app bundle IDs accepted as id_token audiences |
+| `APPLE_REDIRECT_URI` | `None` | Web callback URL registered on the Services ID |
+| `APPLE_NOTIFICATION_TRIGGER` | `None` | Dotted path to a trigger class for verified S2S events |
+| `APPLE_CALLBACK_COOKIE_SAMESITE` | `"None"` | SameSite value for Apple form_post state/PKCE/nonce cookies |
+| `APPLE_NOTIFICATION_MAX_AGE_SECONDS` | `300` | Maximum accepted age of S2S `event_time` values |
+| `APPLE_NOTIFICATION_FUTURE_LEEWAY_SECONDS` | `60` | Allowed future clock skew for S2S `event_time` values |
+| `APPLE_WEB_CALLBACK_RATE_LIMIT` | `(30, 60)` | Per-IP `(max_requests, window_seconds)` for `/apple/callback/` |
+| `APPLE_NATIVE_VERIFY_RATE_LIMIT` | `(30, 60)` | Per-IP `(max_requests, window_seconds)` for `/apple/verify/` |
+| `APPLE_NOTIFICATION_RATE_LIMIT` | `(60, 60)` | Per-IP `(max_requests, window_seconds)` for `/apple/notifications/` |
+
 ## Feature Flags
 
 | Setting | Default | Description |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "blockauth"
-version = "0.16.1"
+version = "0.16.2"
 description = "Comprehensive Python authentication package bridging Web2 and Web3"
 authors = [{name = "BloclabsHQ", email = "eng@bloclabs.com"}]
 license = {text = "MIT"}

--- a/uv.lock
+++ b/uv.lock
@@ -312,7 +312,7 @@ wheels = [
 
 [[package]]
 name = "blockauth"
-version = "0.16.1"
+version = "0.16.2"
 source = { editable = "." }
 dependencies = [
     { name = "argon2-cffi" },


### PR DESCRIPTION
## Summary
- Harden Apple S2S notification handling by validating stale/future `event_time`, suppressing replayed notifications, and using Apple's documented `account-deleted` event type.
- Add package-level per-IP throttles for public Apple callback, native verify, and notification endpoints so malformed traffic is limited before expensive validation work.
- Align Apple notification triggers with the public `BaseTrigger.trigger(context)` contract and document the v0.16.2 settings surface.

Closes #152
Closes #153

## Test plan
- [x] `uv run pytest blockauth/apple/tests/test_notification_service.py blockauth/apple/tests/test_view_throttles.py`
- [x] `uv run pytest blockauth/apple/tests blockauth/docs/test_apple_google_native_schemas.py blockauth/social/tests/test_service.py`
- [x] `uv run pytest blockauth/apple/tests blockauth/social/tests/test_service.py`
- [x] `uv run pytest`
- [x] `uv run python -c "... pyproject=0.16.2 init=0.16.2 ..."`
- [x] `uv build --out-dir /private/tmp/auth-pack-dist-0.16.2`
- [x] `git diff --cached --check`
- [x] `uv run flake8 blockauth/__init__.py blockauth/apple/throttles.py blockauth/apple/notification_service.py blockauth/apple/views.py blockauth/apple/constants.py blockauth/apple/id_token_verifier.py blockauth/apple/tests/test_notification_service.py blockauth/apple/tests/test_view_throttles.py blockauth/apple/tests/test_id_token_verifier.py blockauth/conf.py blockauth/docs/apple_docs.py --ignore=E501`
- [ ] `make lint` is still blocked by the repo-wide flake8/default-line-length mismatch; changed-file lint passes with E501 isolated.
