### PR TITLE
Prevent social provider HTTP hangs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — pre-1
 
 ---
 
+## [0.16.3] - 2026-05-10
+
+### Fixed
+
+- Bounded outbound Google, Facebook, LinkedIn, and Apple social-provider HTTP calls with a shared `(connect, read)` timeout tuple configurable through `BLOCK_AUTH_SETTINGS["SOCIAL_OUTBOUND_TIMEOUT"]`.
+
+---
+
 ## [0.16.2] - 2026-05-01
 
 ### Added

--- a/blockauth/__init__.py
+++ b/blockauth/__init__.py
@@ -28,7 +28,7 @@ Static utilities (no storage needed):
     backup_codes = TOTPService.generate_backup_codes()
 """
 
-__version__ = "0.16.2"
+__version__ = "0.16.3"
 
 # =============================================================================
 # Direct imports (Django-independent, no AppRegistryNotReady errors)

--- a/blockauth/apple/revocation_client.py
+++ b/blockauth/apple/revocation_client.py
@@ -15,6 +15,7 @@ from blockauth.apple._settings import apple_setting
 from blockauth.apple.client_secret import apple_client_secret_builder
 from blockauth.apple.constants import AppleEndpoints
 from blockauth.apple.exceptions import AppleClientSecretConfigError
+from blockauth.utils.outbound_http import get_social_outbound_timeout
 
 logger = logging.getLogger(__name__)
 
@@ -39,7 +40,7 @@ class AppleRevocationClient:
                     "token": refresh_token,
                     "token_type_hint": "refresh_token",
                 },
-                timeout=10,
+                timeout=get_social_outbound_timeout(),
             )
         except requests.RequestException as exc:
             logger.error(

--- a/blockauth/apple/tests/test_native_view.py
+++ b/blockauth/apple/tests/test_native_view.py
@@ -118,6 +118,7 @@ def test_native_verify_redeems_authorization_code(apple_settings, client, build_
     assert mock_post.call_args.kwargs["data"]["code"] == "auth-code"
     assert mock_post.call_args.kwargs["data"]["client_id"] == "com.example.app"
     assert mock_post.call_args.kwargs["data"]["grant_type"] == "authorization_code"
+    assert mock_post.call_args.kwargs["timeout"] == (3.05, 10)
     assert "redirect_uri" not in mock_post.call_args.kwargs["data"]
     client_secret_claims = pyjwt.decode(
         mock_post.call_args.kwargs["data"]["client_secret"],

--- a/blockauth/apple/tests/test_revocation_client.py
+++ b/blockauth/apple/tests/test_revocation_client.py
@@ -61,6 +61,7 @@ def test_revoke_posts_to_apple(configured):
     assert call.kwargs["data"]["token"] == "apple-refresh-token"
     assert call.kwargs["data"]["token_type_hint"] == "refresh_token"
     assert call.kwargs["data"]["client_id"] == "com.example.services"
+    assert call.kwargs["timeout"] == (3.05, 10)
 
 
 def test_revoke_swallows_non_200(configured):

--- a/blockauth/apple/tests/test_web_views.py
+++ b/blockauth/apple/tests/test_web_views.py
@@ -141,6 +141,7 @@ def test_callback_full_flow(apple_settings, client, build_id_token, jwks_payload
     assert mock_post.call_args.kwargs["data"]["code"] == "real-auth-code"
     assert mock_post.call_args.kwargs["data"]["code_verifier"] == pkce_verifier
     assert mock_post.call_args.kwargs["data"]["grant_type"] == "authorization_code"
+    assert mock_post.call_args.kwargs["timeout"] == (3.05, 10)
 
 
 @pytest.mark.django_db

--- a/blockauth/apple/views.py
+++ b/blockauth/apple/views.py
@@ -87,6 +87,7 @@ from blockauth.utils.oauth_state import (
     set_state_cookie,
     verify_state_values,
 )
+from blockauth.utils.outbound_http import get_social_outbound_timeout
 from blockauth.utils.pkce import generate_pkce_pair
 from blockauth.utils.social import social_login_data
 
@@ -207,7 +208,7 @@ class AppleWebCallbackView(APIView):
                     "grant_type": "authorization_code",
                     "redirect_uri": apple_setting("APPLE_REDIRECT_URI"),
                 },
-                timeout=10,
+                timeout=get_social_outbound_timeout(),
             )
         except requests.exceptions.RequestException as exc:
             blockauth_logger.warning(
@@ -341,7 +342,7 @@ class AppleNativeVerifyView(APIView):
                         "code": authorization_code,
                         "grant_type": "authorization_code",
                     },
-                    timeout=10,
+                    timeout=get_social_outbound_timeout(),
                 )
             except requests.exceptions.RequestException as exc:
                 # Code redemption is a best-effort enrichment, not a

--- a/blockauth/conf.py
+++ b/blockauth/conf.py
@@ -83,6 +83,8 @@ DEFAULTS = {
     "APPLE_WEB_CALLBACK_RATE_LIMIT": (30, 60),  # per-IP (requests, seconds)
     "APPLE_NATIVE_VERIFY_RATE_LIMIT": (30, 60),  # per-IP (requests, seconds)
     "APPLE_NOTIFICATION_RATE_LIMIT": (60, 60),  # per-IP (requests, seconds)
+    # Outbound OAuth/SocialIdentity provider calls
+    "SOCIAL_OUTBOUND_TIMEOUT": (3.05, 10),  # requests timeout tuple: (connect_seconds, read_seconds)
     # Google native id_token verify
     "GOOGLE_NATIVE_AUDIENCES": (),  # tuple of web client IDs accepted in id_token.aud
     # Generic OIDC verifier

--- a/blockauth/utils/outbound_http.py
+++ b/blockauth/utils/outbound_http.py
@@ -1,0 +1,20 @@
+"""Shared outbound HTTP settings."""
+
+from typing import TypeAlias
+
+from django.conf import settings
+
+RequestsTimeout: TypeAlias = float | tuple[float, float]
+
+DEFAULT_SOCIAL_OUTBOUND_TIMEOUT: tuple[float, float] = (3.05, 10)
+
+
+def get_social_outbound_timeout() -> RequestsTimeout:
+    block_settings = getattr(settings, "BLOCK_AUTH_SETTINGS", {}) or {}
+    configured = block_settings.get(
+        "SOCIAL_OUTBOUND_TIMEOUT",
+        DEFAULT_SOCIAL_OUTBOUND_TIMEOUT,
+    )
+    if isinstance(configured, list):
+        return tuple(configured)
+    return configured

--- a/blockauth/utils/tests/test_outbound_http.py
+++ b/blockauth/utils/tests/test_outbound_http.py
@@ -1,0 +1,15 @@
+from django.test import override_settings
+
+from blockauth.utils.outbound_http import get_social_outbound_timeout
+
+
+def test_social_outbound_timeout_defaults_to_connect_read_tuple():
+    with override_settings(BLOCK_AUTH_SETTINGS={}):
+        assert get_social_outbound_timeout() == (3.05, 10)
+
+
+def test_social_outbound_timeout_reads_runtime_setting():
+    with override_settings(
+        BLOCK_AUTH_SETTINGS={"SOCIAL_OUTBOUND_TIMEOUT": [1.5, 4]}
+    ):
+        assert get_social_outbound_timeout() == (1.5, 4)

--- a/blockauth/views/facebook_auth_views.py
+++ b/blockauth/views/facebook_auth_views.py
@@ -41,6 +41,7 @@ from blockauth.utils.oauth_state import (
     set_state_cookie,
     verify_state,
 )
+from blockauth.utils.outbound_http import get_social_outbound_timeout
 from blockauth.utils.pkce import generate_pkce_pair
 from blockauth.utils.social import social_login_data
 
@@ -150,7 +151,7 @@ class FacebookAuthCallbackView(APIView):
                     "redirect_uri": redirect_uri,
                     "code_verifier": pkce_verifier,
                 },
-                timeout=10,
+                timeout=get_social_outbound_timeout(),
             )
         except requests.exceptions.RequestException as exc:
             blockauth_logger.warning(
@@ -168,7 +169,7 @@ class FacebookAuthCallbackView(APIView):
             userinfo_response = requests.get(
                 FACEBOOK_USERINFO_URL,
                 params={"fields": "id,name,email", "access_token": access_token},
-                timeout=10,
+                timeout=get_social_outbound_timeout(),
             )
         except requests.exceptions.RequestException as exc:
             blockauth_logger.warning(

--- a/blockauth/views/google_auth_views.py
+++ b/blockauth/views/google_auth_views.py
@@ -55,6 +55,7 @@ from blockauth.utils.oauth_state import (
     set_state_cookie,
     verify_state,
 )
+from blockauth.utils.outbound_http import get_social_outbound_timeout
 from blockauth.utils.pkce import generate_pkce_pair
 from blockauth.utils.social import social_login_data
 
@@ -291,7 +292,7 @@ class GoogleAuthCallbackView(APIView):
                     "grant_type": "authorization_code",
                     "code_verifier": pkce_verifier,
                 },
-                timeout=10,
+                timeout=get_social_outbound_timeout(),
             )
         except requests.exceptions.RequestException as exc:
             blockauth_logger.warning(

--- a/blockauth/views/linkedin_auth_views.py
+++ b/blockauth/views/linkedin_auth_views.py
@@ -49,6 +49,7 @@ from blockauth.utils.oauth_state import (
     set_state_cookie,
     verify_state,
 )
+from blockauth.utils.outbound_http import get_social_outbound_timeout
 from blockauth.utils.pkce import generate_pkce_pair
 from blockauth.utils.social import social_login_data
 
@@ -265,7 +266,7 @@ class LinkedInAuthCallbackView(APIView):
                     "grant_type": "authorization_code",
                     "code_verifier": pkce_verifier,
                 },
-                timeout=10,
+                timeout=get_social_outbound_timeout(),
             )
         except requests.exceptions.RequestException as exc:
             blockauth_logger.warning(

--- a/blockauth/views/tests/test_oauth_views.py
+++ b/blockauth/views/tests/test_oauth_views.py
@@ -185,6 +185,7 @@ def test_google_callback_verifies_id_token_and_links_identity(
     body = callback.json()
     assert "access" in body and "refresh" in body and "user" in body
     assert mock_post.call_args.kwargs["data"]["code_verifier"] == pkce_verifier
+    assert mock_post.call_args.kwargs["timeout"] == (3.05, 10)
     # The userinfo HTTP call has been REMOVED from the refactor — claims now
     # come from the verified id_token. Only the JWKSCache fetch should hit
     # `requests.get`; the legacy `https://www.googleapis.com/oauth2/v2/userinfo`
@@ -237,6 +238,23 @@ class TestGoogleAuthCallbackView:
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         mock_post.assert_not_called()
 
+    @patch("blockauth.views.google_auth_views.requests.post")
+    def test_callback_token_timeout_returns_documented_error(self, mock_post, api_client):
+        import requests as real_requests
+
+        state = _prime_state(api_client)
+        api_client.cookies[OAUTH_PKCE_VERIFIER_COOKIE_NAME] = "test-pkce-verifier"
+        api_client.cookies["blockauth_google_nonce"] = "test-raw-nonce"
+        mock_post.side_effect = real_requests.exceptions.Timeout("provider hung")
+
+        response = api_client.get(
+            reverse("google-login-callback"),
+            {"code": "auth-code", "state": state},
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json()["detail"] == "Google token endpoint unreachable"
+
 
 @pytest.fixture
 def facebook_settings():
@@ -288,12 +306,14 @@ def test_facebook_callback_links_by_subject(facebook_settings, client):
     me_response = MagicMock(status_code=200)
     me_response.json.return_value = {"id": "fb_user_123", "name": "FB User", "email": "u@example.com"}
 
-    with patch("blockauth.views.facebook_auth_views.requests.get", side_effect=[token_response, me_response]):
+    with patch("blockauth.views.facebook_auth_views.requests.get", side_effect=[token_response, me_response]) as mock_get:
         callback = client.get(f"/facebook/callback/?code=auth-code&state={state}")
 
     assert callback.status_code == 200, callback.content
     body = callback.json()
     assert "access" in body and "user" in body
+    timeouts = [call.kwargs["timeout"] for call in mock_get.call_args_list]
+    assert timeouts == [(3.05, 10), (3.05, 10)]
 
     from blockauth.social.models import SocialIdentity
 
@@ -444,6 +464,7 @@ def test_linkedin_callback_verifies_id_token(linkedin_settings, client, build_id
     body = callback.json()
     assert "access" in body and "user" in body
     assert mock_post.call_args.kwargs["data"]["code_verifier"] == pkce_verifier
+    assert mock_post.call_args.kwargs["timeout"] == (3.05, 10)
     # Verifier fetched JWKS but no userinfo endpoint was hit.
     assert all("userinfo" not in url.lower() for url in seen_get_urls)
 

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -60,6 +60,12 @@ All settings are configured in `BLOCK_AUTH_SETTINGS` in your Django settings mod
 | `APPLE_NATIVE_VERIFY_RATE_LIMIT` | `(30, 60)` | Per-IP `(max_requests, window_seconds)` for `/apple/verify/` |
 | `APPLE_NOTIFICATION_RATE_LIMIT` | `(60, 60)` | Per-IP `(max_requests, window_seconds)` for `/apple/notifications/` |
 
+## Social Provider HTTP
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `SOCIAL_OUTBOUND_TIMEOUT` | `(3.05, 10)` | `requests` timeout tuple `(connect_seconds, read_seconds)` for Google, Facebook, LinkedIn, and Apple provider calls |
+
 ## Feature Flags
 
 | Setting | Default | Description |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "blockauth"
-version = "0.16.2"
+version = "0.16.3"
 description = "Comprehensive Python authentication package bridging Web2 and Web3"
 authors = [{name = "BloclabsHQ", email = "eng@bloclabs.com"}]
 license = {text = "MIT"}

--- a/uv.lock
+++ b/uv.lock
@@ -312,7 +312,7 @@ wheels = [
 
 [[package]]
 name = "blockauth"
-version = "0.16.2"
+version = "0.16.3"
 source = { editable = "." }
 dependencies = [
     { name = "argon2-cffi" },


### PR DESCRIPTION
## Summary
- Add a shared social-provider outbound HTTP timeout default so Google, Facebook, LinkedIn, and Apple calls cannot hang indefinitely
- Make the timeout configurable through BLOCK_AUTH_SETTINGS while preserving the existing timeout error handling paths
- Bump the package to 0.16.3 and document the new setting

Closes #157

## Test plan
- [x] uv run pytest
- [x] uv run flake8 blockauth/utils/outbound_http.py blockauth/utils/tests/test_outbound_http.py
- [x] git diff --check
- [ ] make lint (repo-wide pre-existing E501/F841 failures remain outside this PR scope)