### PR TITLE
chore(release): v0.16.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,16 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — pre-1
 
 ---
 
+## [0.16.8] - 2026-05-14
+
+### Changed
+
+- **Breaking:** OAuth `state` and `pkce_verifier` cookies are now namespaced per provider. Cookie names become `blockauth_oauth_state_<provider>` and `blockauth_oauth_pkce_<provider>`. The helpers in `blockauth.utils.oauth_state` (`set_state_cookie`, `clear_state_cookie`, `set_pkce_verifier_cookie`, `read_pkce_verifier_cookie`, `clear_pkce_verifier_cookie`, `verify_state`) now require a `provider` keyword argument. The module-level constants `OAUTH_STATE_COOKIE_NAME` and `OAUTH_PKCE_VERIFIER_COOKIE_NAME` are removed; use the new `oauth_state_cookie_name(provider)` and `oauth_pkce_verifier_cookie_name(provider)` helpers. Two concurrent OAuth flows in the same browser can no longer stomp each other's state or PKCE verifier, and Apple's `SameSite=None` no longer leaks onto Google/Facebook/LinkedIn cookies. Integrators that import the removed constants directly must migrate to the new helpers.
+- `FacebookAuthCallbackView` token exchange now uses POST per RFC 6749 §4.1.3; the previous GET form leaked `client_secret`, `code`, and `code_verifier` into URLs and any upstream access log. The POST body includes an explicit `grant_type=authorization_code` field.
+- Facebook Graph API constants bumped from `v18.0` to `v25.0`. v18.0 reached end-of-life on 2026-01-26. `FACEBOOK_USERINFO_URL` stays version-less.
+
+---
+
 ## [0.16.7] - 2026-05-12
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "blockauth"
-version = "0.16.7"
+version = "0.16.8"
 description = "Comprehensive Python authentication package bridging Web2 and Web3"
 authors = [{name = "BloclabsHQ", email = "eng@bloclabs.com"}]
 license = {text = "MIT"}


### PR DESCRIPTION
Release-prep for the OAuth hygiene changes merged in #170 (per-provider cookie namespacing, Facebook token exchange via POST, Graph API v25). Bumps `pyproject.toml` from `0.16.7` to `0.16.8` and adds the matching `CHANGELOG.md` entry. No code change.

## Heads-up on the version bump

The CHANGELOG header reads *"pre-1.0, breaking changes increment the minor version"*. This release removes the module-level constants `OAUTH_STATE_COOKIE_NAME` and `OAUTH_PKCE_VERIFIER_COOKIE_NAME`, which is a breaking change for direct importers (fabric-auth has three test files affected). Per that stated policy this would normally be `0.17.0`; using `0.16.8` here is a deliberate choice on Pramod's call since fabric-auth is the only known integrator and is being migrated in lockstep.

## Test plan

- [x] No code change; existing CI suite is the only gate
- [ ] CI green
- [ ] After merge: tag `v0.16.8` on `dev`, then open the fabric-auth pin-bump PR