### PR TITLE
feat: extract per-provider cookie-clear helpers (Google + Facebook + LinkedIn)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,21 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — pre-1
 
 ---
 
+## [0.16.6] - 2026-05-12
+
+### Added
+
+- `clear_google_callback_cookies(response, samesite=None)` helper in `blockauth.views.google_auth_views`. Clears OAuth state, PKCE verifier, and the Google nonce cookie. Mirrors `clear_apple_callback_cookies` from v0.16.5.
+- `clear_facebook_callback_cookies(response, samesite=None)` helper in `blockauth.views.facebook_auth_views`. Clears OAuth state + PKCE verifier (Facebook is not OIDC; no nonce cookie).
+- `clear_linkedin_callback_cookies(response, samesite=None)` helper in `blockauth.views.linkedin_auth_views`. Clears OAuth state, PKCE verifier, and the LinkedIn nonce cookie.
+
+### Changed
+
+- `GoogleAuthCallbackView.handle_exception`, `FacebookAuthCallbackView.handle_exception`, and `LinkedInAuthCallbackView.handle_exception` now delegate the cookie clear to the corresponding helper above. No behaviour change — each provider's clear list still matches what was previously inlined.
+- Helper docstrings + handler comments drop the "BFF integrators" framing in favour of "subclasses" / "cookie-session pattern". The cookie-session pattern these helpers support is generic across any client; "Backend For Frontend" reads as frontend-specific even though it isn't.
+
+---
+
 ## [0.16.5] - 2026-05-11
 
 ### Added

--- a/blockauth/__init__.py
+++ b/blockauth/__init__.py
@@ -28,7 +28,7 @@ Static utilities (no storage needed):
     backup_codes = TOTPService.generate_backup_codes()
 """
 
-__version__ = "0.16.5"
+__version__ = "0.16.6"
 
 # =============================================================================
 # Direct imports (Django-independent, no AppRegistryNotReady errors)

--- a/blockauth/apple/tests/test_native_view.py
+++ b/blockauth/apple/tests/test_native_view.py
@@ -324,7 +324,7 @@ def test_native_verify_email_collision_with_existing_user_returns_4090(
 # ---------------------------------------------------------------------------
 #
 # Mirrors the hook on AppleWebCallbackView so integrators that issue tokens
-# differently for the native-verify flow (BFF cookies, custom envelope) can
+# differently for the native-verify flow (cookie session, custom envelope) can
 # subclass instead of re-implementing the verifier.
 
 
@@ -373,7 +373,7 @@ def test_native_verify_post_routes_through_build_success_response(
     Patches the hook on AppleNativeVerifyView, runs the full verify flow,
     and asserts the patched response reaches the client. Without this,
     a future refactor that drops the self.build_success_response(...)
-    call would silently break every BFF integrator.
+    call would silently break every subclass relying on the override hook.
     """
     from rest_framework import status as drf_status
     from rest_framework.response import Response

--- a/blockauth/apple/tests/test_web_views.py
+++ b/blockauth/apple/tests/test_web_views.py
@@ -228,7 +228,7 @@ def test_callback_clears_cookies_on_error(apple_settings, client):
 # clear_apple_callback_cookies helper
 # ---------------------------------------------------------------------------
 #
-# Re-usable error-path cleanup so BFF integrators that swap the response
+# Re-usable error-path cleanup so subclasses that swap the response
 # shape (and therefore bypass AppleWebCallbackView.handle_exception) don't
 # have to re-implement the security-critical state/PKCE/nonce clear in
 # every consumer. Owning "what cookies need clearing on Apple's error
@@ -293,9 +293,9 @@ def test_clear_apple_callback_cookies_honours_explicit_samesite():
 #
 # Google, Facebook, LinkedIn, and Google-native already expose
 # build_success_response(request, result) so integrators can swap the success
-# response shape (e.g. BFF cookie redirect) without re-implementing the auth
-# flow. These tests pin the contract for Apple's web callback so fabric-auth
-# can plug in alongside the other providers.
+# response shape (e.g. cookie-session 302 redirect) without re-implementing
+# the auth flow. These tests pin the contract for Apple's web callback so
+# integrators can plug in alongside the other providers.
 
 
 class _StubBlockUser:
@@ -344,7 +344,7 @@ def test_web_callback_post_routes_through_build_success_response(
     and asserts both that the patched response is returned to the client
     and that the hook was reached. Without this, a future refactor that
     drops the self.build_success_response(...) call site would silently
-    break every BFF integrator.
+    break every subclass relying on the override hook.
     """
     from rest_framework import status as drf_status
     from rest_framework.response import Response

--- a/blockauth/apple/views.py
+++ b/blockauth/apple/views.py
@@ -102,9 +102,9 @@ def clear_apple_callback_cookies(response, samesite: str | None = None) -> None:
     replay stale values, so the same three cookies must be cleared
     there too.
 
-    Owning that list here means BFF integrators that swap the response
-    shape (and therefore bypass `AppleWebCallbackView.handle_exception`)
-    can call this helper instead of re-implementing the clear in every
+    Owning that list here means subclasses that swap the response shape
+    (and therefore bypass `AppleWebCallbackView.handle_exception`) can
+    call this helper instead of re-implementing the clear in every
     consumer. If Apple's flow ever grows a fourth cookie, this helper
     is the single place that needs updating.
 
@@ -180,7 +180,7 @@ class AppleWebCallbackView(APIView):
         # a retry could replay stale credentials. DRF builds the error
         # response in `super().handle_exception(...)`, so we mutate it
         # before returning. The clear list is owned by
-        # `clear_apple_callback_cookies` so BFF integrators that swap the
+        # `clear_apple_callback_cookies` so subclasses that swap the
         # response shape can re-use the same single source of truth.
         response = super().handle_exception(exc)
         clear_apple_callback_cookies(response)
@@ -192,9 +192,9 @@ class AppleWebCallbackView(APIView):
 
         Default returns the standard `AuthStateResponseSerializer` JSON
         body. Subclasses can override to swap the body shape (for example,
-        a BFF cookie redirect) without re-implementing the auth flow.
-        Mirrors the hook Google, Facebook, LinkedIn, and Google-native
-        already expose.
+        a cookie-session 302 redirect) without re-implementing the auth
+        flow. Mirrors the hook Google, Facebook, LinkedIn, and
+        Google-native already expose.
         """
         return _build_auth_state_response(result)
 
@@ -325,7 +325,7 @@ class AppleNativeVerifyView(APIView):
 
         Default returns the standard `AuthStateResponseSerializer` JSON
         body. Subclasses can override to swap the body shape (for example,
-        a BFF cookie envelope for browser-based native flows) without
+        a cookie-session envelope for browser-based native flows) without
         re-implementing the verifier.
         """
         return _build_auth_state_response(result)

--- a/blockauth/utils/social.py
+++ b/blockauth/utils/social.py
@@ -6,9 +6,9 @@ callers can decide the wire shape (JSON body, redirect + cookie, etc).
 
 `social_login()` wraps that data into the legacy JSON response so existing
 callers that expect a DRF ``Response`` back continue to work unchanged.
-Integrators who want to BFF-ify the OAuth callback (set HttpOnly cookies
-and return a redirect) subclass the view and use `social_login_data()`
-directly.
+Integrators that want to swap the response shape (e.g. set HttpOnly
+cookies and return a 302 redirect — the cookie-session pattern) subclass
+the view and use `social_login_data()` directly.
 """
 
 from dataclasses import dataclass
@@ -34,7 +34,7 @@ class SocialLoginResult:
     Carries the raw user model + freshly-issued token pair so callers
     can build whatever response shape their integration needs:
     - legacy JSON body (via ``social_login()``)
-    - BFF cookie + redirect
+    - cookie-session 302 redirect (HttpOnly cookies + Location header)
     - popup + postMessage
     """
 

--- a/blockauth/views/facebook_auth_views.py
+++ b/blockauth/views/facebook_auth_views.py
@@ -224,6 +224,5 @@ class FacebookAuthCallbackView(APIView):
             provider_data={"provider": "facebook", "user_info": user_info, "preexisting_user": user},
         )
         response = self.build_success_response(request, result)
-        clear_state_cookie(response)
-        clear_pkce_verifier_cookie(response)
+        clear_facebook_callback_cookies(response)
         return response

--- a/blockauth/views/facebook_auth_views.py
+++ b/blockauth/views/facebook_auth_views.py
@@ -120,8 +120,8 @@ class FacebookAuthCallbackView(APIView):
     def handle_exception(self, exc):
         # Any error path must clear the state/PKCE cookies so a retry
         # can't replay stale credentials. The clear list is owned by
-        # `clear_facebook_callback_cookies` so BFF integrators that
-        # swap the response shape can re-use the same single source of
+        # `clear_facebook_callback_cookies` so subclasses that swap
+        # the response shape can re-use the same single source of
         # truth.
         response = super().handle_exception(exc)
         clear_facebook_callback_cookies(response)

--- a/blockauth/views/facebook_auth_views.py
+++ b/blockauth/views/facebook_auth_views.py
@@ -94,18 +94,37 @@ class FacebookAuthLoginView(APIView):
         return response
 
 
+def clear_facebook_callback_cookies(response, samesite: str | None = None) -> None:
+    """Clear every cookie the Facebook web auth flow sets.
+
+    `FacebookAuthLoginView` sets two cookies before the redirect — the
+    OAuth state token and the PKCE verifier. Facebook is not OIDC and
+    does not set a nonce cookie. The callback consumes and clears them
+    on success; on any error response a retry must not replay stale
+    values.
+
+    Subclasses that override `handle_exception` to swap the response
+    shape (e.g. HttpOnly cookies + 302 redirect instead of DRF's default
+    JSON body) can call this helper instead of re-implementing the
+    state/PKCE clear. Mirrors `clear_apple_callback_cookies` (v0.16.5)
+    and the sibling Google / LinkedIn helpers.
+    """
+    clear_state_cookie(response, samesite=samesite)
+    clear_pkce_verifier_cookie(response, samesite=samesite)
+
+
 class FacebookAuthCallbackView(APIView):
     permission_classes = (AllowAny,)
     authentication_classes = ()
 
     def handle_exception(self, exc):
-        # Mirror the Apple callback's defensive cookie cleanup: any error
-        # path must clear the state and PKCE verifier cookies so a retry
-        # doesn't replay stale credentials. (No nonce cookie — Facebook is
-        # not OIDC and doesn't carry a nonce.)
+        # Any error path must clear the state/PKCE cookies so a retry
+        # can't replay stale credentials. The clear list is owned by
+        # `clear_facebook_callback_cookies` so BFF integrators that
+        # swap the response shape can re-use the same single source of
+        # truth.
         response = super().handle_exception(exc)
-        clear_state_cookie(response)
-        clear_pkce_verifier_cookie(response)
+        clear_facebook_callback_cookies(response)
         return response
 
     def build_success_response(self, request, result) -> Response:

--- a/blockauth/views/google_auth_views.py
+++ b/blockauth/views/google_auth_views.py
@@ -362,7 +362,5 @@ class GoogleAuthCallbackView(APIView):
             },
         )
         response = self.build_success_response(request, result)
-        clear_state_cookie(response)
-        clear_pkce_verifier_cookie(response)
-        response.delete_cookie(GOOGLE_NONCE_COOKIE_NAME, samesite="Lax")
+        clear_google_callback_cookies(response)
         return response

--- a/blockauth/views/google_auth_views.py
+++ b/blockauth/views/google_auth_views.py
@@ -223,11 +223,12 @@ def clear_google_callback_cookies(response, samesite: str | None = None) -> None
     the Google nonce. The callback consumes and clears them on success;
     on any error response a retry must not replay stale values.
 
-    BFF integrators that swap the response shape (and therefore bypass
-    `GoogleAuthCallbackView.handle_exception`) can call this helper
-    instead of re-implementing the clear in every consumer. Mirrors
-    `clear_apple_callback_cookies` in `blockauth.apple.views` (v0.16.5)
-    and the sibling Facebook / LinkedIn helpers introduced alongside.
+    Subclasses that override `handle_exception` to swap the response
+    shape (e.g. HttpOnly cookies + 302 redirect instead of DRF's default
+    JSON body) can call this helper instead of re-implementing the
+    state/PKCE/nonce clear. Mirrors `clear_apple_callback_cookies` in
+    `blockauth.apple.views` (v0.16.5) and the sibling Facebook /
+    LinkedIn helpers introduced alongside.
     """
     clear_state_cookie(response, samesite=samesite)
     clear_pkce_verifier_cookie(response, samesite=samesite)
@@ -239,7 +240,7 @@ class GoogleAuthCallbackView(APIView):
 
     Subclass and override :meth:`build_success_response` to ship tokens via
     HttpOnly cookies + a 302 to the application origin instead of the
-    default JSON body (BFF pattern).
+    default JSON body (cookie-session pattern).
     """
 
     permission_classes = (AllowAny,)
@@ -248,8 +249,8 @@ class GoogleAuthCallbackView(APIView):
     def handle_exception(self, exc):
         # Any error path must clear the state/PKCE/nonce cookies so a
         # retry can't replay stale credentials. The clear list is owned
-        # by `clear_google_callback_cookies` so BFF integrators that
-        # swap the response shape can re-use the same single source of
+        # by `clear_google_callback_cookies` so subclasses that swap
+        # the response shape can re-use the same single source of
         # truth.
         response = super().handle_exception(exc)
         clear_google_callback_cookies(response)

--- a/blockauth/views/google_auth_views.py
+++ b/blockauth/views/google_auth_views.py
@@ -215,6 +215,25 @@ class GoogleAuthLoginView(APIView):
         return response
 
 
+def clear_google_callback_cookies(response, samesite: str | None = None) -> None:
+    """Clear every cookie the Google web auth flow sets.
+
+    `GoogleAuthLoginView` sets three cookies before the redirect to
+    accounts.google.com — the OAuth state token, the PKCE verifier, and
+    the Google nonce. The callback consumes and clears them on success;
+    on any error response a retry must not replay stale values.
+
+    BFF integrators that swap the response shape (and therefore bypass
+    `GoogleAuthCallbackView.handle_exception`) can call this helper
+    instead of re-implementing the clear in every consumer. Mirrors
+    `clear_apple_callback_cookies` in `blockauth.apple.views` (v0.16.5)
+    and the sibling Facebook / LinkedIn helpers introduced alongside.
+    """
+    clear_state_cookie(response, samesite=samesite)
+    clear_pkce_verifier_cookie(response, samesite=samesite)
+    response.delete_cookie(GOOGLE_NONCE_COOKIE_NAME, samesite=samesite or "Lax")
+
+
 class GoogleAuthCallbackView(APIView):
     """Handle Google OAuth callback — verify state + PKCE + nonce + id_token.
 
@@ -227,15 +246,13 @@ class GoogleAuthCallbackView(APIView):
     authentication_classes = ()
 
     def handle_exception(self, exc):
-        # Mirror the Apple callback's defensive cookie cleanup: any error
-        # path must clear the state, PKCE verifier, and Google nonce cookies
-        # so a retry doesn't replay stale credentials. The cookies are
-        # HttpOnly + Secure + 10-min TTL so the leak window is small, but
-        # consistency across providers is worth the few extra lines.
+        # Any error path must clear the state/PKCE/nonce cookies so a
+        # retry can't replay stale credentials. The clear list is owned
+        # by `clear_google_callback_cookies` so BFF integrators that
+        # swap the response shape can re-use the same single source of
+        # truth.
         response = super().handle_exception(exc)
-        clear_state_cookie(response)
-        clear_pkce_verifier_cookie(response)
-        response.delete_cookie(GOOGLE_NONCE_COOKIE_NAME, samesite="Lax")
+        clear_google_callback_cookies(response)
         return response
 
     def build_success_response(self, request, result) -> Response:

--- a/blockauth/views/linkedin_auth_views.py
+++ b/blockauth/views/linkedin_auth_views.py
@@ -194,25 +194,43 @@ class LinkedInAuthLoginView(APIView):
         return response
 
 
+def clear_linkedin_callback_cookies(response, samesite: str | None = None) -> None:
+    """Clear every cookie the LinkedIn web auth flow sets.
+
+    `LinkedInAuthLoginView` sets three cookies before the redirect — the
+    OAuth state token, the PKCE verifier, and the LinkedIn nonce. The
+    callback consumes and clears them on success; on any error response
+    a retry must not replay stale values.
+
+    Subclasses that override `handle_exception` to swap the response
+    shape (e.g. HttpOnly cookies + 302 redirect instead of DRF's default
+    JSON body) can call this helper instead of re-implementing the
+    state/PKCE/nonce clear. Mirrors the sibling Google / Facebook /
+    Apple helpers.
+    """
+    clear_state_cookie(response, samesite=samesite)
+    clear_pkce_verifier_cookie(response, samesite=samesite)
+    response.delete_cookie(LINKEDIN_NONCE_COOKIE_NAME, samesite=samesite or "Lax")
+
+
 class LinkedInAuthCallbackView(APIView):
     """Handle LinkedIn OAuth callback — verify state + PKCE + nonce + id_token.
 
     Subclass and override :meth:`build_success_response` to ship tokens via
     HttpOnly cookies + a 302 to the application origin instead of the
-    default JSON body (BFF pattern).
+    default JSON body (cookie-session pattern).
     """
 
     permission_classes = (AllowAny,)
     authentication_classes = ()
 
     def handle_exception(self, exc):
-        # Mirror the Apple callback's defensive cookie cleanup: any error
-        # path must clear the state, PKCE verifier, and LinkedIn nonce
-        # cookies so a retry doesn't replay stale credentials.
+        # Any error path must clear the state/PKCE/nonce cookies so a
+        # retry can't replay stale credentials. The clear list is owned
+        # by `clear_linkedin_callback_cookies` so subclasses that swap
+        # the response shape can re-use the same single source of truth.
         response = super().handle_exception(exc)
-        clear_state_cookie(response)
-        clear_pkce_verifier_cookie(response)
-        response.delete_cookie(LINKEDIN_NONCE_COOKIE_NAME, samesite="Lax")
+        clear_linkedin_callback_cookies(response)
         return response
 
     def build_success_response(self, request, result) -> Response:

--- a/blockauth/views/linkedin_auth_views.py
+++ b/blockauth/views/linkedin_auth_views.py
@@ -336,7 +336,5 @@ class LinkedInAuthCallbackView(APIView):
             },
         )
         response = self.build_success_response(request, result)
-        clear_state_cookie(response)
-        clear_pkce_verifier_cookie(response)
-        response.delete_cookie(LINKEDIN_NONCE_COOKIE_NAME, samesite="Lax")
+        clear_linkedin_callback_cookies(response)
         return response

--- a/blockauth/views/tests/test_callback_cookie_helpers.py
+++ b/blockauth/views/tests/test_callback_cookie_helpers.py
@@ -86,8 +86,11 @@ def test_clear_linkedin_callback_cookies_marks_state_pkce_and_nonce_for_deletion
 )
 def test_explicit_samesite_kwarg_overrides_default(helper_path, samesite_value):
     """The samesite kwarg lets integrators that diverge from the default
-    override without monkey-patching. Mirrors the same kwarg on
-    clear_apple_callback_cookies."""
+    override without monkey-patching. Assert the kwarg propagates to
+    every cookie the helper touches (state, PKCE, and the provider's
+    nonce cookie where applicable) — not just state — so a future helper
+    that forgets to pass `samesite` through to one of its calls fails
+    this test instead of silently leaking the wrong attribute."""
     import importlib
 
     module_path, _, attr = helper_path.rpartition(".")
@@ -97,4 +100,12 @@ def test_explicit_samesite_kwarg_overrides_default(helper_path, samesite_value):
     response = HttpResponse()
     helper(response, samesite=samesite_value)
 
-    assert response.cookies[OAUTH_STATE_COOKIE_NAME]["samesite"].lower() == samesite_value.lower()
+    # Every cookie the helper actually sets must carry the requested
+    # samesite. Iterate over response.cookies rather than a fixed list
+    # so this test stays correct if a future helper grows another
+    # cookie (Apple-style fourth-cookie case).
+    assert response.cookies, "helper did not clear any cookies"
+    for cookie_name, morsel in response.cookies.items():
+        assert morsel["samesite"].lower() == samesite_value.lower(), (
+            f"{cookie_name} samesite={morsel['samesite']!r} did not match override={samesite_value!r}"
+        )

--- a/blockauth/views/tests/test_callback_cookie_helpers.py
+++ b/blockauth/views/tests/test_callback_cookie_helpers.py
@@ -1,0 +1,100 @@
+"""Tests for the per-provider callback cookie-clear helpers.
+
+`clear_google_callback_cookies`, `clear_facebook_callback_cookies`, and
+`clear_linkedin_callback_cookies` mirror `clear_apple_callback_cookies`
+(introduced in v0.16.5). They exist so BFF integrators that swap the
+response shape (HttpOnly cookies + 302 redirect instead of JSON body) can
+call a single helper per provider instead of re-implementing the
+state/PKCE/nonce clear in every consumer.
+
+These tests pin the contract: each helper marks every cookie set by its
+provider's authorize view for deletion (max-age=0).
+"""
+
+import pytest
+from django.http import HttpResponse
+
+from blockauth.utils.oauth_state import (
+    OAUTH_PKCE_VERIFIER_COOKIE_NAME,
+    OAUTH_STATE_COOKIE_NAME,
+)
+
+
+def test_clear_google_callback_cookies_marks_state_pkce_and_nonce_for_deletion():
+    """The helper must clear state, PKCE verifier, and the Google nonce
+    cookie. Mirrors clear_apple_callback_cookies from v0.16.5."""
+    from blockauth.views.google_auth_views import (
+        GOOGLE_NONCE_COOKIE_NAME,
+        clear_google_callback_cookies,
+    )
+
+    response = HttpResponse()
+    clear_google_callback_cookies(response)
+
+    for cookie_name in (
+        OAUTH_STATE_COOKIE_NAME,
+        OAUTH_PKCE_VERIFIER_COOKIE_NAME,
+        GOOGLE_NONCE_COOKIE_NAME,
+    ):
+        assert cookie_name in response.cookies, f"{cookie_name} not cleared"
+        assert response.cookies[cookie_name]["max-age"] == 0, f"{cookie_name} not marked for deletion (max-age != 0)"
+
+
+def test_clear_facebook_callback_cookies_marks_state_and_pkce_for_deletion():
+    """Facebook is not OIDC and does not set a nonce cookie, so the
+    helper only clears state and PKCE verifier."""
+    from blockauth.views.facebook_auth_views import clear_facebook_callback_cookies
+
+    response = HttpResponse()
+    clear_facebook_callback_cookies(response)
+
+    for cookie_name in (
+        OAUTH_STATE_COOKIE_NAME,
+        OAUTH_PKCE_VERIFIER_COOKIE_NAME,
+    ):
+        assert cookie_name in response.cookies, f"{cookie_name} not cleared"
+        assert response.cookies[cookie_name]["max-age"] == 0, f"{cookie_name} not marked for deletion (max-age != 0)"
+
+
+def test_clear_linkedin_callback_cookies_marks_state_pkce_and_nonce_for_deletion():
+    """The helper must clear state, PKCE verifier, and the LinkedIn nonce
+    cookie."""
+    from blockauth.views.linkedin_auth_views import (
+        LINKEDIN_NONCE_COOKIE_NAME,
+        clear_linkedin_callback_cookies,
+    )
+
+    response = HttpResponse()
+    clear_linkedin_callback_cookies(response)
+
+    for cookie_name in (
+        OAUTH_STATE_COOKIE_NAME,
+        OAUTH_PKCE_VERIFIER_COOKIE_NAME,
+        LINKEDIN_NONCE_COOKIE_NAME,
+    ):
+        assert cookie_name in response.cookies, f"{cookie_name} not cleared"
+        assert response.cookies[cookie_name]["max-age"] == 0, f"{cookie_name} not marked for deletion (max-age != 0)"
+
+
+@pytest.mark.parametrize(
+    ("helper_path", "samesite_value"),
+    [
+        ("blockauth.views.google_auth_views.clear_google_callback_cookies", "Strict"),
+        ("blockauth.views.facebook_auth_views.clear_facebook_callback_cookies", "Strict"),
+        ("blockauth.views.linkedin_auth_views.clear_linkedin_callback_cookies", "Strict"),
+    ],
+)
+def test_explicit_samesite_kwarg_overrides_default(helper_path, samesite_value):
+    """The samesite kwarg lets integrators that diverge from the default
+    override without monkey-patching. Mirrors the same kwarg on
+    clear_apple_callback_cookies."""
+    import importlib
+
+    module_path, _, attr = helper_path.rpartition(".")
+    module = importlib.import_module(module_path)
+    helper = getattr(module, attr)
+
+    response = HttpResponse()
+    helper(response, samesite=samesite_value)
+
+    assert response.cookies[OAUTH_STATE_COOKIE_NAME]["samesite"].lower() == samesite_value.lower()

--- a/blockauth/views/tests/test_callback_cookie_helpers.py
+++ b/blockauth/views/tests/test_callback_cookie_helpers.py
@@ -2,10 +2,10 @@
 
 `clear_google_callback_cookies`, `clear_facebook_callback_cookies`, and
 `clear_linkedin_callback_cookies` mirror `clear_apple_callback_cookies`
-(introduced in v0.16.5). They exist so BFF integrators that swap the
-response shape (HttpOnly cookies + 302 redirect instead of JSON body) can
-call a single helper per provider instead of re-implementing the
-state/PKCE/nonce clear in every consumer.
+(introduced in v0.16.5). They exist so subclasses that swap the
+response shape (e.g. HttpOnly cookies + 302 redirect instead of DRF's
+default JSON body) can call a single helper per provider instead of
+re-implementing the state/PKCE/nonce clear in every consumer.
 
 These tests pin the contract: each helper marks every cookie set by its
 provider's authorize view for deletion (max-age=0).
@@ -106,6 +106,6 @@ def test_explicit_samesite_kwarg_overrides_default(helper_path, samesite_value):
     # cookie (Apple-style fourth-cookie case).
     assert response.cookies, "helper did not clear any cookies"
     for cookie_name, morsel in response.cookies.items():
-        assert morsel["samesite"].lower() == samesite_value.lower(), (
-            f"{cookie_name} samesite={morsel['samesite']!r} did not match override={samesite_value!r}"
-        )
+        assert (
+            morsel["samesite"].lower() == samesite_value.lower()
+        ), f"{cookie_name} samesite={morsel['samesite']!r} did not match override={samesite_value!r}"

--- a/blockauth/views/tests/test_oauth_views.py
+++ b/blockauth/views/tests/test_oauth_views.py
@@ -507,7 +507,7 @@ class TestLinkedInAuthCallbackView:
 
 @pytest.mark.django_db
 class TestCallbackSuccessResponseHook:
-    """BFF-cookie integrations subclass these callback views and override
+    """Cookie-session integrations subclass these callback views and override
     ``build_success_response`` to ship tokens via HttpOnly cookies + a 302
     to the application origin, instead of the default JSON body. These tests
     pin the hook surface so the override point doesn't silently disappear in

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "blockauth"
-version = "0.16.5"
+version = "0.16.6"
 description = "Comprehensive Python authentication package bridging Web2 and Web3"
 authors = [{name = "BloclabsHQ", email = "eng@bloclabs.com"}]
 license = {text = "MIT"}


### PR DESCRIPTION
Mirrors the boundary fix landed for Apple in v0.16.5. Each provider's cookie-name knowledge stays inside blockauth; subclasses that swap the response shape (cookie-session pattern in fabric-auth and other future integrations) can call a single helper per provider instead of re-implementing the state/PKCE/nonce clear in every consumer.

## Five commits

1. **\`0e0232b\`** \`feat(google): extract clear_google_callback_cookies helper\`
2. **\`a537b13\`** \`feat(facebook): extract clear_facebook_callback_cookies helper\`
3. **\`c967dc1\`** \`feat(linkedin): extract clear_linkedin_callback_cookies helper\`
4. **\`98c7bba\`** \`chore(docs): drop 'BFF integrators' framing from helper docstrings\` — including the pre-existing Apple helper. \`Backend For Frontend\` reads as fabric-shell-specific even though the cookie-session pattern is generic.
5. **\`4aec0ca\`** \`chore: bump to 0.16.6\`

## Added

- \`clear_google_callback_cookies\` — state + PKCE + Google nonce
- \`clear_facebook_callback_cookies\` — state + PKCE (Facebook is not OIDC)
- \`clear_linkedin_callback_cookies\` — state + PKCE + LinkedIn nonce

## Changed

- Each provider's \`handle_exception\` now delegates the cookie clear to the corresponding helper. No behaviour change.
- Helper docstrings + handler comments drop the \"BFF integrators\" framing in favour of \"subclasses\" / \"cookie-session pattern\".

## Motivating consumer

fabric-auth #680 generalises the conflict-redirect path (currently Apple-only) to all four providers via a shared mixin that dispatches the cookie-clear via \`_COOKIE_CLEARERS\` keyed on provider name. Each provider's clear must happen even when the response shape is swapped from DRF JSON 409 to a 302 redirect; the shared helpers in this PR keep the cookie-name knowledge inside blockauth where it belongs.

## Test plan

- [x] Three new helper tests assert state/PKCE/nonce cookies are marked for deletion (max-age=0)
- [x] One parametrized test asserts the \`samesite\` kwarg override
- [x] Existing provider suites (\`blockauth/views/tests/test_oauth_views.py\`) stay green — \`handle_exception\` refactor is mechanical
- [x] Full \`uv run pytest\` green (783 passed)

## After merge

Tag \`v0.16.6\` on dev so fabric-auth #680 can bump the pin.