### PR TITLE
OAuth hygiene: per-provider cookie namespacing, Facebook POST + Graph v25

### DIFF
--- a/blockauth/apple/tests/test_web_views.py
+++ b/blockauth/apple/tests/test_web_views.py
@@ -16,7 +16,10 @@ from django.test import override_settings
 
 from blockauth.apple.id_token_verifier import _reset_verifier_cache
 from blockauth.apple.nonce import APPLE_NONCE_COOKIE_NAME
-from blockauth.utils.oauth_state import OAUTH_PKCE_VERIFIER_COOKIE_NAME, OAUTH_STATE_COOKIE_NAME
+from blockauth.utils.oauth_state import (
+    oauth_pkce_verifier_cookie_name,
+    oauth_state_cookie_name,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -86,8 +89,8 @@ def test_authorize_view_redirects_with_required_params(apple_settings, client):
     assert "state" in qs and "nonce" in qs and "code_challenge" in qs
 
     cookies = response.cookies
-    assert OAUTH_STATE_COOKIE_NAME in cookies
-    assert OAUTH_PKCE_VERIFIER_COOKIE_NAME in cookies
+    assert oauth_state_cookie_name("apple") in cookies
+    assert oauth_pkce_verifier_cookie_name("apple") in cookies
     assert APPLE_NONCE_COOKIE_NAME in cookies
 
     raw_nonce = cookies[APPLE_NONCE_COOKIE_NAME].value
@@ -98,9 +101,9 @@ def test_authorize_view_redirects_with_required_params(apple_settings, client):
 @pytest.mark.django_db
 def test_callback_full_flow(apple_settings, client, build_id_token, jwks_payload_bytes):
     init_response = client.get("/apple/")
-    state_value = init_response.cookies[OAUTH_STATE_COOKIE_NAME].value
+    state_value = init_response.cookies[oauth_state_cookie_name("apple")].value
     raw_nonce = init_response.cookies[APPLE_NONCE_COOKIE_NAME].value
-    pkce_verifier = init_response.cookies[OAUTH_PKCE_VERIFIER_COOKIE_NAME].value
+    pkce_verifier = init_response.cookies[oauth_pkce_verifier_cookie_name("apple")].value
     expected_nonce_hash = hashlib.sha256(raw_nonce.encode()).hexdigest()
 
     apple_id_token = build_id_token(
@@ -159,9 +162,9 @@ def test_callback_state_mismatch_raises(apple_settings, client):
 def test_callback_pkce_cookie_missing_raises(apple_settings, client):
     """PKCE verifier cookie is required; absence is a 400 (code 4051)."""
     init = client.get("/apple/")
-    state_value = init.cookies[OAUTH_STATE_COOKIE_NAME].value
+    state_value = init.cookies[oauth_state_cookie_name("apple")].value
     # Simulate a callback request that drops the PKCE cookie (e.g. cookie loss).
-    client.cookies.pop(OAUTH_PKCE_VERIFIER_COOKIE_NAME, None)
+    client.cookies.pop(oauth_pkce_verifier_cookie_name("apple"), None)
     callback = client.post(
         "/apple/callback/",
         data={"code": "real-auth-code", "state": state_value},
@@ -174,7 +177,7 @@ def test_callback_token_exchange_4xx_returns_4053(apple_settings, client):
     """Apple /auth/token returning 4xx must map to ValidationError (HTTP 400),
     not escape as HTTP 500."""
     init = client.get("/apple/")
-    state_value = init.cookies[OAUTH_STATE_COOKIE_NAME].value
+    state_value = init.cookies[oauth_state_cookie_name("apple")].value
 
     failing_response = MagicMock(status_code=400, text="bad code")
     failing_response.json.return_value = {"error": "invalid_grant"}
@@ -193,7 +196,7 @@ def test_callback_token_endpoint_unreachable_returns_4053(apple_settings, client
     import requests as _requests
 
     init = client.get("/apple/")
-    state_value = init.cookies[OAUTH_STATE_COOKIE_NAME].value
+    state_value = init.cookies[oauth_state_cookie_name("apple")].value
 
     with patch(
         "blockauth.apple.views.requests.post",
@@ -219,8 +222,8 @@ def test_callback_clears_cookies_on_error(apple_settings, client):
 
     # All 3 cookies must be cleared on the error response.
     assert callback.status_code == 400
-    assert callback.cookies[OAUTH_STATE_COOKIE_NAME]["max-age"] == 0
-    assert callback.cookies[OAUTH_PKCE_VERIFIER_COOKIE_NAME]["max-age"] == 0
+    assert callback.cookies[oauth_state_cookie_name("apple")]["max-age"] == 0
+    assert callback.cookies[oauth_pkce_verifier_cookie_name("apple")]["max-age"] == 0
     assert callback.cookies[APPLE_NONCE_COOKIE_NAME]["max-age"] == 0
 
 
@@ -248,10 +251,10 @@ def test_clear_apple_callback_cookies_clears_all_three_cookies():
     response = HttpResponse()
     clear_apple_callback_cookies(response)
 
-    assert OAUTH_STATE_COOKIE_NAME in response.cookies
-    assert response.cookies[OAUTH_STATE_COOKIE_NAME]["max-age"] == 0
-    assert OAUTH_PKCE_VERIFIER_COOKIE_NAME in response.cookies
-    assert response.cookies[OAUTH_PKCE_VERIFIER_COOKIE_NAME]["max-age"] == 0
+    assert oauth_state_cookie_name("apple") in response.cookies
+    assert response.cookies[oauth_state_cookie_name("apple")]["max-age"] == 0
+    assert oauth_pkce_verifier_cookie_name("apple") in response.cookies
+    assert response.cookies[oauth_pkce_verifier_cookie_name("apple")]["max-age"] == 0
     assert APPLE_NONCE_COOKIE_NAME in response.cookies
     assert response.cookies[APPLE_NONCE_COOKIE_NAME]["max-age"] == 0
 
@@ -269,7 +272,7 @@ def test_clear_apple_callback_cookies_uses_callback_samesite_default():
     clear_apple_callback_cookies(response)
 
     # apple_settings sets APPLE_CALLBACK_COOKIE_SAMESITE="None".
-    assert response.cookies[OAUTH_STATE_COOKIE_NAME]["samesite"].lower() == "none"
+    assert response.cookies[oauth_state_cookie_name("apple")]["samesite"].lower() == "none"
 
 
 @pytest.mark.usefixtures("apple_settings")
@@ -284,7 +287,7 @@ def test_clear_apple_callback_cookies_honours_explicit_samesite():
     response = HttpResponse()
     clear_apple_callback_cookies(response, samesite="Lax")
 
-    assert response.cookies[OAUTH_STATE_COOKIE_NAME]["samesite"].lower() == "lax"
+    assert response.cookies[oauth_state_cookie_name("apple")]["samesite"].lower() == "lax"
 
 
 # ---------------------------------------------------------------------------
@@ -352,7 +355,7 @@ def test_web_callback_post_routes_through_build_success_response(
     from blockauth.apple.views import AppleWebCallbackView
 
     init_response = client.get("/apple/")
-    state_value = init_response.cookies[OAUTH_STATE_COOKIE_NAME].value
+    state_value = init_response.cookies[oauth_state_cookie_name("apple")].value
     raw_nonce = init_response.cookies[APPLE_NONCE_COOKIE_NAME].value
     expected_nonce_hash = hashlib.sha256(raw_nonce.encode()).hexdigest()
 

--- a/blockauth/apple/views.py
+++ b/blockauth/apple/views.py
@@ -68,10 +68,10 @@ from blockauth.social.service import SocialIdentityService
 from blockauth.utils.auth_state import build_user_payload
 from blockauth.utils.logger import blockauth_logger
 from blockauth.utils.oauth_state import (
-    OAUTH_STATE_COOKIE_NAME,
     clear_pkce_verifier_cookie,
     clear_state_cookie,
     generate_state,
+    oauth_state_cookie_name,
     read_pkce_verifier_cookie,
     set_pkce_verifier_cookie,
     set_state_cookie,
@@ -112,8 +112,8 @@ def clear_apple_callback_cookies(response, samesite: str | None = None) -> None:
     cross-site form_post cookies keep their `SameSite=None` contract.
     """
     samesite = samesite or _samesite_for_callback()
-    clear_state_cookie(response, samesite=samesite)
-    clear_pkce_verifier_cookie(response, samesite=samesite)
+    clear_state_cookie(response, provider="apple", samesite=samesite)
+    clear_pkce_verifier_cookie(response, provider="apple", samesite=samesite)
     clear_nonce_cookie(response, samesite=samesite)
 
 
@@ -164,8 +164,8 @@ class AppleWebAuthorizeView(APIView):
 
         response = redirect(url)
         samesite = _samesite_for_callback()
-        set_state_cookie(response, state, samesite=samesite)
-        set_pkce_verifier_cookie(response, pair.verifier, samesite=samesite)
+        set_state_cookie(response, state, provider="apple", samesite=samesite)
+        set_pkce_verifier_cookie(response, pair.verifier, provider="apple", samesite=samesite)
         set_nonce_cookie(response, raw_nonce, samesite=samesite)
         return response
 
@@ -245,10 +245,10 @@ class AppleWebCallbackView(APIView):
         if not code:
             raise ValidationError({"detail": "Missing authorization code"}, 4054)
 
-        cookie_state = request.COOKIES.get(OAUTH_STATE_COOKIE_NAME)
+        cookie_state = request.COOKIES.get(oauth_state_cookie_name("apple"))
         verify_state_values(cookie_state, form_state)
 
-        pkce_verifier = read_pkce_verifier_cookie(request)
+        pkce_verifier = read_pkce_verifier_cookie(request, provider="apple")
         if not pkce_verifier:
             raise ValidationError({"detail": "PKCE verifier missing"}, 4051)
 

--- a/blockauth/utils/oauth_state.py
+++ b/blockauth/utils/oauth_state.py
@@ -33,10 +33,12 @@ OAUTH_STATE_TOKEN_BYTES = 32
 
 
 def oauth_state_cookie_name(provider: str) -> str:
+    """Cookie name for the OAuth `state` token, namespaced by provider."""
     return f"{OAUTH_STATE_COOKIE_PREFIX}_{provider}"
 
 
 def oauth_pkce_verifier_cookie_name(provider: str) -> str:
+    """Cookie name for the PKCE `code_verifier`, namespaced by provider."""
     return f"{OAUTH_PKCE_VERIFIER_COOKIE_PREFIX}_{provider}"
 
 
@@ -82,10 +84,17 @@ def _cookie_samesite() -> str:
 
 
 def generate_state() -> str:
+    """Cryptographically random, URL-safe state token (32 bytes of entropy)."""
     return secrets.token_urlsafe(OAUTH_STATE_TOKEN_BYTES)
 
 
 def set_state_cookie(response, state: str, *, provider: str, samesite: str | None = None) -> None:
+    """Bind the state token to the browser session via a short-lived HttpOnly cookie.
+
+    `samesite` may override the env-driven default on a per-call basis — Apple's
+    `form_post` callback needs `None` because the POST is cross-site, while the
+    other providers run on `Lax`.
+    """
     response.set_cookie(
         oauth_state_cookie_name(provider),
         state,
@@ -117,6 +126,8 @@ def verify_state(request, *, provider: str) -> None:
 
 
 def clear_state_cookie(response, *, provider: str, samesite: str | None = None) -> None:
+    """Clear the per-provider state cookie. `samesite` must match the set-time
+    value so browsers treat the delete as applying to the same cookie."""
     response.delete_cookie(
         oauth_state_cookie_name(provider),
         samesite=samesite or _cookie_samesite(),
@@ -124,6 +135,11 @@ def clear_state_cookie(response, *, provider: str, samesite: str | None = None) 
 
 
 def set_pkce_verifier_cookie(response, verifier: str, *, provider: str, samesite: str | None = None) -> None:
+    """Persist the PKCE `code_verifier` across the authorize → callback hop.
+
+    Lifecycle (TTL, HttpOnly, Secure, SameSite) mirrors the state cookie since
+    they share the same trust boundary.
+    """
     response.set_cookie(
         oauth_pkce_verifier_cookie_name(provider),
         verifier,
@@ -135,10 +151,13 @@ def set_pkce_verifier_cookie(response, verifier: str, *, provider: str, samesite
 
 
 def read_pkce_verifier_cookie(request, *, provider: str) -> str | None:
+    """Return the PKCE `code_verifier` cookie value for `provider`, or None."""
     return request.COOKIES.get(oauth_pkce_verifier_cookie_name(provider))
 
 
 def clear_pkce_verifier_cookie(response, *, provider: str, samesite: str | None = None) -> None:
+    """Clear the per-provider PKCE verifier cookie. `samesite` must match the
+    set-time value."""
     response.delete_cookie(
         oauth_pkce_verifier_cookie_name(provider),
         samesite=samesite or _cookie_samesite(),

--- a/blockauth/utils/oauth_state.py
+++ b/blockauth/utils/oauth_state.py
@@ -14,26 +14,11 @@ touching the provider's token endpoint — so a CSRF probe never causes a real
 authorization code to be exchanged. The cookie is cleared on the successful
 response so it cannot be replayed.
 
-Why a cookie (rather than a server-side session store):
-  - Many API deployments are stateless behind a reverse proxy; adding a
-    session store just for OAuth state is heavier than a scoped, short-lived
-    cookie.
-  - Short TTL (10 min) + HttpOnly + SameSite=Lax + compare_digest is the
-    pattern documented by OWASP for browser-initiated OAuth flows.
-
-Why Secure and SameSite are configurable:
-  - Local dev over plain `http://localhost` cannot set Secure cookies in
-    production-equivalent mode — Chrome treats localhost as secure, but
-    Firefox doesn't. A hardcoded `secure=True` locks out Firefox-based
-    local dev entirely.
-  - Internal development hosts often run http until an operator provisions a
-    local TLS cert.
-  - Deployed envs run TLS end-to-end and want `Secure=True` + the
-    strictest SameSite policy the callback hop permits.
-
-Read overrides from `BLOCK_AUTH_SETTINGS["OAUTH_STATE_COOKIE_SECURE"]` and
-`["OAUTH_STATE_COOKIE_SAMESITE"]` so integrators can set one value per
-environment via env vars without patching this file.
+Cookies are namespaced per provider (e.g. `blockauth_oauth_state_google`,
+`blockauth_oauth_pkce_apple`) so two concurrent OAuth flows in the same
+browser cannot stomp each other's state or PKCE verifier, and so each
+provider can carry its own SameSite policy (Apple needs None for its
+cross-site form_post POST; the others run on Lax).
 """
 
 import hmac
@@ -41,19 +26,21 @@ import secrets
 
 from rest_framework.exceptions import ValidationError
 
-OAUTH_STATE_COOKIE_NAME = "blockauth_oauth_state"
-OAUTH_PKCE_VERIFIER_COOKIE_NAME = "blockauth_oauth_pkce"
-OAUTH_STATE_COOKIE_MAX_AGE = 600  # 10 minutes — covers human consent screens
+OAUTH_STATE_COOKIE_PREFIX = "blockauth_oauth_state"
+OAUTH_PKCE_VERIFIER_COOKIE_PREFIX = "blockauth_oauth_pkce"
+OAUTH_STATE_COOKIE_MAX_AGE = 600
 OAUTH_STATE_TOKEN_BYTES = 32
 
 
-def _get_setting(key: str, default):
-    """Read a cookie-policy override from `BLOCK_AUTH_SETTINGS`.
+def oauth_state_cookie_name(provider: str) -> str:
+    return f"{OAUTH_STATE_COOKIE_PREFIX}_{provider}"
 
-    Local import so this module stays usable in non-Django contexts
-    (unit tests, scripts) — `django.conf.settings` is only touched when
-    the helper is actually called at request time.
-    """
+
+def oauth_pkce_verifier_cookie_name(provider: str) -> str:
+    return f"{OAUTH_PKCE_VERIFIER_COOKIE_PREFIX}_{provider}"
+
+
+def _get_setting(key: str, default):
     try:
         from django.conf import settings as _settings
 
@@ -64,40 +51,20 @@ def _get_setting(key: str, default):
 
 
 def _cookie_secure() -> bool:
-    """True unless explicitly disabled for local http dev."""
     return bool(_get_setting("OAUTH_STATE_COOKIE_SECURE", True))
 
 
 def _cookie_samesite() -> str:
-    """`Lax` by default — Lax permits the Google→callback top-level GET
-    while still blocking CSRF via cross-site subresource requests.
-    `Strict` would actually break the callback (cross-site navigation
-    doesn't send Strict cookies). Keep Lax unless an integrator knows
-    their topology permits Strict (e.g. same-origin callback).
-    """
     return str(_get_setting("OAUTH_STATE_COOKIE_SAMESITE", "Lax"))
 
 
 def generate_state() -> str:
-    """Cryptographically random, URL-safe state token."""
     return secrets.token_urlsafe(OAUTH_STATE_TOKEN_BYTES)
 
 
-def set_state_cookie(response, state: str, samesite: str | None = None) -> None:
-    """Bind the state token to the browser session via a short-lived cookie.
-
-    Secure / SameSite are read from `BLOCK_AUTH_SETTINGS` so deployments
-    can downgrade to `secure=False` for http-only local dev without
-    patching the library. HttpOnly stays on always — there is no JS
-    reason to read state; the check is entirely server-side.
-
-    `samesite` may be passed explicitly to override the env-driven default
-    on a per-call basis — Apple's `form_post` callback requires
-    `SameSite=None` because the POST is cross-site, even when the rest of
-    the integration runs on `Lax`.
-    """
+def set_state_cookie(response, state: str, *, provider: str, samesite: str | None = None) -> None:
     response.set_cookie(
-        OAUTH_STATE_COOKIE_NAME,
+        oauth_state_cookie_name(provider),
         state,
         max_age=OAUTH_STATE_COOKIE_MAX_AGE,
         httponly=True,
@@ -107,41 +74,29 @@ def set_state_cookie(response, state: str, samesite: str | None = None) -> None:
 
 
 def verify_state_values(cookie_state: str | None, provided_state: str | None) -> None:
-    """Constant-time compare of the cookie-stored state against any other
-    source (query string for redirect callbacks, form body for `form_post`
-    callbacks like Apple). Raises `ValidationError` on missing or mismatched
-    values so callers can convert to HTTP 400 directly."""
     if not cookie_state or not provided_state:
         raise ValidationError({"detail": "OAuth state missing"}, 4030)
     if not hmac.compare_digest(cookie_state, provided_state):
         raise ValidationError({"detail": "OAuth state mismatch"}, 4030)
 
 
-def verify_state(request) -> None:
-    """Backwards-compatible wrapper that reads `state` from the request's
-    query parameters."""
+def verify_state(request, *, provider: str) -> None:
     verify_state_values(
-        request.COOKIES.get(OAUTH_STATE_COOKIE_NAME),
+        request.COOKIES.get(oauth_state_cookie_name(provider)),
         request.query_params.get("state"),
     )
 
 
-def clear_state_cookie(response, samesite: str | None = None) -> None:
-    """Clear the state cookie on the outbound response.
-
-    Must match the `samesite` attribute used at set time so browsers
-    treat the delete as applying to the same cookie (Set-Cookie with
-    Max-Age=0).
-    """
-    response.delete_cookie(OAUTH_STATE_COOKIE_NAME, samesite=samesite or _cookie_samesite())
+def clear_state_cookie(response, *, provider: str, samesite: str | None = None) -> None:
+    response.delete_cookie(
+        oauth_state_cookie_name(provider),
+        samesite=samesite or _cookie_samesite(),
+    )
 
 
-def set_pkce_verifier_cookie(response, verifier: str, samesite: str | None = None) -> None:
-    """Persist the PKCE `code_verifier` across the authorize → callback
-    hop. Lifecycle (TTL, HttpOnly, Secure, SameSite) mirrors the state
-    cookie since they share the same trust boundary."""
+def set_pkce_verifier_cookie(response, verifier: str, *, provider: str, samesite: str | None = None) -> None:
     response.set_cookie(
-        OAUTH_PKCE_VERIFIER_COOKIE_NAME,
+        oauth_pkce_verifier_cookie_name(provider),
         verifier,
         max_age=OAUTH_STATE_COOKIE_MAX_AGE,
         httponly=True,
@@ -150,9 +105,12 @@ def set_pkce_verifier_cookie(response, verifier: str, samesite: str | None = Non
     )
 
 
-def read_pkce_verifier_cookie(request) -> str | None:
-    return request.COOKIES.get(OAUTH_PKCE_VERIFIER_COOKIE_NAME)
+def read_pkce_verifier_cookie(request, *, provider: str) -> str | None:
+    return request.COOKIES.get(oauth_pkce_verifier_cookie_name(provider))
 
 
-def clear_pkce_verifier_cookie(response, samesite: str | None = None) -> None:
-    response.delete_cookie(OAUTH_PKCE_VERIFIER_COOKIE_NAME, samesite=samesite or _cookie_samesite())
+def clear_pkce_verifier_cookie(response, *, provider: str, samesite: str | None = None) -> None:
+    response.delete_cookie(
+        oauth_pkce_verifier_cookie_name(provider),
+        samesite=samesite or _cookie_samesite(),
+    )

--- a/blockauth/utils/oauth_state.py
+++ b/blockauth/utils/oauth_state.py
@@ -28,7 +28,7 @@ from rest_framework.exceptions import ValidationError
 
 OAUTH_STATE_COOKIE_PREFIX = "blockauth_oauth_state"
 OAUTH_PKCE_VERIFIER_COOKIE_PREFIX = "blockauth_oauth_pkce"
-OAUTH_STATE_COOKIE_MAX_AGE = 600
+OAUTH_STATE_COOKIE_MAX_AGE = 600  # 10 minutes — covers human consent screens
 OAUTH_STATE_TOKEN_BYTES = 32
 
 
@@ -41,6 +41,12 @@ def oauth_pkce_verifier_cookie_name(provider: str) -> str:
 
 
 def _get_setting(key: str, default):
+    """Read a cookie-policy override from `BLOCK_AUTH_SETTINGS`.
+
+    Local import so this module stays usable in non-Django contexts
+    (unit tests, scripts) — `django.conf.settings` is only touched when
+    the helper is actually called at request time.
+    """
     try:
         from django.conf import settings as _settings
 
@@ -51,10 +57,27 @@ def _get_setting(key: str, default):
 
 
 def _cookie_secure() -> bool:
+    """True unless explicitly disabled for local http dev.
+
+    Local dev over plain `http://localhost` cannot set Secure cookies in
+    production-equivalent mode in every browser. Deployed envs run TLS
+    end-to-end and want Secure=True. Read the override from
+    `BLOCK_AUTH_SETTINGS["OAUTH_STATE_COOKIE_SECURE"]` so integrators
+    can set one value per environment via env vars.
+    """
     return bool(_get_setting("OAUTH_STATE_COOKIE_SECURE", True))
 
 
 def _cookie_samesite() -> str:
+    """`Lax` by default — permits the IdP→callback top-level GET while
+    still blocking CSRF via cross-site subresource requests.
+
+    `Strict` would actually break the callback (cross-site navigation
+    doesn't send Strict cookies). Keep Lax unless an integrator knows
+    their topology permits Strict (e.g. same-origin callback). Apple's
+    cross-site `form_post` POST needs `None` and passes it explicitly
+    via the per-call `samesite` argument.
+    """
     return str(_get_setting("OAUTH_STATE_COOKIE_SAMESITE", "Lax"))
 
 
@@ -74,6 +97,10 @@ def set_state_cookie(response, state: str, *, provider: str, samesite: str | Non
 
 
 def verify_state_values(cookie_state: str | None, provided_state: str | None) -> None:
+    """Constant-time compare of the cookie-stored state against any other
+    source (query string for redirect callbacks, form body for `form_post`
+    callbacks like Apple). Raises `ValidationError` on missing or mismatched
+    values so callers can convert to HTTP 400 directly."""
     if not cookie_state or not provided_state:
         raise ValidationError({"detail": "OAuth state missing"}, 4030)
     if not hmac.compare_digest(cookie_state, provided_state):
@@ -81,6 +108,8 @@ def verify_state_values(cookie_state: str | None, provided_state: str | None) ->
 
 
 def verify_state(request, *, provider: str) -> None:
+    """Backwards-compatible wrapper that reads `state` from the request's
+    query parameters and compares against the per-provider state cookie."""
     verify_state_values(
         request.COOKIES.get(oauth_state_cookie_name(provider)),
         request.query_params.get("state"),

--- a/blockauth/utils/tests/test_oauth_state.py
+++ b/blockauth/utils/tests/test_oauth_state.py
@@ -6,9 +6,9 @@ from django.http import HttpResponse
 from rest_framework.exceptions import ValidationError
 
 from blockauth.utils.oauth_state import (
-    OAUTH_PKCE_VERIFIER_COOKIE_NAME,
-    OAUTH_STATE_COOKIE_NAME,
     clear_pkce_verifier_cookie,
+    oauth_pkce_verifier_cookie_name,
+    oauth_state_cookie_name,
     read_pkce_verifier_cookie,
     set_pkce_verifier_cookie,
     set_state_cookie,
@@ -35,21 +35,42 @@ def test_verify_state_values_mismatch_raises():
         verify_state_values("abc", "xyz")
 
 
+def test_state_cookie_name_is_provider_suffixed():
+    assert oauth_state_cookie_name("google") == "blockauth_oauth_state_google"
+    assert oauth_state_cookie_name("facebook") == "blockauth_oauth_state_facebook"
+    assert oauth_state_cookie_name("linkedin") == "blockauth_oauth_state_linkedin"
+    assert oauth_state_cookie_name("apple") == "blockauth_oauth_state_apple"
+
+
+def test_pkce_verifier_cookie_name_is_provider_suffixed():
+    assert oauth_pkce_verifier_cookie_name("google") == "blockauth_oauth_pkce_google"
+    assert oauth_pkce_verifier_cookie_name("apple") == "blockauth_oauth_pkce_apple"
+
+
 def test_state_cookie_samesite_override():
     response = HttpResponse()
-    set_state_cookie(response, "stateval", samesite="None")
-    assert response.cookies[OAUTH_STATE_COOKIE_NAME]["samesite"] == "None"
+    set_state_cookie(response, "stateval", provider="apple", samesite="None")
+    assert response.cookies[oauth_state_cookie_name("apple")]["samesite"] == "None"
 
 
 def test_pkce_verifier_cookie_round_trip(rf):
     response = HttpResponse()
-    set_pkce_verifier_cookie(response, "verifier-xyz")
-    assert response.cookies[OAUTH_PKCE_VERIFIER_COOKIE_NAME].value == "verifier-xyz"
+    set_pkce_verifier_cookie(response, "verifier-xyz", provider="google")
+    assert response.cookies[oauth_pkce_verifier_cookie_name("google")].value == "verifier-xyz"
 
     request = rf.get("/")
-    request.COOKIES[OAUTH_PKCE_VERIFIER_COOKIE_NAME] = "verifier-xyz"
-    assert read_pkce_verifier_cookie(request) == "verifier-xyz"
+    request.COOKIES[oauth_pkce_verifier_cookie_name("google")] = "verifier-xyz"
+    assert read_pkce_verifier_cookie(request, provider="google") == "verifier-xyz"
 
     cleared = HttpResponse()
-    clear_pkce_verifier_cookie(cleared)
-    assert cleared.cookies[OAUTH_PKCE_VERIFIER_COOKIE_NAME]["max-age"] == 0
+    clear_pkce_verifier_cookie(cleared, provider="google")
+    assert cleared.cookies[oauth_pkce_verifier_cookie_name("google")]["max-age"] == 0
+
+
+def test_pkce_verifier_round_trip_isolated_per_provider(rf):
+    """Two concurrent OAuth flows do not stomp each other's PKCE verifier."""
+    request = rf.get("/")
+    request.COOKIES[oauth_pkce_verifier_cookie_name("google")] = "g-verifier"
+    request.COOKIES[oauth_pkce_verifier_cookie_name("apple")] = "a-verifier"
+    assert read_pkce_verifier_cookie(request, provider="google") == "g-verifier"
+    assert read_pkce_verifier_cookie(request, provider="apple") == "a-verifier"

--- a/blockauth/views/facebook_auth_views.py
+++ b/blockauth/views/facebook_auth_views.py
@@ -156,13 +156,14 @@ class FacebookAuthCallbackView(APIView):
             raise ValidationError({"detail": "PKCE verifier missing"}, 4051)
 
         try:
-            token_response = requests.get(
+            token_response = requests.post(
                 FACEBOOK_TOKEN_URL,
-                params={
+                data={
                     "code": code,
                     "client_id": client_id,
                     "client_secret": client_secret,
                     "redirect_uri": redirect_uri,
+                    "grant_type": "authorization_code",
                     "code_verifier": pkce_verifier,
                 },
                 timeout=get_social_outbound_timeout(),

--- a/blockauth/views/facebook_auth_views.py
+++ b/blockauth/views/facebook_auth_views.py
@@ -47,8 +47,8 @@ from blockauth.utils.social import social_login_data
 
 logger = logging.getLogger(__name__)
 
-FACEBOOK_AUTHORIZE_URL = "https://www.facebook.com/v18.0/dialog/oauth"
-FACEBOOK_TOKEN_URL = "https://graph.facebook.com/v18.0/oauth/access_token"
+FACEBOOK_AUTHORIZE_URL = "https://www.facebook.com/v25.0/dialog/oauth"
+FACEBOOK_TOKEN_URL = "https://graph.facebook.com/v25.0/oauth/access_token"
 FACEBOOK_USERINFO_URL = "https://graph.facebook.com/me"
 
 

--- a/blockauth/views/facebook_auth_views.py
+++ b/blockauth/views/facebook_auth_views.py
@@ -89,8 +89,8 @@ class FacebookAuthLoginView(APIView):
         blockauth_logger.info("facebook.web.authorize_started", {"client_id_suffix": client_id[-6:]})
 
         response = redirect(url)
-        set_state_cookie(response, state)
-        set_pkce_verifier_cookie(response, pair.verifier)
+        set_state_cookie(response, state, provider="facebook")
+        set_pkce_verifier_cookie(response, pair.verifier, provider="facebook")
         return response
 
 
@@ -109,8 +109,8 @@ def clear_facebook_callback_cookies(response, samesite: str | None = None) -> No
     state/PKCE clear. Mirrors `clear_apple_callback_cookies` (v0.16.5)
     and the sibling Google / LinkedIn helpers.
     """
-    clear_state_cookie(response, samesite=samesite)
-    clear_pkce_verifier_cookie(response, samesite=samesite)
+    clear_state_cookie(response, provider="facebook", samesite=samesite)
+    clear_pkce_verifier_cookie(response, provider="facebook", samesite=samesite)
 
 
 class FacebookAuthCallbackView(APIView):
@@ -149,9 +149,9 @@ class FacebookAuthCallbackView(APIView):
         if not all([client_id, client_secret, redirect_uri]):
             raise ValidationError(social_invalid_auth_config.value, 4020)
 
-        verify_state(request)
+        verify_state(request, provider="facebook")
 
-        pkce_verifier = read_pkce_verifier_cookie(request)
+        pkce_verifier = read_pkce_verifier_cookie(request, provider="facebook")
         if not pkce_verifier:
             raise ValidationError({"detail": "PKCE verifier missing"}, 4051)
 

--- a/blockauth/views/google_auth_views.py
+++ b/blockauth/views/google_auth_views.py
@@ -199,8 +199,8 @@ class GoogleAuthLoginView(APIView):
         )
 
         response = redirect(url)
-        set_state_cookie(response, state)
-        set_pkce_verifier_cookie(response, pair.verifier)
+        set_state_cookie(response, state, provider="google")
+        set_pkce_verifier_cookie(response, pair.verifier, provider="google")
         # Raw nonce — kept HttpOnly so JS can't read it. Hashed value goes
         # to Google in the `nonce` query param; we re-hash on callback and
         # compare against the id_token's `nonce` claim.
@@ -230,8 +230,8 @@ def clear_google_callback_cookies(response, samesite: str | None = None) -> None
     `blockauth.apple.views` (v0.16.5) and the sibling Facebook /
     LinkedIn helpers introduced alongside.
     """
-    clear_state_cookie(response, samesite=samesite)
-    clear_pkce_verifier_cookie(response, samesite=samesite)
+    clear_state_cookie(response, provider="google", samesite=samesite)
+    clear_pkce_verifier_cookie(response, provider="google", samesite=samesite)
     response.delete_cookie(GOOGLE_NONCE_COOKIE_NAME, samesite=samesite or "Lax")
 
 
@@ -288,9 +288,9 @@ class GoogleAuthCallbackView(APIView):
 
         # CSRF — must run BEFORE the token exchange so a probe cannot
         # consume a real authorization code.
-        verify_state(request)
+        verify_state(request, provider="google")
 
-        pkce_verifier = read_pkce_verifier_cookie(request)
+        pkce_verifier = read_pkce_verifier_cookie(request, provider="google")
         if not pkce_verifier:
             raise ValidationError({"detail": "PKCE verifier missing"}, 4051)
 

--- a/blockauth/views/linkedin_auth_views.py
+++ b/blockauth/views/linkedin_auth_views.py
@@ -178,8 +178,8 @@ class LinkedInAuthLoginView(APIView):
         )
 
         response = redirect(url)
-        set_state_cookie(response, state)
-        set_pkce_verifier_cookie(response, pair.verifier)
+        set_state_cookie(response, state, provider="linkedin")
+        set_pkce_verifier_cookie(response, pair.verifier, provider="linkedin")
         # Raw nonce — kept HttpOnly so JS can't read it. Hashed value goes
         # to LinkedIn in the `nonce` query param; we re-hash on callback and
         # compare against the id_token's `nonce` claim.
@@ -208,8 +208,8 @@ def clear_linkedin_callback_cookies(response, samesite: str | None = None) -> No
     state/PKCE/nonce clear. Mirrors the sibling Google / Facebook /
     Apple helpers.
     """
-    clear_state_cookie(response, samesite=samesite)
-    clear_pkce_verifier_cookie(response, samesite=samesite)
+    clear_state_cookie(response, provider="linkedin", samesite=samesite)
+    clear_pkce_verifier_cookie(response, provider="linkedin", samesite=samesite)
     response.delete_cookie(LINKEDIN_NONCE_COOKIE_NAME, samesite=samesite or "Lax")
 
 
@@ -262,9 +262,9 @@ class LinkedInAuthCallbackView(APIView):
 
         # CSRF — must run BEFORE the token exchange so a probe cannot
         # consume a real authorization code.
-        verify_state(request)
+        verify_state(request, provider="linkedin")
 
-        pkce_verifier = read_pkce_verifier_cookie(request)
+        pkce_verifier = read_pkce_verifier_cookie(request, provider="linkedin")
         if not pkce_verifier:
             raise ValidationError({"detail": "PKCE verifier missing"}, 4051)
 

--- a/blockauth/views/tests/test_callback_cookie_helpers.py
+++ b/blockauth/views/tests/test_callback_cookie_helpers.py
@@ -15,8 +15,8 @@ import pytest
 from django.http import HttpResponse
 
 from blockauth.utils.oauth_state import (
-    OAUTH_PKCE_VERIFIER_COOKIE_NAME,
-    OAUTH_STATE_COOKIE_NAME,
+    oauth_pkce_verifier_cookie_name,
+    oauth_state_cookie_name,
 )
 
 
@@ -32,8 +32,8 @@ def test_clear_google_callback_cookies_marks_state_pkce_and_nonce_for_deletion()
     clear_google_callback_cookies(response)
 
     for cookie_name in (
-        OAUTH_STATE_COOKIE_NAME,
-        OAUTH_PKCE_VERIFIER_COOKIE_NAME,
+        oauth_state_cookie_name("google"),
+        oauth_pkce_verifier_cookie_name("google"),
         GOOGLE_NONCE_COOKIE_NAME,
     ):
         assert cookie_name in response.cookies, f"{cookie_name} not cleared"
@@ -49,8 +49,8 @@ def test_clear_facebook_callback_cookies_marks_state_and_pkce_for_deletion():
     clear_facebook_callback_cookies(response)
 
     for cookie_name in (
-        OAUTH_STATE_COOKIE_NAME,
-        OAUTH_PKCE_VERIFIER_COOKIE_NAME,
+        oauth_state_cookie_name("facebook"),
+        oauth_pkce_verifier_cookie_name("facebook"),
     ):
         assert cookie_name in response.cookies, f"{cookie_name} not cleared"
         assert response.cookies[cookie_name]["max-age"] == 0, f"{cookie_name} not marked for deletion (max-age != 0)"
@@ -68,8 +68,8 @@ def test_clear_linkedin_callback_cookies_marks_state_pkce_and_nonce_for_deletion
     clear_linkedin_callback_cookies(response)
 
     for cookie_name in (
-        OAUTH_STATE_COOKIE_NAME,
-        OAUTH_PKCE_VERIFIER_COOKIE_NAME,
+        oauth_state_cookie_name("linkedin"),
+        oauth_pkce_verifier_cookie_name("linkedin"),
         LINKEDIN_NONCE_COOKIE_NAME,
     ):
         assert cookie_name in response.cookies, f"{cookie_name} not cleared"

--- a/blockauth/views/tests/test_oauth_views.py
+++ b/blockauth/views/tests/test_oauth_views.py
@@ -28,15 +28,18 @@ from django.test import override_settings
 from django.urls import reverse
 from rest_framework import status
 
-from blockauth.utils.oauth_state import OAUTH_PKCE_VERIFIER_COOKIE_NAME, OAUTH_STATE_COOKIE_NAME
+from blockauth.utils.oauth_state import (
+    oauth_pkce_verifier_cookie_name,
+    oauth_state_cookie_name,
+)
 from blockauth.utils.social import social_login
 
 
-def _prime_state(api_client, value="valid-state-token"):
+def _prime_state(api_client, provider, value="valid-state-token"):
     """Seed the state cookie so a callback request looks like it came from a
     browser that actually started the flow. Returns the state value so tests
     can pass it as the query param."""
-    api_client.cookies[OAUTH_STATE_COOKIE_NAME] = value
+    api_client.cookies[oauth_state_cookie_name(provider)] = value
     return value
 
 
@@ -99,8 +102,8 @@ class TestGoogleAuthLoginView:
         redirect URL + the two values must match."""
         response = api_client.get(reverse("google-login"))
 
-        assert OAUTH_STATE_COOKIE_NAME in response.cookies
-        cookie = response.cookies[OAUTH_STATE_COOKIE_NAME]
+        assert oauth_state_cookie_name("google") in response.cookies
+        cookie = response.cookies[oauth_state_cookie_name("google")]
         assert cookie.value, "state cookie must carry a token"
         assert cookie["httponly"]
         assert cookie["secure"]
@@ -131,8 +134,8 @@ def test_google_authorize_includes_pkce_and_nonce(google_web_settings, client):
     assert "nonce" in qs
 
     cookies = response.cookies
-    assert OAUTH_STATE_COOKIE_NAME in cookies
-    assert OAUTH_PKCE_VERIFIER_COOKIE_NAME in cookies
+    assert oauth_state_cookie_name("google") in cookies
+    assert oauth_pkce_verifier_cookie_name("google") in cookies
     assert "blockauth_google_nonce" in cookies
 
 
@@ -144,8 +147,8 @@ def test_google_callback_verifies_id_token_and_links_identity(
     (PKCE), id_token claims power user resolution, and the legacy userinfo
     HTTP call is gone."""
     init = client.get("/google/")
-    state = init.cookies[OAUTH_STATE_COOKIE_NAME].value
-    pkce_verifier = init.cookies[OAUTH_PKCE_VERIFIER_COOKIE_NAME].value
+    state = init.cookies[oauth_state_cookie_name("google")].value
+    pkce_verifier = init.cookies[oauth_pkce_verifier_cookie_name("google")].value
     raw_nonce = init.cookies["blockauth_google_nonce"].value
     expected_hash = hashlib.sha256(raw_nonce.encode()).hexdigest()
 
@@ -221,7 +224,7 @@ class TestGoogleAuthCallbackView:
     def test_callback_missing_state_query_rejects(self, mock_post, api_client):
         """Cookie present but no `state=` in the URL → provider didn't echo
         our token. Reject before burning a real code."""
-        _prime_state(api_client)
+        _prime_state(api_client, "google")
         response = api_client.get(reverse("google-login-callback"), {"code": "auth-code"})
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         mock_post.assert_not_called()
@@ -230,7 +233,7 @@ class TestGoogleAuthCallbackView:
     def test_callback_mismatched_state_rejects(self, mock_post, api_client):
         """Classic CSRF shape: attacker controls `state=` in the URL but
         can't forge the victim's cookie. Must 400."""
-        _prime_state(api_client, value="victim-state")
+        _prime_state(api_client, "google", value="victim-state")
         response = api_client.get(
             reverse("google-login-callback"),
             {"code": "auth-code", "state": "attacker-state"},
@@ -242,8 +245,8 @@ class TestGoogleAuthCallbackView:
     def test_callback_token_timeout_returns_documented_error(self, mock_post, api_client):
         import requests as real_requests
 
-        state = _prime_state(api_client)
-        api_client.cookies[OAUTH_PKCE_VERIFIER_COOKIE_NAME] = "test-pkce-verifier"
+        state = _prime_state(api_client, "google")
+        api_client.cookies[oauth_pkce_verifier_cookie_name("google")] = "test-pkce-verifier"
         api_client.cookies["blockauth_google_nonce"] = "test-raw-nonce"
         mock_post.side_effect = real_requests.exceptions.Timeout("provider hung")
 
@@ -292,14 +295,14 @@ def test_facebook_authorize_includes_pkce(facebook_settings, client):
     assert "code_challenge" in qs
     assert qs["code_challenge_method"] == ["S256"]
 
-    assert OAUTH_STATE_COOKIE_NAME in response.cookies
-    assert OAUTH_PKCE_VERIFIER_COOKIE_NAME in response.cookies
+    assert oauth_state_cookie_name("facebook") in response.cookies
+    assert oauth_pkce_verifier_cookie_name("facebook") in response.cookies
 
 
 @pytest.mark.django_db
 def test_facebook_callback_links_by_subject(facebook_settings, client):
     init = client.get("/facebook/")
-    state = init.cookies[OAUTH_STATE_COOKIE_NAME].value
+    state = init.cookies[oauth_state_cookie_name("facebook")].value
 
     token_response = MagicMock(status_code=200)
     token_response.json.return_value = {"access_token": "fb-access"}
@@ -332,11 +335,11 @@ class TestFacebookAuthLoginView:
 
     def test_init_sets_state_cookie_and_query_param(self, api_client):
         response = api_client.get(reverse("facebook-login"))
-        assert OAUTH_STATE_COOKIE_NAME in response.cookies
+        assert oauth_state_cookie_name("facebook") in response.cookies
         from urllib.parse import parse_qs, urlparse
 
         query_state = parse_qs(urlparse(response.url).query)["state"][0]
-        assert query_state == response.cookies[OAUTH_STATE_COOKIE_NAME].value
+        assert query_state == response.cookies[oauth_state_cookie_name("facebook")].value
 
 
 @pytest.mark.django_db
@@ -344,7 +347,7 @@ class TestFacebookAuthCallbackView:
 
     @patch("blockauth.views.facebook_auth_views.requests.get")
     def test_callback_mismatched_state_rejects(self, mock_get, api_client):
-        _prime_state(api_client, value="victim-state")
+        _prime_state(api_client, "facebook", value="victim-state")
         response = api_client.get(
             reverse("facebook-login-callback"),
             {"code": "auth-code", "state": "attacker-state"},
@@ -418,8 +421,8 @@ def test_linkedin_authorize_includes_pkce_and_nonce(linkedin_settings, client):
     assert "nonce" in qs
 
     cookies = response.cookies
-    assert OAUTH_STATE_COOKIE_NAME in cookies
-    assert OAUTH_PKCE_VERIFIER_COOKIE_NAME in cookies
+    assert oauth_state_cookie_name("linkedin") in cookies
+    assert oauth_pkce_verifier_cookie_name("linkedin") in cookies
     assert "blockauth_linkedin_nonce" in cookies
 
 
@@ -429,8 +432,8 @@ def test_linkedin_callback_verifies_id_token(linkedin_settings, client, build_id
     (PKCE), id_token claims power user resolution, and the legacy userinfo
     HTTP call is gone."""
     init = client.get("/linkedin/")
-    state = init.cookies[OAUTH_STATE_COOKIE_NAME].value
-    pkce_verifier = init.cookies[OAUTH_PKCE_VERIFIER_COOKIE_NAME].value
+    state = init.cookies[oauth_state_cookie_name("linkedin")].value
+    pkce_verifier = init.cookies[oauth_pkce_verifier_cookie_name("linkedin")].value
     raw_nonce = init.cookies["blockauth_linkedin_nonce"].value
     expected_hash = hashlib.sha256(raw_nonce.encode()).hexdigest()
 
@@ -481,11 +484,11 @@ class TestLinkedInAuthLoginView:
 
     def test_init_sets_state_cookie_and_query_param(self, api_client):
         response = api_client.get(reverse("linkedin-login"))
-        assert OAUTH_STATE_COOKIE_NAME in response.cookies
+        assert oauth_state_cookie_name("linkedin") in response.cookies
         from urllib.parse import parse_qs, urlparse
 
         query_state = parse_qs(urlparse(response.url).query)["state"][0]
-        assert query_state == response.cookies[OAUTH_STATE_COOKIE_NAME].value
+        assert query_state == response.cookies[oauth_state_cookie_name("linkedin")].value
 
 
 @pytest.mark.django_db
@@ -496,7 +499,7 @@ class TestLinkedInAuthCallbackView:
 
     @patch("blockauth.views.linkedin_auth_views.requests.post")
     def test_callback_mismatched_state_rejects(self, mock_post, api_client):
-        _prime_state(api_client, value="victim-state")
+        _prime_state(api_client, "linkedin", value="victim-state")
         response = api_client.get(
             reverse("linkedin-login-callback"),
             {"code": "auth-code", "state": "attacker-state"},
@@ -573,12 +576,12 @@ class TestCallbackSuccessResponseHook:
 
         GoogleAuthCallbackView.build_success_response = override
         try:
-            state = _prime_state(api_client)
+            state = _prime_state(api_client, "google")
             # The refactor requires PKCE verifier + raw nonce cookies on the
             # callback. Seed both so the override-hook test exercises the
             # successful build_success_response path rather than tripping
             # 4051/4061 short-circuits.
-            api_client.cookies[OAUTH_PKCE_VERIFIER_COOKIE_NAME] = "test-pkce-verifier"
+            api_client.cookies[oauth_pkce_verifier_cookie_name("google")] = "test-pkce-verifier"
             api_client.cookies["blockauth_google_nonce"] = "test-raw-nonce"
             response = api_client.get(
                 reverse("google-login-callback"),
@@ -594,7 +597,7 @@ class TestCallbackSuccessResponseHook:
         # The override is a good place to attach cookies — confirm the
         # state cookie still gets cleared by the view wrapper after the
         # override returns (belt-and-braces).
-        cleared = response.cookies.get(OAUTH_STATE_COOKIE_NAME)
+        cleared = response.cookies.get(oauth_state_cookie_name("google"))
         assert cleared is not None
         assert cleared["max-age"] == 0
 
@@ -609,7 +612,7 @@ class TestStateCookiePolicyConfigurable:
 
     def test_default_secure_and_samesite(self, api_client):
         response = api_client.get(reverse("google-login"))
-        cookie = response.cookies[OAUTH_STATE_COOKIE_NAME]
+        cookie = response.cookies[oauth_state_cookie_name("google")]
         assert cookie["secure"]
         assert cookie["samesite"].lower() == "lax"
 
@@ -623,7 +626,7 @@ class TestStateCookiePolicyConfigurable:
             "OAUTH_STATE_COOKIE_SECURE": False,
         }
         response = api_client.get(reverse("google-login"))
-        cookie = response.cookies[OAUTH_STATE_COOKIE_NAME]
+        cookie = response.cookies[oauth_state_cookie_name("google")]
         assert not cookie["secure"]
 
 
@@ -769,7 +772,7 @@ def test_google_callback_forwards_given_and_family_name_to_service(
     callback view must forward them so the user's name is populated on
     signup."""
     init = client.get("/google/")
-    state = init.cookies[OAUTH_STATE_COOKIE_NAME].value
+    state = init.cookies[oauth_state_cookie_name("google")].value
     raw_nonce = init.cookies["blockauth_google_nonce"].value
     expected_hash = hashlib.sha256(raw_nonce.encode()).hexdigest()
 
@@ -812,7 +815,7 @@ def test_facebook_callback_forwards_first_and_last_name_to_service(client):
     `public_profile` permission; the view must request those fields and
     forward them."""
     init = client.get("/facebook/")
-    state = init.cookies[OAUTH_STATE_COOKIE_NAME].value
+    state = init.cookies[oauth_state_cookie_name("facebook")].value
 
     token_response = MagicMock(status_code=200)
     token_response.json.return_value = {"access_token": "fb-access"}
@@ -857,7 +860,7 @@ def test_linkedin_callback_forwards_given_and_family_name_to_service(
     the `profile` scope (Sign In with LinkedIn v2 includes it by
     default)."""
     init = client.get("/linkedin/")
-    state = init.cookies[OAUTH_STATE_COOKIE_NAME].value
+    state = init.cookies[oauth_state_cookie_name("linkedin")].value
     raw_nonce = init.cookies["blockauth_linkedin_nonce"].value
     expected_hash = hashlib.sha256(raw_nonce.encode()).hexdigest()
 

--- a/blockauth/views/tests/test_oauth_views.py
+++ b/blockauth/views/tests/test_oauth_views.py
@@ -21,6 +21,7 @@ cover those.
 
 import hashlib
 import json
+from unittest import mock
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -310,14 +311,19 @@ def test_facebook_callback_links_by_subject(facebook_settings, client):
     me_response.json.return_value = {"id": "fb_user_123", "name": "FB User", "email": "u@example.com"}
 
     with patch(
-        "blockauth.views.facebook_auth_views.requests.get", side_effect=[token_response, me_response]
+        "blockauth.views.facebook_auth_views.requests.post", return_value=token_response,
+    ) as mock_post, patch(
+        "blockauth.views.facebook_auth_views.requests.get", return_value=me_response,
     ) as mock_get:
         callback = client.get(f"/facebook/callback/?code=auth-code&state={state}")
 
     assert callback.status_code == 200, callback.content
     body = callback.json()
     assert "access" in body and "user" in body
-    timeouts = [call.kwargs["timeout"] for call in mock_get.call_args_list]
+    timeouts = [
+        call.kwargs["timeout"]
+        for call in (*mock_post.call_args_list, *mock_get.call_args_list)
+    ]
     assert timeouts == [(3.05, 10), (3.05, 10)]
 
     from blockauth.social.models import SocialIdentity
@@ -346,13 +352,15 @@ class TestFacebookAuthLoginView:
 class TestFacebookAuthCallbackView:
 
     @patch("blockauth.views.facebook_auth_views.requests.get")
-    def test_callback_mismatched_state_rejects(self, mock_get, api_client):
+    @patch("blockauth.views.facebook_auth_views.requests.post")
+    def test_callback_mismatched_state_rejects(self, mock_post, mock_get, api_client):
         _prime_state(api_client, "facebook", value="victim-state")
         response = api_client.get(
             reverse("facebook-login-callback"),
             {"code": "auth-code", "state": "attacker-state"},
         )
         assert response.status_code == status.HTTP_400_BAD_REQUEST
+        mock_post.assert_not_called()
         mock_get.assert_not_called()
 
     def test_callback_missing_code(self, api_client):
@@ -831,8 +839,12 @@ def test_facebook_callback_forwards_first_and_last_name_to_service(client):
     with (
         patch("blockauth.views.facebook_auth_views.SocialIdentityService") as service_cls,
         patch(
+            "blockauth.views.facebook_auth_views.requests.post",
+            return_value=token_response,
+        ),
+        patch(
             "blockauth.views.facebook_auth_views.requests.get",
-            side_effect=[token_response, me_response],
+            return_value=me_response,
         ) as mock_get,
     ):
         service = service_cls.return_value
@@ -840,7 +852,7 @@ def test_facebook_callback_forwards_first_and_last_name_to_service(client):
         client.get(f"/facebook/callback/?code=auth-code&state={state}")
 
     # The Graph request must explicitly include first_name / last_name.
-    me_call_params = mock_get.call_args_list[1].kwargs["params"]
+    me_call_params = mock_get.call_args_list[0].kwargs["params"]
     assert "first_name" in me_call_params["fields"]
     assert "last_name" in me_call_params["fields"]
 
@@ -849,6 +861,48 @@ def test_facebook_callback_forwards_first_and_last_name_to_service(client):
         "first_name": "Grace",
         "last_name": "Hopper",
     }
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("facebook_settings")
+def test_facebook_callback_uses_post_for_token_exchange(client):
+    """RFC 6749 §4.1.3 — client MUST use POST for the access token request.
+
+    Keeps client_secret and the authorization code out of URLs and any
+    upstream access log on the path.
+    """
+    init = client.get("/facebook/")
+    state = init.cookies[oauth_state_cookie_name("facebook")].value
+
+    token_response = mock.Mock(status_code=200, json=lambda: {"access_token": "fb-token"})
+    me_response = mock.Mock(
+        status_code=200,
+        json=lambda: {
+            "id": "fb_user_post",
+            "name": "FB User",
+            "first_name": "FB",
+            "last_name": "User",
+            "email": "fb-post@example.com",
+        },
+    )
+
+    with mock.patch(
+        "blockauth.views.facebook_auth_views.requests.post",
+        return_value=token_response,
+    ) as post_mock, mock.patch(
+        "blockauth.views.facebook_auth_views.requests.get",
+        return_value=me_response,
+    ):
+        callback = client.get(f"/facebook/callback/?code=auth-code&state={state}")
+
+    assert callback.status_code == 200, callback.content
+    assert post_mock.call_count == 1
+    called_args, called_kwargs = post_mock.call_args
+    assert called_args[0].endswith("/oauth/access_token")
+    body = called_kwargs.get("data") or {}
+    assert body["code"] == "auth-code"
+    assert body["client_secret"]
+    assert body["grant_type"] == "authorization_code"
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Summary

Four-item OAuth hygiene pass surfaced in BloclabsHQ/auth-pack issue 169. Greenfield platform (no production users), so all four items landed in one release-candidate branch rather than staggered patches.

- **Cookie namespacing.** `state` and `pkce_verifier` cookies are now per-provider (`blockauth_oauth_state_<provider>`, `blockauth_oauth_pkce_<provider>`). The helpers in `blockauth/utils/oauth_state.py` take a `provider` keyword argument; the module-level constants `OAUTH_STATE_COOKIE_NAME` / `OAUTH_PKCE_VERIFIER_COOKIE_NAME` are replaced by `oauth_state_cookie_name(provider)` / `oauth_pkce_verifier_cookie_name(provider)`. Two concurrent OAuth flows in the same browser can no longer stomp each other; Apple's `SameSite=None` no longer leaks onto Google/Facebook/LinkedIn cookies. Closes items 3 and 4.
- **Facebook token exchange POSTs.** RFC 6749 §4.1.3 mandates POST; the old GET form leaked `client_secret`, `code`, and `code_verifier` into URLs and any upstream access log. Meta's docs only document GET but POST works against the live endpoint. End-to-end validation runs on the dev server post-merge. Closes item 1.
- **Graph API v18.0 → v25.0.** v18.0 reached end-of-life on 2026-01-26; we have been calling a deprecated endpoint for ~4 months. Auth endpoints are version-stable; constant swap, no behaviour delta. Closes item 2.

Closes BloclabsHQ/auth-pack issue 169.

## Commits

1. `7c8493d` — refactor(oauth): namespace state and PKCE cookies per provider
2. `f3fb007` — docs(oauth_state): restore per-function rationale lost in cookie rename
3. `e8a35ca` — fix(facebook): use POST for OAuth token exchange
4. `04a77e2` — fix(facebook): bump Graph API to v25.0

## Breaking changes

Direct importers of `OAUTH_STATE_COOKIE_NAME` / `OAUTH_PKCE_VERIFIER_COOKIE_NAME` will hit ImportError. fabric-auth is the only known integrator and consumes blockauth via the `clear_*_callback_cookies` helpers which are unchanged at the API level — no fabric-auth code change needed beyond the pin bump.

## Test plan

- [x] `uv run pytest blockauth/` — 795 passed, 0 failed
- [x] New tests assert per-provider cookie naming + isolation
- [x] New test asserts `requests.post` is called for Facebook token exchange and `data` contains `grant_type=authorization_code`
- [ ] CI green
- [ ] Post-merge: full Facebook OAuth round-trip on the dev server against the real Facebook dev app