### PR TITLE
fix(oauth): populate user names on signup across all 4 providers (closes #167)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,18 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — pre-1
 
 ---
 
+## [0.16.7] - 2026-05-12
+
+### Fixed
+
+- OAuth web flows (Google, Facebook, LinkedIn, Apple) now populate `first_name` / `last_name` on the user model for first-OAuth signup. Previously every provider except Apple's native-verify endpoint dropped these fields silently, even though all providers return them. Each web view now forwards `extra_user_fields={"first_name": ..., "last_name": ...}` to `SocialIdentityService.upsert_and_link`. Apple's web callback additionally parses the first-sign-in `user` form_post payload (Apple's id_token never carries the name).
+
+### Changed
+
+- `FacebookAuthCallbackView` Graph API request broadened from `fields=id,name,email` to `fields=id,name,first_name,last_name,email`. All four fields are granted by the `public_profile` permission — no additional scope required.
+
+---
+
 ## [0.16.6] - 2026-05-12
 
 ### Added

--- a/blockauth/__init__.py
+++ b/blockauth/__init__.py
@@ -28,7 +28,7 @@ Static utilities (no storage needed):
     backup_codes = TOTPService.generate_backup_codes()
 """
 
-__version__ = "0.16.6"
+__version__ = "0.16.7"
 
 # =============================================================================
 # Direct imports (Django-independent, no AppRegistryNotReady errors)

--- a/blockauth/apple/tests/test_web_views.py
+++ b/blockauth/apple/tests/test_web_views.py
@@ -464,9 +464,7 @@ def test_apple_web_callback_handles_non_dict_user_payload():
     from blockauth.apple.views import AppleWebCallbackView
 
     for non_dict_payload in (json.dumps("just a string"), json.dumps(["x", "y"]), json.dumps(42), json.dumps(None)):
-        first, last = AppleWebCallbackView._parse_first_sign_in_user(
-            MagicMock(data={"user": non_dict_payload})
-        )
+        first, last = AppleWebCallbackView._parse_first_sign_in_user(MagicMock(data={"user": non_dict_payload}))
         assert (first, last) == ("", ""), f"non-dict payload {non_dict_payload!r} produced ({first!r}, {last!r})"
 
 
@@ -480,8 +478,6 @@ def test_apple_web_callback_handles_non_dict_name_object():
     from blockauth.apple.views import AppleWebCallbackView
 
     payload = json.dumps({"name": "Tim Cook", "email": "tim@example.com"})
-    first, last = AppleWebCallbackView._parse_first_sign_in_user(
-        MagicMock(data={"user": payload})
-    )
+    first, last = AppleWebCallbackView._parse_first_sign_in_user(MagicMock(data={"user": payload}))
     assert first == ""
     assert last == ""

--- a/blockauth/apple/tests/test_web_views.py
+++ b/blockauth/apple/tests/test_web_views.py
@@ -435,9 +435,7 @@ def test_apple_web_callback_handles_missing_user_payload():
 
     from blockauth.apple.views import AppleWebCallbackView
 
-    first, last = AppleWebCallbackView._parse_first_sign_in_user(
-        MagicMock(data={})
-    )
+    first, last = AppleWebCallbackView._parse_first_sign_in_user(MagicMock(data={}))
     assert first == ""
     assert last == ""
 
@@ -449,8 +447,6 @@ def test_apple_web_callback_handles_malformed_user_payload():
 
     from blockauth.apple.views import AppleWebCallbackView
 
-    first, last = AppleWebCallbackView._parse_first_sign_in_user(
-        MagicMock(data={"user": "{not valid json"})
-    )
+    first, last = AppleWebCallbackView._parse_first_sign_in_user(MagicMock(data={"user": "{not valid json"}))
     assert first == ""
     assert last == ""

--- a/blockauth/apple/tests/test_web_views.py
+++ b/blockauth/apple/tests/test_web_views.py
@@ -450,3 +450,38 @@ def test_apple_web_callback_handles_malformed_user_payload():
     first, last = AppleWebCallbackView._parse_first_sign_in_user(MagicMock(data={"user": "{not valid json"}))
     assert first == ""
     assert last == ""
+
+
+def test_apple_web_callback_handles_non_dict_user_payload():
+    """Valid JSON that isn't an object — e.g. `"1"`, `null`, `["x"]` —
+    must return empty strings rather than crashing the callback with
+    AttributeError. Apple's contract says `user` is always an object on
+    first sign-in, but defensive parsing keeps the view 200-or-302
+    no matter what arrives."""
+    import json
+    from unittest.mock import MagicMock
+
+    from blockauth.apple.views import AppleWebCallbackView
+
+    for non_dict_payload in (json.dumps("just a string"), json.dumps(["x", "y"]), json.dumps(42), json.dumps(None)):
+        first, last = AppleWebCallbackView._parse_first_sign_in_user(
+            MagicMock(data={"user": non_dict_payload})
+        )
+        assert (first, last) == ("", ""), f"non-dict payload {non_dict_payload!r} produced ({first!r}, {last!r})"
+
+
+def test_apple_web_callback_handles_non_dict_name_object():
+    """The `name` field inside the `user` payload must itself be an
+    object. A string / list / number there would have triggered
+    AttributeError on the inner `.get(...)` calls."""
+    import json
+    from unittest.mock import MagicMock
+
+    from blockauth.apple.views import AppleWebCallbackView
+
+    payload = json.dumps({"name": "Tim Cook", "email": "tim@example.com"})
+    first, last = AppleWebCallbackView._parse_first_sign_in_user(
+        MagicMock(data={"user": payload})
+    )
+    assert first == ""
+    assert last == ""

--- a/blockauth/apple/tests/test_web_views.py
+++ b/blockauth/apple/tests/test_web_views.py
@@ -393,3 +393,64 @@ def test_web_callback_post_routes_through_build_success_response(
     assert mock_hook.call_count == 1
     assert callback.status_code == drf_status.HTTP_201_CREATED
     assert callback.json() == {"swapped": True}
+
+
+# ---------------------------------------------------------------------------
+# _parse_first_sign_in_user helper — first-sign-in `user` form_post payload
+# ---------------------------------------------------------------------------
+#
+# Apple POSTs a `user` field alongside `code` + `state` on the FIRST
+# sign-in only — shaped {"name": {"firstName": ..., "lastName": ...},
+# "email": ...}. The id_token never carries the name (privacy by
+# design), so this is the only place to get it. Subsequent sign-ins
+# omit the field entirely.
+
+
+def test_apple_web_callback_parses_first_sign_in_user_payload():
+    """First sign-in: parse `user` JSON, return (firstName, lastName)."""
+    import json
+    from unittest.mock import MagicMock
+
+    from blockauth.apple.views import AppleWebCallbackView
+
+    first, last = AppleWebCallbackView._parse_first_sign_in_user(
+        MagicMock(
+            data={
+                "user": json.dumps(
+                    {
+                        "name": {"firstName": "Tim", "lastName": "Cook"},
+                        "email": "tim@example.com",
+                    }
+                ),
+            }
+        )
+    )
+    assert first == "Tim"
+    assert last == "Cook"
+
+
+def test_apple_web_callback_handles_missing_user_payload():
+    """Returning sign-ins omit `user` — return empty strings, never raise."""
+    from unittest.mock import MagicMock
+
+    from blockauth.apple.views import AppleWebCallbackView
+
+    first, last = AppleWebCallbackView._parse_first_sign_in_user(
+        MagicMock(data={})
+    )
+    assert first == ""
+    assert last == ""
+
+
+def test_apple_web_callback_handles_malformed_user_payload():
+    """Malformed JSON must not crash the callback — log a warning,
+    return empty strings, let SocialIdentityService dedupe on (provider, sub)."""
+    from unittest.mock import MagicMock
+
+    from blockauth.apple.views import AppleWebCallbackView
+
+    first, last = AppleWebCallbackView._parse_first_sign_in_user(
+        MagicMock(data={"user": "{not valid json"})
+    )
+    assert first == ""
+    assert last == ""

--- a/blockauth/apple/views.py
+++ b/blockauth/apple/views.py
@@ -218,7 +218,15 @@ class AppleWebCallbackView(APIView):
             return "", ""
         try:
             payload = json.loads(raw_user) if isinstance(raw_user, str) else raw_user
-            name_obj = (payload or {}).get("name") or {}
+            # Valid JSON like `"1"`, `["x"]`, or `null` parses successfully
+            # but isn't a dict. Apple's documented contract says `user` is
+            # always an object on the first sign-in — anything else is
+            # treated the same as a missing field.
+            if not isinstance(payload, dict):
+                return "", ""
+            name_obj = payload.get("name") or {}
+            if not isinstance(name_obj, dict):
+                return "", ""
             return (
                 str(name_obj.get("firstName") or ""),
                 str(name_obj.get("lastName") or ""),

--- a/blockauth/apple/views.py
+++ b/blockauth/apple/views.py
@@ -198,6 +198,38 @@ class AppleWebCallbackView(APIView):
         """
         return _build_auth_state_response(result)
 
+    @staticmethod
+    def _parse_first_sign_in_user(request) -> tuple[str, str]:
+        """Extract `firstName` / `lastName` from Apple's first-sign-in form_post.
+
+        Apple POSTs a `user` field on the *first* sign-in only, shaped:
+
+            {"name": {"firstName": "...", "lastName": "..."}, "email": "..."}
+
+        Subsequent sign-ins omit this field entirely (Apple's privacy model:
+        the modified name lives on the user's device, not on Apple's
+        servers, so they can't replay it). Returns empty strings when the
+        field is absent or malformed — the SocialIdentityService dedupes
+        on (provider, sub) anyway, so missing names are fine on returning
+        sign-ins.
+        """
+        raw_user = request.data.get("user")
+        if not raw_user:
+            return "", ""
+        try:
+            payload = json.loads(raw_user) if isinstance(raw_user, str) else raw_user
+            name_obj = (payload or {}).get("name") or {}
+            return (
+                str(name_obj.get("firstName") or ""),
+                str(name_obj.get("lastName") or ""),
+            )
+        except (TypeError, ValueError, json.JSONDecodeError):
+            blockauth_logger.warning(
+                "apple.web.first_sign_in_user_payload_malformed",
+                {"raw_type": type(raw_user).__name__},
+            )
+            return "", ""
+
     @extend_schema(**apple_callback_schema)
     def post(self, request):
         code = request.data.get("code")
@@ -275,11 +307,26 @@ class AppleWebCallbackView(APIView):
             )
             raise ValidationError({"detail": "Apple id_token verification failed"}, 4054) from exc
 
+        # Apple POSTs a `user` JSON field alongside `code` + `state` on
+        # the very first sign-in only — it carries the user's name (and
+        # email, which we already have from the id_token). Subsequent
+        # sign-ins omit it entirely; on those, names default to empty
+        # strings and SocialIdentityService dedupes on (provider, sub).
+        first_name, last_name = self._parse_first_sign_in_user(request)
+
         # SocialIdentityConflictError extends APIException with
         # status_code=409 + default_code="SOCIAL_IDENTITY_CONFLICT"; let it
         # propagate so the HTTP-semantic Conflict (409) reaches the client
         # rather than being demoted to 400 by an extra ValidationError wrap.
         # Apple identities never auto-link by email per AccountLinkingPolicy.
+        #
+        # `extra_user_fields` seeds the user model on first-OAuth signup
+        # so the Creator (or any custom AUTH_USER_MODEL with name fields)
+        # lands with the user's name from Apple rather than NULL. Apple's
+        # id_token never carries the name (privacy by design); first/last
+        # come from the form_post `user` field above and are only present
+        # on the very first sign-in. SocialIdentityService filters these
+        # against the user model's schema.
         user, _, _ = SocialIdentityService().upsert_and_link(
             provider="apple",
             subject=claims.sub,
@@ -287,11 +334,15 @@ class AppleWebCallbackView(APIView):
             email_verified=claims.email_verified,
             extra_claims={"is_private_email": claims.is_private_email},
             refresh_token=refresh_token,
+            extra_user_fields={
+                "first_name": first_name,
+                "last_name": last_name,
+            },
         )
 
         result = social_login_data(
             email=claims.email or "",
-            name="",
+            name=" ".join(filter(None, [first_name, last_name])).strip(),
             provider_data={"provider": "apple", "user_info": claims.raw, "preexisting_user": user},
         )
 

--- a/blockauth/views/facebook_auth_views.py
+++ b/blockauth/views/facebook_auth_views.py
@@ -182,7 +182,16 @@ class FacebookAuthCallbackView(APIView):
         try:
             userinfo_response = requests.get(
                 FACEBOOK_USERINFO_URL,
-                params={"fields": "id,name,email", "access_token": access_token},
+                params={
+                    # `first_name` / `last_name` ride alongside `name` so we can
+                    # populate the user model's name fields directly on signup
+                    # (the full `name` is kept as a fallback for callers that
+                    # still display the full string). All three are part of the
+                    # `public_profile` permission so no additional scope is
+                    # required.
+                    "fields": "id,name,first_name,last_name,email",
+                    "access_token": access_token,
+                },
                 timeout=get_social_outbound_timeout(),
             )
         except requests.exceptions.RequestException as exc:
@@ -210,12 +219,24 @@ class FacebookAuthCallbackView(APIView):
 
         # SocialIdentityConflictError extends APIException with status_code=409;
         # let it propagate (Phase 9 cross-flow consistency).
+        #
+        # `extra_user_fields` seeds the user model on first-OAuth signup so
+        # the Creator (or any custom AUTH_USER_MODEL with name fields) lands
+        # with the user's name from Facebook rather than NULL. Facebook's
+        # Graph API ships `first_name` / `last_name` under the
+        # `public_profile` permission (no additional scope needed); absent
+        # values fall back to empty strings. SocialIdentityService filters
+        # these against the user model's schema.
         user, _, _ = SocialIdentityService().upsert_and_link(
             provider="facebook",
             subject=str(fb_user_id),
             email=email,
             email_verified=email_verified,
             extra_claims={},
+            extra_user_fields={
+                "first_name": user_info.get("first_name") or "",
+                "last_name": user_info.get("last_name") or "",
+            },
         )
 
         result = social_login_data(

--- a/blockauth/views/google_auth_views.py
+++ b/blockauth/views/google_auth_views.py
@@ -344,12 +344,25 @@ class GoogleAuthCallbackView(APIView):
         # let it propagate to the HTTP-semantic Conflict response rather than
         # demoting it to 400 by an extra ValidationError wrap. Phase 9
         # cross-flow consistency.
+        #
+        # `extra_user_fields` seeds the user model on first-OAuth signup so
+        # the Creator (or any custom AUTH_USER_MODEL with name fields) lands
+        # with the user's name from Google rather than NULL. Google reliably
+        # ships `given_name` / `family_name` for personal accounts and
+        # Workspace accounts; absent values fall back to empty strings.
+        # SocialIdentityService filters these against the user model's
+        # schema — integrators whose model lacks first_name / last_name
+        # simply ignore the values.
         user, _, _ = SocialIdentityService().upsert_and_link(
             provider="google",
             subject=str(claims["sub"]),
             email=claims.get("email"),
             email_verified=bool(claims.get("email_verified")),
             extra_claims={"hd": claims.get("hd")},
+            extra_user_fields={
+                "first_name": claims.get("given_name") or "",
+                "last_name": claims.get("family_name") or "",
+            },
         )
 
         result = social_login_data(

--- a/blockauth/views/linkedin_auth_views.py
+++ b/blockauth/views/linkedin_auth_views.py
@@ -318,12 +318,25 @@ class LinkedInAuthCallbackView(APIView):
         # let it propagate to the HTTP-semantic Conflict response rather than
         # demoting it to 400 by an extra ValidationError wrap. Phase 9
         # cross-flow consistency.
+        #
+        # `extra_user_fields` seeds the user model on first-OAuth signup so
+        # the Creator (or any custom AUTH_USER_MODEL with name fields) lands
+        # with the user's name from LinkedIn rather than NULL. LinkedIn's
+        # OIDC id_token ships `given_name` / `family_name` under the
+        # `profile` scope (which Sign In with LinkedIn v2 includes by
+        # default); absent values fall back to empty strings.
+        # SocialIdentityService filters these against the user model's
+        # schema.
         user, _, _ = SocialIdentityService().upsert_and_link(
             provider="linkedin",
             subject=str(claims["sub"]),
             email=claims.get("email"),
             email_verified=bool(claims.get("email_verified")),
             extra_claims={},
+            extra_user_fields={
+                "first_name": claims.get("given_name") or "",
+                "last_name": claims.get("family_name") or "",
+            },
         )
 
         result = social_login_data(

--- a/blockauth/views/tests/test_oauth_views.py
+++ b/blockauth/views/tests/test_oauth_views.py
@@ -757,7 +757,7 @@ class TestSocialLoginResponseShape:
 
 def _stub_upsert_returning(user):
     """Tuple shape that matches `SocialIdentityService.upsert_and_link`."""
-    return user, MagicMock(), {}
+    return user, MagicMock(), False
 
 
 @pytest.mark.django_db

--- a/blockauth/views/tests/test_oauth_views.py
+++ b/blockauth/views/tests/test_oauth_views.py
@@ -761,8 +761,9 @@ def _stub_upsert_returning(user):
 
 
 @pytest.mark.django_db
+@pytest.mark.usefixtures("google_web_settings")
 def test_google_callback_forwards_given_and_family_name_to_service(
-    google_web_settings, client, build_id_token, jwks_response
+    client, build_id_token, jwks_response
 ):
     """Google's OIDC id_token ships `given_name` / `family_name`; the
     callback view must forward them so the user's name is populated on
@@ -805,7 +806,8 @@ def test_google_callback_forwards_given_and_family_name_to_service(
 
 
 @pytest.mark.django_db
-def test_facebook_callback_forwards_first_and_last_name_to_service(facebook_settings, client):
+@pytest.mark.usefixtures("facebook_settings")
+def test_facebook_callback_forwards_first_and_last_name_to_service(client):
     """Facebook's Graph API ships `first_name` / `last_name` under the
     `public_profile` permission; the view must request those fields and
     forward them."""
@@ -847,8 +849,9 @@ def test_facebook_callback_forwards_first_and_last_name_to_service(facebook_sett
 
 
 @pytest.mark.django_db
+@pytest.mark.usefixtures("linkedin_settings")
 def test_linkedin_callback_forwards_given_and_family_name_to_service(
-    linkedin_settings, client, build_id_token, linkedin_jwks_response
+    client, build_id_token, linkedin_jwks_response
 ):
     """LinkedIn's OIDC id_token ships `given_name` / `family_name` under
     the `profile` scope (Sign In with LinkedIn v2 includes it by

--- a/blockauth/views/tests/test_oauth_views.py
+++ b/blockauth/views/tests/test_oauth_views.py
@@ -740,3 +740,156 @@ class TestSocialLoginResponseShape:
         user = User.objects.get(email="named@test.com")
         if hasattr(user, "first_name"):
             assert user.first_name == "Ada Lovelace"
+
+
+# ---------------------------------------------------------------------------
+# Name population on first OAuth signup
+# ---------------------------------------------------------------------------
+#
+# Each web callback view must forward the provider's first/last name as
+# `extra_user_fields` to `SocialIdentityService.upsert_and_link`, so the
+# user model's `first_name` / `last_name` are populated on signup rather
+# than NULL. The test user model here (`tests.TestBlockUser`) extends
+# `AbstractBaseUser` and does not declare those fields, so we mock the
+# service to assert the kwarg payload — the integration the view is
+# responsible for.
+
+
+def _stub_upsert_returning(user):
+    """Tuple shape that matches `SocialIdentityService.upsert_and_link`."""
+    return user, MagicMock(), {}
+
+
+@pytest.mark.django_db
+def test_google_callback_forwards_given_and_family_name_to_service(
+    google_web_settings, client, build_id_token, jwks_response
+):
+    """Google's OIDC id_token ships `given_name` / `family_name`; the
+    callback view must forward them so the user's name is populated on
+    signup."""
+    init = client.get("/google/")
+    state = init.cookies[OAUTH_STATE_COOKIE_NAME].value
+    raw_nonce = init.cookies["blockauth_google_nonce"].value
+    expected_hash = hashlib.sha256(raw_nonce.encode()).hexdigest()
+
+    google_id_token = build_id_token(
+        {
+            "iss": "https://accounts.google.com",
+            "aud": "123-web.apps.googleusercontent.com",
+            "sub": "google-name-sub",
+            "email": "ada@example.com",
+            "email_verified": True,
+            "name": "Ada Lovelace",
+            "given_name": "Ada",
+            "family_name": "Lovelace",
+            "nonce": expected_hash,
+        }
+    )
+    token_response = MagicMock(status_code=200)
+    token_response.json.return_value = {"id_token": google_id_token}
+
+    with patch(
+        "blockauth.views.google_auth_views.SocialIdentityService"
+    ) as service_cls, patch(
+        "blockauth.views.google_auth_views.requests.post", return_value=token_response
+    ), patch("blockauth.utils.jwt.jwks_cache.requests.get", return_value=jwks_response):
+        service = service_cls.return_value
+        service.upsert_and_link.return_value = _stub_upsert_returning(MagicMock())
+        client.get(f"/google/callback/?code=auth-code&state={state}")
+
+    kwargs = service.upsert_and_link.call_args.kwargs
+    assert kwargs["extra_user_fields"] == {
+        "first_name": "Ada",
+        "last_name": "Lovelace",
+    }
+
+
+@pytest.mark.django_db
+def test_facebook_callback_forwards_first_and_last_name_to_service(
+    facebook_settings, client
+):
+    """Facebook's Graph API ships `first_name` / `last_name` under the
+    `public_profile` permission; the view must request those fields and
+    forward them."""
+    init = client.get("/facebook/")
+    state = init.cookies[OAUTH_STATE_COOKIE_NAME].value
+
+    token_response = MagicMock(status_code=200)
+    token_response.json.return_value = {"access_token": "fb-access"}
+    me_response = MagicMock(status_code=200)
+    me_response.json.return_value = {
+        "id": "fb_name_user",
+        "name": "Grace Hopper",
+        "first_name": "Grace",
+        "last_name": "Hopper",
+        "email": "grace@example.com",
+    }
+
+    with patch(
+        "blockauth.views.facebook_auth_views.SocialIdentityService"
+    ) as service_cls, patch(
+        "blockauth.views.facebook_auth_views.requests.get",
+        side_effect=[token_response, me_response],
+    ) as mock_get:
+        service = service_cls.return_value
+        service.upsert_and_link.return_value = _stub_upsert_returning(MagicMock())
+        client.get(f"/facebook/callback/?code=auth-code&state={state}")
+
+    # The Graph request must explicitly include first_name / last_name.
+    me_call_params = mock_get.call_args_list[1].kwargs["params"]
+    assert "first_name" in me_call_params["fields"]
+    assert "last_name" in me_call_params["fields"]
+
+    kwargs = service.upsert_and_link.call_args.kwargs
+    assert kwargs["extra_user_fields"] == {
+        "first_name": "Grace",
+        "last_name": "Hopper",
+    }
+
+
+@pytest.mark.django_db
+def test_linkedin_callback_forwards_given_and_family_name_to_service(
+    linkedin_settings, client, build_id_token, linkedin_jwks_response
+):
+    """LinkedIn's OIDC id_token ships `given_name` / `family_name` under
+    the `profile` scope (Sign In with LinkedIn v2 includes it by
+    default)."""
+    init = client.get("/linkedin/")
+    state = init.cookies[OAUTH_STATE_COOKIE_NAME].value
+    raw_nonce = init.cookies["blockauth_linkedin_nonce"].value
+    expected_hash = hashlib.sha256(raw_nonce.encode()).hexdigest()
+
+    linkedin_id_token = build_id_token(
+        {
+            "iss": "https://www.linkedin.com",
+            "aud": "linkedin-client-id",
+            "sub": "linkedin-name-sub",
+            "email": "alan@example.com",
+            "email_verified": True,
+            "name": "Alan Turing",
+            "given_name": "Alan",
+            "family_name": "Turing",
+            "nonce": expected_hash,
+        }
+    )
+    token_response = MagicMock(status_code=200)
+    token_response.json.return_value = {"id_token": linkedin_id_token}
+
+    with patch(
+        "blockauth.views.linkedin_auth_views.SocialIdentityService"
+    ) as service_cls, patch(
+        "blockauth.views.linkedin_auth_views.requests.post",
+        return_value=token_response,
+    ), patch(
+        "blockauth.utils.jwt.jwks_cache.requests.get",
+        return_value=linkedin_jwks_response,
+    ):
+        service = service_cls.return_value
+        service.upsert_and_link.return_value = _stub_upsert_returning(MagicMock())
+        client.get(f"/linkedin/callback/?code=auth-code&state={state}")
+
+    kwargs = service.upsert_and_link.call_args.kwargs
+    assert kwargs["extra_user_fields"] == {
+        "first_name": "Alan",
+        "last_name": "Turing",
+    }

--- a/blockauth/views/tests/test_oauth_views.py
+++ b/blockauth/views/tests/test_oauth_views.py
@@ -788,11 +788,11 @@ def test_google_callback_forwards_given_and_family_name_to_service(
     token_response = MagicMock(status_code=200)
     token_response.json.return_value = {"id_token": google_id_token}
 
-    with patch(
-        "blockauth.views.google_auth_views.SocialIdentityService"
-    ) as service_cls, patch(
-        "blockauth.views.google_auth_views.requests.post", return_value=token_response
-    ), patch("blockauth.utils.jwt.jwks_cache.requests.get", return_value=jwks_response):
+    with (
+        patch("blockauth.views.google_auth_views.SocialIdentityService") as service_cls,
+        patch("blockauth.views.google_auth_views.requests.post", return_value=token_response),
+        patch("blockauth.utils.jwt.jwks_cache.requests.get", return_value=jwks_response),
+    ):
         service = service_cls.return_value
         service.upsert_and_link.return_value = _stub_upsert_returning(MagicMock())
         client.get(f"/google/callback/?code=auth-code&state={state}")
@@ -805,9 +805,7 @@ def test_google_callback_forwards_given_and_family_name_to_service(
 
 
 @pytest.mark.django_db
-def test_facebook_callback_forwards_first_and_last_name_to_service(
-    facebook_settings, client
-):
+def test_facebook_callback_forwards_first_and_last_name_to_service(facebook_settings, client):
     """Facebook's Graph API ships `first_name` / `last_name` under the
     `public_profile` permission; the view must request those fields and
     forward them."""
@@ -825,12 +823,13 @@ def test_facebook_callback_forwards_first_and_last_name_to_service(
         "email": "grace@example.com",
     }
 
-    with patch(
-        "blockauth.views.facebook_auth_views.SocialIdentityService"
-    ) as service_cls, patch(
-        "blockauth.views.facebook_auth_views.requests.get",
-        side_effect=[token_response, me_response],
-    ) as mock_get:
+    with (
+        patch("blockauth.views.facebook_auth_views.SocialIdentityService") as service_cls,
+        patch(
+            "blockauth.views.facebook_auth_views.requests.get",
+            side_effect=[token_response, me_response],
+        ) as mock_get,
+    ):
         service = service_cls.return_value
         service.upsert_and_link.return_value = _stub_upsert_returning(MagicMock())
         client.get(f"/facebook/callback/?code=auth-code&state={state}")
@@ -875,14 +874,16 @@ def test_linkedin_callback_forwards_given_and_family_name_to_service(
     token_response = MagicMock(status_code=200)
     token_response.json.return_value = {"id_token": linkedin_id_token}
 
-    with patch(
-        "blockauth.views.linkedin_auth_views.SocialIdentityService"
-    ) as service_cls, patch(
-        "blockauth.views.linkedin_auth_views.requests.post",
-        return_value=token_response,
-    ), patch(
-        "blockauth.utils.jwt.jwks_cache.requests.get",
-        return_value=linkedin_jwks_response,
+    with (
+        patch("blockauth.views.linkedin_auth_views.SocialIdentityService") as service_cls,
+        patch(
+            "blockauth.views.linkedin_auth_views.requests.post",
+            return_value=token_response,
+        ),
+        patch(
+            "blockauth.utils.jwt.jwks_cache.requests.get",
+            return_value=linkedin_jwks_response,
+        ),
     ):
         service = service_cls.return_value
         service.upsert_and_link.return_value = _stub_upsert_returning(MagicMock())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "blockauth"
-version = "0.16.6"
+version = "0.16.7"
 description = "Comprehensive Python authentication package bridging Web2 and Web3"
 authors = [{name = "BloclabsHQ", email = "eng@bloclabs.com"}]
 license = {text = "MIT"}

--- a/uv.lock
+++ b/uv.lock
@@ -312,7 +312,7 @@ wheels = [
 
 [[package]]
 name = "blockauth"
-version = "0.16.4"
+version = "0.16.6"
 source = { editable = "." }
 dependencies = [
     { name = "argon2-cffi" },

--- a/uv.lock
+++ b/uv.lock
@@ -312,7 +312,7 @@ wheels = [
 
 [[package]]
 name = "blockauth"
-version = "0.16.6"
+version = "0.16.7"
 source = { editable = "." }
 dependencies = [
     { name = "argon2-cffi" },


### PR DESCRIPTION
Closes #167.

All four OAuth web flows silently dropped the user's name on first signup — the user model lands with \`first_name=NULL\`, \`last_name=NULL\` even though every provider returns these fields. Apple's native verify endpoint (\`/v1/auth/apple/verify/\`) was the only flow that got it right; the others were just incomplete.

## What changed per provider

| Provider | Source of name fields | Implementation |
|---|---|---|
| **Google** | OIDC id_token: \`given_name\`, \`family_name\` | View extracts both, passes via \`extra_user_fields\` |
| **LinkedIn** | OIDC id_token: \`given_name\`, \`family_name\` (Sign In with LinkedIn v2 ships these under the \`profile\` scope) | Same as Google |
| **Facebook** | Graph API \`/me?fields=...\`: \`first_name\`, \`last_name\` (both granted by \`public_profile\` — no new scope) | Graph request broadened from \`fields=id,name,email\` → \`fields=id,name,first_name,last_name,email\` |
| **Apple WEB** | First-sign-in \`user\` form_post field: \`{"name": {"firstName": ..., "lastName": ...}}\`. The id_token never carries the name (privacy by design); the \`user\` field is only present on first sign-in | New \`_parse_first_sign_in_user\` static helper + \`extra_user_fields\` |
| **Apple NATIVE** | Already correct — request body \`first_name\` / \`last_name\` | Unchanged (reference implementation) |

## Two commits

1. **\`fb413e9\`** \`fix(oauth): populate user names on OAuth signup across all 4 providers\` — view changes + tests
2. **\`9e77020\`** \`chore: bump to 0.16.7\`

## Test coverage

7 new tests, all green (789 passed total):

- \`test_oauth_views.py::test_google_callback_forwards_given_and_family_name_to_service\` — mocks SocialIdentityService, asserts the kwarg payload after a real id_token round-trip
- \`test_oauth_views.py::test_facebook_callback_forwards_first_and_last_name_to_service\` — also asserts the Graph API request includes \`first_name,last_name\` in \`fields\`
- \`test_oauth_views.py::test_linkedin_callback_forwards_given_and_family_name_to_service\` — same pattern as Google
- \`test_web_views.py::test_apple_web_callback_parses_first_sign_in_user_payload\` — happy path
- \`test_web_views.py::test_apple_web_callback_handles_missing_user_payload\` — returning sign-in
- \`test_web_views.py::test_apple_web_callback_handles_malformed_user_payload\` — defensive

Tests mock at the \`SocialIdentityService.upsert_and_link\` boundary rather than the live user model because the test user model (\`tests.TestBlockUser\` → \`AbstractBaseUser\`) does not declare \`first_name\` / \`last_name\`. The integration the view is responsible for is the kwarg payload — the service applies fields against whatever schema the integrator's user model exposes.

## Out of scope

- **Profile picture URL** — Creator model has no \`picture\` / \`avatar\` field today. Adding picture support is a separate fabric-auth model migration.
- **\`social_login_data\` legacy path** — the email-based \`get_or_create\` branch puts \`name\` (the full string) into \`first_name\`. That's also wrong, but the modern OIDC path (the one all current callers use) is the priority fix here. Legacy path stays as-is for backwards compat.

## After merge

Tag \`v0.16.7\` so fabric-auth can bump its pin in a follow-up PR.

## Sources for the field availability per provider

- Google OIDC standard claims — https://developers.google.com/identity/openid-connect/openid-connect
- Facebook Graph API \`public_profile\` permission — https://developers.facebook.com/docs/graph-api/reference/user/
- LinkedIn OIDC claims — https://learn.microsoft.com/en-us/linkedin/consumer/integrations/self-serve/sign-in-with-linkedin-v2
- Apple Sign In form_post \`user\` field — https://developer.apple.com/documentation/sign_in_with_apple/sign_in_with_apple_rest_api/authenticating_users_with_sign_in_with_apple