### PR TITLE
chore: dead-code cleanup in apple/social/views (closes #164)

### DIFF
--- a/blockauth/apple/constants.py
+++ b/blockauth/apple/constants.py
@@ -14,7 +14,6 @@ class AppleEndpoints:
 
 
 class AppleClaimKeys:
-    SUB = "sub"
     EMAIL = "email"
     EMAIL_VERIFIED = "email_verified"
     IS_PRIVATE_EMAIL = "is_private_email"

--- a/blockauth/apple/nonce.py
+++ b/blockauth/apple/nonce.py
@@ -13,9 +13,7 @@ import secrets
 
 from django.http import HttpRequest, HttpResponse
 
-from blockauth.utils.oauth_state import (  # noqa: F401  re-exported for callers
-    OAUTH_STATE_COOKIE_MAX_AGE,
-)
+from blockauth.utils.oauth_state import OAUTH_STATE_COOKIE_MAX_AGE
 
 APPLE_NONCE_COOKIE_NAME = "blockauth_apple_nonce"
 NONCE_BYTES = 32

--- a/blockauth/apple/views.py
+++ b/blockauth/apple/views.py
@@ -65,15 +65,6 @@ from blockauth.docs.apple_docs import (
     apple_notifications_schema,
 )
 from blockauth.serializers.user_account_serializers import AuthStateResponseSerializer
-
-# SocialIdentityConflictError extends APIException with status_code=409 and
-# is allowed to propagate naturally from the views below — see callsite
-# comments. The import is kept so the symbol resolves for type-checking
-# and so a future change that catches it explicitly doesn't have to re-add
-# the import.
-from blockauth.social.exceptions import (  # noqa: F401
-    SocialIdentityConflictError,
-)
 from blockauth.social.service import SocialIdentityService
 from blockauth.utils.auth_state import build_user_payload
 from blockauth.utils.logger import blockauth_logger

--- a/blockauth/apple/views.py
+++ b/blockauth/apple/views.py
@@ -18,7 +18,6 @@ deploy to a TLS-fronted environment to test the callback path.
 """
 
 import json
-import logging
 from urllib.parse import urlencode
 
 import requests
@@ -81,8 +80,6 @@ from blockauth.utils.oauth_state import (
 from blockauth.utils.outbound_http import get_social_outbound_timeout
 from blockauth.utils.pkce import generate_pkce_pair
 from blockauth.utils.social import social_login_data
-
-logger = logging.getLogger(__name__)
 
 
 def _client_id_from_audience(audience) -> str:

--- a/blockauth/social/linking_policy.py
+++ b/blockauth/social/linking_policy.py
@@ -7,11 +7,11 @@ each provider isolated so future additions (Microsoft, GitHub) get their own
 explicit case rather than inheriting a default.
 """
 
-from typing import Any, Literal
+from typing import Any
 
-# Provider literals supported by this policy. Adding a new provider also
-# requires adding an explicit branch in `can_link_to_existing_user`.
-SupportedProvider = Literal["google", "linkedin", "facebook", "apple"]
+# Adding a new provider requires an explicit branch in
+# `can_link_to_existing_user` — the default-deny posture means an unknown
+# provider falls through and is rejected.
 
 GOOGLE_AUTHORITATIVE_DOMAINS = ("@gmail.com", "@googlemail.com")
 

--- a/blockauth/views/facebook_auth_views.py
+++ b/blockauth/views/facebook_auth_views.py
@@ -52,11 +52,6 @@ FACEBOOK_TOKEN_URL = "https://graph.facebook.com/v18.0/oauth/access_token"
 FACEBOOK_USERINFO_URL = "https://graph.facebook.com/me"
 
 
-def _block_setting(key, default=None):
-    block_settings = getattr(settings, "BLOCK_AUTH_SETTINGS", {}) or {}
-    return block_settings.get(key, default)
-
-
 def _provider_setting(key, default=None):
     block_settings = getattr(settings, "BLOCK_AUTH_SETTINGS", {}) or {}
     providers = block_settings.get("AUTH_PROVIDERS", {}) or {}


### PR DESCRIPTION
Resolves #164 — six small dead-code findings from the deep-dive audit. Each finding is its own commit so they can be reviewed (or reverted) in isolation.

## Commits

1. **41de691** — `chore(apple): drop dead SocialIdentityConflictError noqa import`
   Import in `apple/views.py:74-76` had a 5-line preamble comment justifying it for type-checking and future explicit catches. Neither claim was true; only the callsite comments at lines 290/409 mention the class, and those comments remain.

2. **7764761** — `chore(apple): drop dead stdlib logging import and module logger`
   `import logging` + `logger = logging.getLogger(__name__)` at module scope had zero callers — every log call in the file uses `blockauth_logger` (from `blockauth.utils.logger`).

3. **afcc343** — `chore(apple): drop misleading noqa F401 from nonce import`
   `OAUTH_STATE_COOKIE_MAX_AGE` was imported with `# noqa: F401  re-exported for callers`, but no module re-exports it. The import IS used internally; just drop the misleading annotation and collapse to a single-line import.

4. **412be87** — `chore(facebook): drop orphaned _block_setting helper`
   Copy/paste residue from sibling provider views. `facebook_auth_views.py` only uses `_provider_setting`; `_block_setting` had zero callers internally and no external imports.

5. **b734e29** — `chore(social): drop unused SupportedProvider Literal alias`
   `SupportedProvider = Literal[...]` was never imported and `can_link_to_existing_user` types `provider` as plain `str`. Drop the alias and the unused `Literal` import.

6. **598eb4b** — `chore(apple): drop unused AppleClaimKeys.SUB constant`
   Production code reads `claims.sub` off the `AppleIdTokenClaims` dataclass; the constant was dead. Sibling claim-key constants (EMAIL, EMAIL_VERIFIED, etc.) remain — all in use.

## Out of scope (intentionally kept)

For reviewer context, these surfaced in the audit but are intentionally kept and should NOT be removed:

- `AppleTokenExchangeFailed` — only used as `__cause__` for Sentry breadcrumbs (line 265 of apple/views.py). Keep.
- `social_login()` legacy wrapper in `blockauth/utils/social.py` — kept for external integrators per its docstring. Keep.
- `AppleNotificationDispatchResult` — discarded by the production caller but used by tests; trivial to repurpose later. Keep.
- Defensive `try/except` + `__getattr__` duplication in `blockauth/social/__init__.py` — intentional PEP 562 + Django app-registry pattern. Keep.

## Tests

```
777 passed, 1600 warnings in 14.85s
```

Per-commit Apple suite (75) and social suite (58) green after each step.

## No version bump

Pure dead-code removal — no behaviour change, no API surface change. Version stays at 0.16.5 until there's a feature/fix worth releasing.

## Test plan

- [x] Apple suite green
- [x] Social suite green
- [x] Views suite green (Facebook helper removal)
- [x] Full `uv run pytest` green (777 passed)