### PR TITLE
chore(release): bump __init__.__version__ to 0.16.4

### DIFF
--- a/blockauth/__init__.py
+++ b/blockauth/__init__.py
@@ -28,7 +28,7 @@ Static utilities (no storage needed):
     backup_codes = TOTPService.generate_backup_codes()
 """
 
-__version__ = "0.16.3"
+__version__ = "0.16.4"
 
 # =============================================================================
 # Direct imports (Django-independent, no AppRegistryNotReady errors)


### PR DESCRIPTION
The 0.16.4 PR (#159) bumped `pyproject.toml` but missed `blockauth/__init__.py`. The publish workflow validates the `v0.16.4` tag against both files and rejects mismatches, so this needs to land before we tag.

One-line file change. No behavior impact.