### PR TITLE
feat(apple): expose clear_apple_callback_cookies helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,18 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — pre-1
 
 ---
 
+## [0.16.5] - 2026-05-11
+
+### Added
+
+- `clear_apple_callback_cookies(response, samesite=None)` helper in `blockauth.apple.views`. BFF integrators that swap the Apple callback response shape (e.g. JSON 409 -> 302 redirect on conflict) no longer have to re-implement the state/PKCE/nonce clear themselves. The clear list is now owned by blockauth so a future fourth cookie picks itself up everywhere the helper is called.
+
+### Changed
+
+- `AppleWebCallbackView.handle_exception` and the success-path cookie clear now call `clear_apple_callback_cookies`. Single source of truth for "what cookies need clearing on Apple's error path."
+
+---
+
 ## [0.16.4] - 2026-05-11
 
 ### Added

--- a/blockauth/__init__.py
+++ b/blockauth/__init__.py
@@ -28,7 +28,7 @@ Static utilities (no storage needed):
     backup_codes = TOTPService.generate_backup_codes()
 """
 
-__version__ = "0.16.4"
+__version__ = "0.16.5"
 
 # =============================================================================
 # Direct imports (Django-independent, no AppRegistryNotReady errors)

--- a/blockauth/apple/tests/test_web_views.py
+++ b/blockauth/apple/tests/test_web_views.py
@@ -237,7 +237,8 @@ def test_callback_clears_cookies_on_error(apple_settings, client):
 # integrator that calls it stays correct.
 
 
-def test_clear_apple_callback_cookies_clears_all_three_cookies(apple_settings):
+@pytest.mark.usefixtures("apple_settings")
+def test_clear_apple_callback_cookies_clears_all_three_cookies():
     """The helper must clear state, PKCE-verifier, and nonce cookies on
     a response — these are the same three set by AppleWebAuthorizeView."""
     from django.http import HttpResponse
@@ -255,7 +256,8 @@ def test_clear_apple_callback_cookies_clears_all_three_cookies(apple_settings):
     assert response.cookies[APPLE_NONCE_COOKIE_NAME]["max-age"] == 0
 
 
-def test_clear_apple_callback_cookies_uses_callback_samesite_default(apple_settings):
+@pytest.mark.usefixtures("apple_settings")
+def test_clear_apple_callback_cookies_uses_callback_samesite_default():
     """When the caller does not pass `samesite`, the helper must read it
     from APPLE_CALLBACK_COOKIE_SAMESITE so cross-site form_post cookies
     keep their SameSite=None contract on the clear response too."""
@@ -270,7 +272,8 @@ def test_clear_apple_callback_cookies_uses_callback_samesite_default(apple_setti
     assert response.cookies[OAUTH_STATE_COOKIE_NAME]["samesite"].lower() == "none"
 
 
-def test_clear_apple_callback_cookies_honours_explicit_samesite(apple_settings):
+@pytest.mark.usefixtures("apple_settings")
+def test_clear_apple_callback_cookies_honours_explicit_samesite():
     """The samesite kwarg lets integrators that diverge from the default
     (or are clearing cookies in a code path that runs outside the
     cross-site form_post POST) override without monkey-patching."""

--- a/blockauth/apple/tests/test_web_views.py
+++ b/blockauth/apple/tests/test_web_views.py
@@ -225,6 +225,66 @@ def test_callback_clears_cookies_on_error(apple_settings, client):
 
 
 # ---------------------------------------------------------------------------
+# clear_apple_callback_cookies helper
+# ---------------------------------------------------------------------------
+#
+# Re-usable error-path cleanup so BFF integrators that swap the response
+# shape (and therefore bypass AppleWebCallbackView.handle_exception) don't
+# have to re-implement the security-critical state/PKCE/nonce clear in
+# every consumer. Owning "what cookies need clearing on Apple's error
+# path" in blockauth keeps the contract in one place: if Apple's auth
+# flow ever grows another cookie, this helper picks it up and every
+# integrator that calls it stays correct.
+
+
+def test_clear_apple_callback_cookies_clears_all_three_cookies(apple_settings):
+    """The helper must clear state, PKCE-verifier, and nonce cookies on
+    a response — these are the same three set by AppleWebAuthorizeView."""
+    from django.http import HttpResponse
+
+    from blockauth.apple.views import clear_apple_callback_cookies
+
+    response = HttpResponse()
+    clear_apple_callback_cookies(response)
+
+    assert OAUTH_STATE_COOKIE_NAME in response.cookies
+    assert response.cookies[OAUTH_STATE_COOKIE_NAME]["max-age"] == 0
+    assert OAUTH_PKCE_VERIFIER_COOKIE_NAME in response.cookies
+    assert response.cookies[OAUTH_PKCE_VERIFIER_COOKIE_NAME]["max-age"] == 0
+    assert APPLE_NONCE_COOKIE_NAME in response.cookies
+    assert response.cookies[APPLE_NONCE_COOKIE_NAME]["max-age"] == 0
+
+
+def test_clear_apple_callback_cookies_uses_callback_samesite_default(apple_settings):
+    """When the caller does not pass `samesite`, the helper must read it
+    from APPLE_CALLBACK_COOKIE_SAMESITE so cross-site form_post cookies
+    keep their SameSite=None contract on the clear response too."""
+    from django.http import HttpResponse
+
+    from blockauth.apple.views import clear_apple_callback_cookies
+
+    response = HttpResponse()
+    clear_apple_callback_cookies(response)
+
+    # apple_settings sets APPLE_CALLBACK_COOKIE_SAMESITE="None".
+    assert response.cookies[OAUTH_STATE_COOKIE_NAME]["samesite"].lower() == "none"
+
+
+def test_clear_apple_callback_cookies_honours_explicit_samesite(apple_settings):
+    """The samesite kwarg lets integrators that diverge from the default
+    (or are clearing cookies in a code path that runs outside the
+    cross-site form_post POST) override without monkey-patching."""
+    from django.http import HttpResponse
+
+    from blockauth.apple.views import clear_apple_callback_cookies
+
+    response = HttpResponse()
+    clear_apple_callback_cookies(response, samesite="Lax")
+
+    assert response.cookies[OAUTH_STATE_COOKIE_NAME]["samesite"].lower() == "lax"
+
+
+# ---------------------------------------------------------------------------
 # build_success_response override hook
 # ---------------------------------------------------------------------------
 #

--- a/blockauth/apple/views.py
+++ b/blockauth/apple/views.py
@@ -104,6 +104,31 @@ def _samesite_for_callback() -> str:
     return str(apple_setting("APPLE_CALLBACK_COOKIE_SAMESITE") or "None")
 
 
+def clear_apple_callback_cookies(response, samesite: str | None = None) -> None:
+    """Clear every cookie the Apple web auth flow sets.
+
+    `AppleWebAuthorizeView` sets three HttpOnly cookies before the
+    redirect to appleid.apple.com — the OAuth state token, the PKCE
+    verifier, and the raw nonce. The callback consumes and clears them
+    on success. On any error response a retry must not be able to
+    replay stale values, so the same three cookies must be cleared
+    there too.
+
+    Owning that list here means BFF integrators that swap the response
+    shape (and therefore bypass `AppleWebCallbackView.handle_exception`)
+    can call this helper instead of re-implementing the clear in every
+    consumer. If Apple's flow ever grows a fourth cookie, this helper
+    is the single place that needs updating.
+
+    The default `samesite` follows `APPLE_CALLBACK_COOKIE_SAMESITE` so
+    cross-site form_post cookies keep their `SameSite=None` contract.
+    """
+    samesite = samesite or _samesite_for_callback()
+    clear_state_cookie(response, samesite=samesite)
+    clear_pkce_verifier_cookie(response, samesite=samesite)
+    clear_nonce_cookie(response, samesite=samesite)
+
+
 def _build_auth_state_response(result) -> Response:
     """Build the standard success response shape for any Apple flow."""
     serializer = AuthStateResponseSerializer(
@@ -166,12 +191,11 @@ class AppleWebCallbackView(APIView):
         # Any error path must clear the state/PKCE/nonce cookies; otherwise
         # a retry could replay stale credentials. DRF builds the error
         # response in `super().handle_exception(...)`, so we mutate it
-        # before returning.
+        # before returning. The clear list is owned by
+        # `clear_apple_callback_cookies` so BFF integrators that swap the
+        # response shape can re-use the same single source of truth.
         response = super().handle_exception(exc)
-        samesite = _samesite_for_callback()
-        clear_state_cookie(response, samesite=samesite)
-        clear_pkce_verifier_cookie(response, samesite=samesite)
-        clear_nonce_cookie(response, samesite=samesite)
+        clear_apple_callback_cookies(response)
         return response
 
     def build_success_response(self, request, result) -> Response:
@@ -284,10 +308,7 @@ class AppleWebCallbackView(APIView):
         )
 
         response = self.build_success_response(request, result)
-        samesite = _samesite_for_callback()
-        clear_state_cookie(response, samesite=samesite)
-        clear_pkce_verifier_cookie(response, samesite=samesite)
-        clear_nonce_cookie(response, samesite=samesite)
+        clear_apple_callback_cookies(response)
         return response
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "blockauth"
-version = "0.16.4"
+version = "0.16.5"
 description = "Comprehensive Python authentication package bridging Web2 and Web3"
 authors = [{name = "BloclabsHQ", email = "eng@bloclabs.com"}]
 license = {text = "MIT"}


### PR DESCRIPTION
BFF integrators that swap the Apple callback response shape (e.g. fabric-auth's `AppleOAuthCallbackBFFView`, which returns a 302 + cookie redirect on `SocialIdentityConflictError` instead of DRF's JSON 409) bypass the base `AppleWebCallbackView.handle_exception`. To preserve security-critical cookie hygiene they have to re-implement the state/PKCE/nonce clear themselves. That duplication is a silent-security-regression hazard: if Apple's auth flow ever grows another cookie, the integrator has no way to know.

Fix: expose `clear_apple_callback_cookies(response, samesite=None)` as a public helper. The base view now calls it too, so blockauth owns "what cookies need clearing on Apple's error path" in a single source of truth.

Default `samesite` reads from `APPLE_CALLBACK_COOKIE_SAMESITE` so cross-site form_post cookies keep their `SameSite=None` contract.

## Test plan
- [x] New tests cover the helper directly (clears all three cookies, default samesite, override samesite)
- [x] Existing test_callback_clears_cookies_on_error stays green (handle_exception now routes through the helper)
- [x] Full blockauth suite: 75 passed (was 72 before A.6, +3 helper tests)