### PR TITLE
feat(apple): expose build_success_response hook + tag AuthenticationType.APPLE on signup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,19 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — pre-1
 
 ---
 
+## [0.16.4] - 2026-05-11
+
+### Added
+
+- `AppleWebCallbackView.build_success_response(request, result)` hook so integrators can override the success response body without re-implementing the auth flow. Default returns the existing `AuthStateResponseSerializer` JSON shape. Matches the override hook Google, Facebook, LinkedIn, and Google-native already expose.
+- `AppleNativeVerifyView.build_success_response(request, result)` hook for symmetry with the web callback.
+
+### Fixed
+
+- `social_login_data` now tags new Apple Creators with `AuthenticationType.APPLE`. The provider check previously listed only Google, Facebook, and LinkedIn, leaving Apple sign-ups with an empty `authentication_types` list. Downstream readers (admin UI, account-issuance, S2S consent-revoked handler) all assume the provider is recorded.
+
+---
+
 ## [0.16.3] - 2026-05-10
 
 ### Fixed

--- a/blockauth/apple/tests/test_native_view.py
+++ b/blockauth/apple/tests/test_native_view.py
@@ -317,3 +317,70 @@ def test_native_verify_email_collision_with_existing_user_returns_4090(
 
     # SocialIdentityConflictError extends APIException with status_code=409.
     assert response.status_code == 409
+
+
+# ---------------------------------------------------------------------------
+# build_success_response override hook
+# ---------------------------------------------------------------------------
+#
+# Mirrors the hook on AppleWebCallbackView so integrators that issue tokens
+# differently for the native-verify flow (BFF cookies, custom envelope) can
+# subclass instead of re-implementing the verifier.
+
+
+class _StubBlockUser:
+    """Minimal stand-in for the BlockUser-shaped object that
+    `build_user_payload` reads. Keeps the hook unit tests off the DB.
+    """
+
+    def __init__(self, user_id: str, email: str):
+        self.id = user_id
+        self.email = email
+        self.is_verified = True
+        self.is_active = True
+        self.wallet_address = None
+        self.date_joined = None
+
+
+def test_native_verify_view_default_build_success_response_returns_auth_state_json():
+    """Default hook impl returns the AuthStateResponseSerializer JSON shape."""
+    from blockauth.apple.views import AppleNativeVerifyView
+    from blockauth.utils.social import SocialLoginResult
+
+    result = SocialLoginResult(
+        user=_StubBlockUser("native-user-1", "apple-native@example.com"),
+        access_token="access-jwt",
+        refresh_token="refresh-jwt",
+        created=False,
+    )
+
+    response = AppleNativeVerifyView().build_success_response(request=None, result=result)
+
+    assert response.status_code == 200
+    assert response.data["access"] == "access-jwt"
+    assert response.data["refresh"] == "refresh-jwt"
+    assert response.data["user"]["id"] == "native-user-1"
+    assert response.data["user"]["email"] == "apple-native@example.com"
+
+
+def test_native_verify_view_subclass_can_override_build_success_response():
+    """A subclass override is reached at the final response builder call site."""
+    from rest_framework.response import Response
+    from blockauth.apple.views import AppleNativeVerifyView
+    from blockauth.utils.social import SocialLoginResult
+
+    class _SwapResponse(AppleNativeVerifyView):
+        def build_success_response(self, request, result):
+            return Response(data={"native_swapped": True}, status=201)
+
+    result = SocialLoginResult(
+        user=_StubBlockUser("native-user-2", "apple-native-2@example.com"),
+        access_token="a",
+        refresh_token="r",
+        created=True,
+    )
+
+    response = _SwapResponse().build_success_response(request=None, result=result)
+
+    assert response.status_code == 201
+    assert response.data == {"native_swapped": True}

--- a/blockauth/apple/tests/test_native_view.py
+++ b/blockauth/apple/tests/test_native_view.py
@@ -377,6 +377,7 @@ def test_native_verify_post_routes_through_build_success_response(
     """
     from rest_framework import status as drf_status
     from rest_framework.response import Response
+
     from blockauth.apple.views import AppleNativeVerifyView
 
     raw_nonce = "hook-raw-nonce"

--- a/blockauth/apple/tests/test_native_view.py
+++ b/blockauth/apple/tests/test_native_view.py
@@ -363,24 +363,50 @@ def test_native_verify_view_default_build_success_response_returns_auth_state_js
     assert response.data["user"]["email"] == "apple-native@example.com"
 
 
-def test_native_verify_view_subclass_can_override_build_success_response():
-    """A subclass override is reached at the final response builder call site."""
+@pytest.mark.django_db
+def test_native_verify_post_routes_through_build_success_response(
+    apple_settings, client, build_id_token, jwks_payload_bytes
+):
+    """post() must call self.build_success_response(...) so subclasses that
+    override the hook actually win the response shape.
+
+    Patches the hook on AppleNativeVerifyView, runs the full verify flow,
+    and asserts the patched response reaches the client. Without this,
+    a future refactor that drops the self.build_success_response(...)
+    call would silently break every BFF integrator.
+    """
+    from rest_framework import status as drf_status
     from rest_framework.response import Response
     from blockauth.apple.views import AppleNativeVerifyView
-    from blockauth.utils.social import SocialLoginResult
 
-    class _SwapResponse(AppleNativeVerifyView):
-        def build_success_response(self, request, result):
-            return Response(data={"native_swapped": True}, status=201)
-
-    result = SocialLoginResult(
-        user=_StubBlockUser("native-user-2", "apple-native-2@example.com"),
-        access_token="a",
-        refresh_token="r",
-        created=True,
+    raw_nonce = "hook-raw-nonce"
+    expected_hash = hashlib.sha256(raw_nonce.encode()).hexdigest()
+    id_token = build_id_token(
+        {
+            "iss": "https://appleid.apple.com",
+            "aud": "com.example.app",
+            "sub": "001234.native.hook",
+            "email": "hook-native@privaterelay.appleid.com",
+            "email_verified": "true",
+            "is_private_email": "true",
+            "nonce": expected_hash,
+            "nonce_supported": True,
+        }
     )
+    jwks_response = MagicMock(status_code=200, content=jwks_payload_bytes)
+    jwks_response.json.return_value = json.loads(jwks_payload_bytes.decode())
 
-    response = _SwapResponse().build_success_response(request=None, result=result)
+    swap_response = Response(data={"native_swapped": True}, status=drf_status.HTTP_201_CREATED)
+    with (
+        patch("blockauth.utils.jwt.jwks_cache.requests.get", return_value=jwks_response),
+        patch.object(AppleNativeVerifyView, "build_success_response", return_value=swap_response) as mock_hook,
+    ):
+        response = client.post(
+            "/apple/verify/",
+            data={"id_token": id_token, "raw_nonce": raw_nonce},
+            content_type="application/json",
+        )
 
-    assert response.status_code == 201
-    assert response.data == {"native_swapped": True}
+    assert mock_hook.call_count == 1
+    assert response.status_code == drf_status.HTTP_201_CREATED
+    assert response.json() == {"native_swapped": True}

--- a/blockauth/apple/tests/test_notification_service.py
+++ b/blockauth/apple/tests/test_notification_service.py
@@ -616,7 +616,9 @@ def test_replayed_notification_is_suppressed_before_second_trigger(apple_setting
 
 @pytest.mark.django_db
 def test_replay_key_normalizes_event_time_without_jti(apple_settings, build_id_token, jwks_response):
-    user = User.objects.create_user(username="normalized_replay_user", email="normalized-replay@example.com", password="pw")
+    user = User.objects.create_user(
+        username="normalized_replay_user", email="normalized-replay@example.com", password="pw"
+    )
     SocialIdentity.objects.create(
         provider="apple",
         subject="001234.normalized-replay",

--- a/blockauth/apple/tests/test_web_views.py
+++ b/blockauth/apple/tests/test_web_views.py
@@ -222,3 +222,72 @@ def test_callback_clears_cookies_on_error(apple_settings, client):
     assert callback.cookies[OAUTH_STATE_COOKIE_NAME]["max-age"] == 0
     assert callback.cookies[OAUTH_PKCE_VERIFIER_COOKIE_NAME]["max-age"] == 0
     assert callback.cookies[APPLE_NONCE_COOKIE_NAME]["max-age"] == 0
+
+
+# ---------------------------------------------------------------------------
+# build_success_response override hook
+# ---------------------------------------------------------------------------
+#
+# Google, Facebook, LinkedIn, and Google-native already expose
+# build_success_response(request, result) so integrators can swap the success
+# response shape (e.g. BFF cookie redirect) without re-implementing the auth
+# flow. These tests pin the contract for Apple's web callback so fabric-auth
+# can plug in alongside the other providers.
+
+
+class _StubBlockUser:
+    """Minimal stand-in for the BlockUser-shaped object that
+    `build_user_payload` reads. Keeps the hook unit tests off the DB.
+    """
+
+    def __init__(self, user_id: str, email: str):
+        self.id = user_id
+        self.email = email
+        self.is_verified = True
+        self.is_active = True
+        self.wallet_address = None
+        self.date_joined = None
+
+
+def test_web_callback_view_default_build_success_response_returns_auth_state_json():
+    """Default hook impl returns the existing AuthStateResponseSerializer JSON shape."""
+    from blockauth.apple.views import AppleWebCallbackView
+    from blockauth.utils.social import SocialLoginResult
+
+    result = SocialLoginResult(
+        user=_StubBlockUser("user-1", "apple-user@example.com"),
+        access_token="access-token-jwt",
+        refresh_token="refresh-token-jwt",
+        created=False,
+    )
+
+    response = AppleWebCallbackView().build_success_response(request=None, result=result)
+
+    assert response.status_code == 200
+    assert response.data["access"] == "access-token-jwt"
+    assert response.data["refresh"] == "refresh-token-jwt"
+    assert response.data["user"]["id"] == "user-1"
+    assert response.data["user"]["email"] == "apple-user@example.com"
+
+
+def test_web_callback_view_subclass_can_override_build_success_response():
+    """A subclass override is reached at the final response builder call site."""
+    from rest_framework.response import Response
+    from blockauth.apple.views import AppleWebCallbackView
+    from blockauth.utils.social import SocialLoginResult
+
+    class _SwapResponse(AppleWebCallbackView):
+        def build_success_response(self, request, result):
+            return Response(data={"swapped": True}, status=201)
+
+    result = SocialLoginResult(
+        user=_StubBlockUser("user-2", "apple-user-2@example.com"),
+        access_token="a",
+        refresh_token="r",
+        created=True,
+    )
+
+    response = _SwapResponse().build_success_response(request=None, result=result)
+
+    assert response.status_code == 201
+    assert response.data == {"swapped": True}

--- a/blockauth/apple/tests/test_web_views.py
+++ b/blockauth/apple/tests/test_web_views.py
@@ -285,6 +285,7 @@ def test_web_callback_post_routes_through_build_success_response(
     """
     from rest_framework import status as drf_status
     from rest_framework.response import Response
+
     from blockauth.apple.views import AppleWebCallbackView
 
     init_response = client.get("/apple/")

--- a/blockauth/apple/tests/test_web_views.py
+++ b/blockauth/apple/tests/test_web_views.py
@@ -270,24 +270,62 @@ def test_web_callback_view_default_build_success_response_returns_auth_state_jso
     assert response.data["user"]["email"] == "apple-user@example.com"
 
 
-def test_web_callback_view_subclass_can_override_build_success_response():
-    """A subclass override is reached at the final response builder call site."""
+@pytest.mark.django_db
+def test_web_callback_post_routes_through_build_success_response(
+    apple_settings, client, build_id_token, jwks_payload_bytes
+):
+    """post() must call self.build_success_response(...) so subclasses that
+    override the hook actually win the response shape.
+
+    Patches the hook on AppleWebCallbackView, runs the full callback flow,
+    and asserts both that the patched response is returned to the client
+    and that the hook was reached. Without this, a future refactor that
+    drops the self.build_success_response(...) call site would silently
+    break every BFF integrator.
+    """
+    from rest_framework import status as drf_status
     from rest_framework.response import Response
     from blockauth.apple.views import AppleWebCallbackView
-    from blockauth.utils.social import SocialLoginResult
 
-    class _SwapResponse(AppleWebCallbackView):
-        def build_success_response(self, request, result):
-            return Response(data={"swapped": True}, status=201)
+    init_response = client.get("/apple/")
+    state_value = init_response.cookies[OAUTH_STATE_COOKIE_NAME].value
+    raw_nonce = init_response.cookies[APPLE_NONCE_COOKIE_NAME].value
+    expected_nonce_hash = hashlib.sha256(raw_nonce.encode()).hexdigest()
 
-    result = SocialLoginResult(
-        user=_StubBlockUser("user-2", "apple-user-2@example.com"),
-        access_token="a",
-        refresh_token="r",
-        created=True,
+    apple_id_token = build_id_token(
+        {
+            "iss": "https://appleid.apple.com",
+            "aud": "com.example.services",
+            "sub": "001234.hook.subject",
+            "email": "hook-user@privaterelay.appleid.com",
+            "email_verified": "true",
+            "is_private_email": "true",
+            "nonce": expected_nonce_hash,
+            "nonce_supported": True,
+        }
     )
+    token_response = MagicMock(status_code=200)
+    token_response.json.return_value = {
+        "access_token": "apple-access",
+        "refresh_token": "apple-refresh",
+        "id_token": apple_id_token,
+        "token_type": "Bearer",
+        "expires_in": 3600,
+    }
+    jwks_response = MagicMock(status_code=200, content=jwks_payload_bytes)
+    jwks_response.json.return_value = json.loads(jwks_payload_bytes.decode())
 
-    response = _SwapResponse().build_success_response(request=None, result=result)
+    swap_response = Response(data={"swapped": True}, status=drf_status.HTTP_201_CREATED)
+    with (
+        patch("blockauth.apple.views.requests.post", return_value=token_response),
+        patch("blockauth.utils.jwt.jwks_cache.requests.get", return_value=jwks_response),
+        patch.object(AppleWebCallbackView, "build_success_response", return_value=swap_response) as mock_hook,
+    ):
+        callback = client.post(
+            "/apple/callback/",
+            data={"code": "real-auth-code", "state": state_value},
+        )
 
-    assert response.status_code == 201
-    assert response.data == {"swapped": True}
+    assert mock_hook.call_count == 1
+    assert callback.status_code == drf_status.HTTP_201_CREATED
+    assert callback.json() == {"swapped": True}

--- a/blockauth/apple/views.py
+++ b/blockauth/apple/views.py
@@ -174,6 +174,18 @@ class AppleWebCallbackView(APIView):
         clear_nonce_cookie(response, samesite=samesite)
         return response
 
+    def build_success_response(self, request, result) -> Response:
+        """Build the response returned to the browser after a successful
+        Apple web callback.
+
+        Default returns the standard `AuthStateResponseSerializer` JSON
+        body. Subclasses can override to swap the body shape (for example,
+        a BFF cookie redirect) without re-implementing the auth flow.
+        Mirrors the hook Google, Facebook, LinkedIn, and Google-native
+        already expose.
+        """
+        return _build_auth_state_response(result)
+
     @extend_schema(**apple_callback_schema)
     def post(self, request):
         code = request.data.get("code")
@@ -271,7 +283,7 @@ class AppleWebCallbackView(APIView):
             provider_data={"provider": "apple", "user_info": claims.raw, "preexisting_user": user},
         )
 
-        response = _build_auth_state_response(result)
+        response = self.build_success_response(request, result)
         samesite = _samesite_for_callback()
         clear_state_cookie(response, samesite=samesite)
         clear_pkce_verifier_cookie(response, samesite=samesite)
@@ -297,6 +309,17 @@ class AppleNativeVerifyView(APIView):
     permission_classes = (AllowAny,)
     authentication_classes = ()
     throttle_classes = [AppleNativeVerifyThrottle]
+
+    def build_success_response(self, request, result) -> Response:
+        """Build the response returned to the client after a successful
+        Apple native-verify call.
+
+        Default returns the standard `AuthStateResponseSerializer` JSON
+        body. Subclasses can override to swap the body shape (for example,
+        a BFF cookie envelope for browser-based native flows) without
+        re-implementing the verifier.
+        """
+        return _build_auth_state_response(result)
 
     @extend_schema(**apple_native_verify_schema)
     def post(self, request):
@@ -393,7 +416,7 @@ class AppleNativeVerifyView(APIView):
             name=" ".join(filter(None, [validated.get("first_name") or "", validated.get("last_name") or ""])).strip(),
             provider_data={"provider": "apple", "user_info": claims.raw, "preexisting_user": user},
         )
-        return _build_auth_state_response(result)
+        return self.build_success_response(request, result)
 
 
 class AppleServerToServerNotificationView(APIView):

--- a/blockauth/utils/social.py
+++ b/blockauth/utils/social.py
@@ -97,7 +97,12 @@ def social_login_data(email: str, name: str, provider_data: dict) -> SocialLogin
 
     # Add authentication type based on provider
     provider = provider_data.get("provider", "").upper()
-    if provider in [AuthenticationType.GOOGLE, AuthenticationType.FACEBOOK, AuthenticationType.LINKEDIN]:
+    if provider in [
+        AuthenticationType.GOOGLE,
+        AuthenticationType.FACEBOOK,
+        AuthenticationType.LINKEDIN,
+        AuthenticationType.APPLE,
+    ]:
         user.add_authentication_type(provider)
 
     # Google returns OIDC-verified email claims. If the

--- a/blockauth/utils/tests/test_outbound_http.py
+++ b/blockauth/utils/tests/test_outbound_http.py
@@ -9,7 +9,5 @@ def test_social_outbound_timeout_defaults_to_connect_read_tuple():
 
 
 def test_social_outbound_timeout_reads_runtime_setting():
-    with override_settings(
-        BLOCK_AUTH_SETTINGS={"SOCIAL_OUTBOUND_TIMEOUT": [1.5, 4]}
-    ):
+    with override_settings(BLOCK_AUTH_SETTINGS={"SOCIAL_OUTBOUND_TIMEOUT": [1.5, 4]}):
         assert get_social_outbound_timeout() == (1.5, 4)

--- a/blockauth/utils/tests/test_social.py
+++ b/blockauth/utils/tests/test_social.py
@@ -1,0 +1,54 @@
+"""Unit tests for blockauth.utils.social.social_login_data.
+
+Focused on the provider-tagging branch that decides whether a successful
+sign-in should record the provider in `BlockUser.authentication_types`.
+The Apple branch was previously omitted, leaving Apple Creators with
+an empty list that downstream readers (admin UI, account-issuance
+service, consent-revoked handler) depend on.
+"""
+
+import pytest
+
+from blockauth.enums import AuthenticationType
+from blockauth.utils.config import get_block_auth_user_model
+from blockauth.utils.social import social_login_data
+
+
+@pytest.mark.django_db
+def test_social_login_data_tags_apple_authentication_type():
+    """A successful Apple sign-in records APPLE in authentication_types."""
+    user_model = get_block_auth_user_model()
+    user = user_model.objects.create(email="apple-tagged@example.com")
+
+    social_login_data(
+        email=user.email,
+        name="",
+        provider_data={
+            "provider": "apple",
+            "user_info": {"sub": "apple-sub-1"},
+            "preexisting_user": user,
+        },
+    )
+
+    user.refresh_from_db()
+    assert AuthenticationType.APPLE.value in (user.authentication_types or [])
+
+
+@pytest.mark.django_db
+def test_social_login_data_tags_google_authentication_type():
+    """Regression: existing Google tagging still works."""
+    user_model = get_block_auth_user_model()
+    user = user_model.objects.create(email="google-tagged@example.com")
+
+    social_login_data(
+        email=user.email,
+        name="",
+        provider_data={
+            "provider": "google",
+            "user_info": {"sub": "google-sub-1"},
+            "preexisting_user": user,
+        },
+    )
+
+    user.refresh_from_db()
+    assert AuthenticationType.GOOGLE.value in (user.authentication_types or [])

--- a/blockauth/views/tests/test_oauth_views.py
+++ b/blockauth/views/tests/test_oauth_views.py
@@ -306,7 +306,9 @@ def test_facebook_callback_links_by_subject(facebook_settings, client):
     me_response = MagicMock(status_code=200)
     me_response.json.return_value = {"id": "fb_user_123", "name": "FB User", "email": "u@example.com"}
 
-    with patch("blockauth.views.facebook_auth_views.requests.get", side_effect=[token_response, me_response]) as mock_get:
+    with patch(
+        "blockauth.views.facebook_auth_views.requests.get", side_effect=[token_response, me_response]
+    ) as mock_get:
         callback = client.get(f"/facebook/callback/?code=auth-code&state={state}")
 
     assert callback.status_code == 200, callback.content

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "blockauth"
-version = "0.16.3"
+version = "0.16.4"
 description = "Comprehensive Python authentication package bridging Web2 and Web3"
 authors = [{name = "BloclabsHQ", email = "eng@bloclabs.com"}]
 license = {text = "MIT"}

--- a/uv.lock
+++ b/uv.lock
@@ -312,7 +312,7 @@ wheels = [
 
 [[package]]
 name = "blockauth"
-version = "0.16.3"
+version = "0.16.4"
 source = { editable = "." }
 dependencies = [
     { name = "argon2-cffi" },


### PR DESCRIPTION
Two related changes that unblock fabric-auth wiring Sign in with Apple end-to-end on the Creator dashboard.

## Override hook on the Apple views

Apple was the only social provider whose views built the success response inline. Google, Facebook, LinkedIn, and Google-native already expose `build_success_response` so integrators can swap the body shape without re-implementing the auth flow. This refactors `AppleWebCallbackView` and `AppleNativeVerifyView` to route their final response through `self.build_success_response(request, result)`.

Default implementations preserve the existing `AuthStateResponseSerializer` JSON contract, so integrators that don't subclass see no behavior change.

Motivating consumer: fabric-auth needs to swap the Apple callback success body for a BFF cookie redirect (HttpOnly access/refresh + 302) to match the pattern already in place for Google, Facebook, and LinkedIn under `fabric_auth.base.views.oauth_callback_views`.

## Tag new Apple Creators with AuthenticationType.APPLE

`social_login_data` was tagging Google/Facebook/LinkedIn but silently skipping Apple, so Apple signups landed with an empty `authentication_types` JSON list. Downstream readers depend on this field: the Django admin user page, account-issuance logic, and the S2S consent-revoked handler. One-line addition to the provider check plus a regression test.

## Test plan

- [x] New hook tests cover both views and a subclass override
- [x] Apple-signup test asserts `AuthenticationType.APPLE` lands in `authentication_types`
- [x] Regression: existing Apple suite (`blockauth/apple/tests/`) stays green
- [x] Full blockauth test suite: 774 passed (up from 772 baseline)