### PR TITLE
fix(totp): resume an abandoned PENDING enrollment (release 0.16.9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,15 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — pre-1
 
 ---
 
+## [0.16.9] - 2026-05-28
+
+### Fixed
+
+- TOTP setup is now idempotent over an unconfirmed enrollment. Calling `TOTPService.setup_totp()` (POST `/totp/setup/`) again while a `PENDING_CONFIRMATION` device exists regenerates the secret and backup codes and returns a fresh setup payload, instead of dead-ending with `TOTPAlreadyEnabledError` (HTTP 409). `DjangoTOTP2FAStore.create()` now reserves the conflict for genuinely `ENABLED` devices and replaces disabled or unconfirmed configurations, so an abandoned setup no longer locks the user out of re-enrolling. Adds direct DB-backed coverage for the storage layer in `blockauth/totp/tests/test_django_storage.py`.
+- Restored `blockauth.__version__` so it matches the packaged `pyproject.toml` version; it had lagged at `0.16.7` through the `0.16.8` release.
+
+---
+
 ## [0.16.8] - 2026-05-14
 
 ### Changed

--- a/blockauth/__init__.py
+++ b/blockauth/__init__.py
@@ -28,7 +28,7 @@ Static utilities (no storage needed):
     backup_codes = TOTPService.generate_backup_codes()
 """
 
-__version__ = "0.16.7"
+__version__ = "0.16.9"
 
 # =============================================================================
 # Direct imports (Django-independent, no AppRegistryNotReady errors)

--- a/blockauth/totp/storage/base.py
+++ b/blockauth/totp/storage/base.py
@@ -93,7 +93,9 @@ class ITOTP2FAStore(ABC):
             Created TOTP2FAData
 
         Raises:
-            TOTPAlreadyEnabledError: If TOTP already exists for user
+            TOTPAlreadyEnabledError: If an enabled TOTP device already exists
+                for the user. A disabled or unconfirmed (pending) configuration
+                is replaced rather than rejected.
         """
 
     @abstractmethod

--- a/blockauth/totp/storage/django_storage.py
+++ b/blockauth/totp/storage/django_storage.py
@@ -74,9 +74,16 @@ class DjangoTOTP2FAStore(ITOTP2FAStore):
         status: str = "pending_confirmation",
     ) -> TOTP2FAData:
         """Create a new TOTP configuration."""
-        # Check if already exists
-        existing = self.get_by_user_id(user_id)
-        if existing and existing.status != TOTPStatus.DISABLED.value:
+        # Lock any existing row for this user up front (within this atomic block)
+        # so a concurrent confirm/enable cannot slip an ENABLED device in between
+        # this guard and the delete below. Only a fully ENABLED device blocks
+        # re-creation; a DISABLED row (after disable) or an unconfirmed
+        # PENDING_CONFIRMATION row (setup started but never confirmed) is safe to
+        # overwrite — the user is (re)enrolling, so reserve the conflict for
+        # genuinely enabled devices. select_for_update takes a row lock on
+        # PostgreSQL and is a harmless no-op on SQLite (which serializes writes).
+        existing = TOTP2FA.objects.select_for_update().filter(user_id=user_id).first()
+        if existing and existing.status == TOTPStatus.ENABLED.value:
             raise TOTPAlreadyEnabledError()
 
         try:
@@ -84,9 +91,10 @@ class DjangoTOTP2FAStore(ITOTP2FAStore):
             User = get_user_model()
             user = User.objects.get(pk=user_id)
 
-            # Delete existing disabled config if any
+            # Replace any existing non-enabled row (disabled or pending) so setup
+            # regenerates a fresh secret and backup codes.
             if existing:
-                TOTP2FA.objects.filter(user_id=user_id).delete()
+                existing.delete()
 
             # Create new config
             totp = TOTP2FA.objects.create(

--- a/blockauth/totp/tests/test_django_storage.py
+++ b/blockauth/totp/tests/test_django_storage.py
@@ -1,0 +1,135 @@
+"""
+Django ORM storage tests for TOTP 2FA.
+
+Exercises ``DjangoTOTP2FAStore`` directly against the database (the service
+suite covers ``TOTPService`` against an in-memory mock). Focuses on the
+re-creation contract: which existing rows block ``create`` and which are
+safely replaced.
+
+Uses Django's ``get_user_model()`` (which resolves to the test environment's
+``auth.User``) — matching ``social/tests/`` and the ``settings.AUTH_USER_MODEL``
+FK on ``TOTP2FA``.
+"""
+
+import pytest
+from django.contrib.auth import get_user_model
+
+from blockauth.totp.constants import TOTPStatus
+from blockauth.totp.exceptions import TOTPAlreadyEnabledError
+from blockauth.totp.models import TOTP2FA
+from blockauth.totp.services.encryption import FernetSecretEncryption
+from blockauth.totp.services.totp_service import TOTPService
+from blockauth.totp.storage.django_storage import DjangoTOTP2FAStore
+
+User = get_user_model()
+
+
+def _make_user(username: str = "totp_user") -> "User":
+    return User.objects.create_user(username=username, email=f"{username}@example.com", password="pw")
+
+
+# =============================================================================
+# Store.create re-creation contract
+# =============================================================================
+
+
+@pytest.mark.django_db
+def test_create_replaces_unconfirmed_pending_row():
+    """An unconfirmed PENDING_CONFIRMATION row is resumable: a second create
+    overwrites it (fresh secret) instead of raising."""
+    store = DjangoTOTP2FAStore()
+    user = _make_user()
+    uid = str(user.pk)
+
+    store.create(user_id=uid, encrypted_secret="enc:first", status=TOTPStatus.PENDING_CONFIRMATION.value)
+
+    # Setup started but never confirmed → starting over must succeed.
+    data = store.create(user_id=uid, encrypted_secret="enc:second", status=TOTPStatus.PENDING_CONFIRMATION.value)
+
+    assert data.status == TOTPStatus.PENDING_CONFIRMATION.value
+    assert data.encrypted_secret == "enc:second"
+    # The stale row is replaced, not duplicated (user FK is OneToOne).
+    assert TOTP2FA.objects.filter(user_id=user.pk).count() == 1
+
+
+@pytest.mark.django_db
+def test_create_replaces_disabled_row():
+    """A DISABLED row is replaced on create (re-enrollment after disable)."""
+    store = DjangoTOTP2FAStore()
+    user = _make_user()
+    uid = str(user.pk)
+
+    store.create(user_id=uid, encrypted_secret="enc:first", status=TOTPStatus.PENDING_CONFIRMATION.value)
+    store.update_status(uid, TOTPStatus.DISABLED.value)
+
+    data = store.create(user_id=uid, encrypted_secret="enc:second", status=TOTPStatus.PENDING_CONFIRMATION.value)
+
+    assert data.encrypted_secret == "enc:second"
+    assert TOTP2FA.objects.filter(user_id=user.pk).count() == 1
+
+
+@pytest.mark.django_db
+def test_create_rejects_enabled_row():
+    """A genuinely ENABLED device still blocks create with a 409-mapped error."""
+    store = DjangoTOTP2FAStore()
+    user = _make_user()
+    uid = str(user.pk)
+
+    store.create(user_id=uid, encrypted_secret="enc:first", status=TOTPStatus.PENDING_CONFIRMATION.value)
+    store.update_status(uid, TOTPStatus.ENABLED.value)
+
+    with pytest.raises(TOTPAlreadyEnabledError):
+        store.create(user_id=uid, encrypted_secret="enc:second", status=TOTPStatus.PENDING_CONFIRMATION.value)
+
+    # The enabled row is untouched.
+    assert store.get_by_user_id(uid).encrypted_secret == "enc:first"
+
+
+# =============================================================================
+# Service + Django store integration (the reported repro)
+# =============================================================================
+
+
+def _service() -> TOTPService:
+    return TOTPService(
+        store=DjangoTOTP2FAStore(),
+        encryption_service=FernetSecretEncryption(master_key="test-master-key-12345"),
+    )
+
+
+@pytest.mark.django_db
+def test_setup_totp_resumes_unconfirmed_enrollment():
+    """setup_totp() over an unconfirmed enrollment regenerates the secret and
+    stays pending, rather than dead-ending on TOTPAlreadyEnabledError."""
+    service = _service()
+    user = _make_user()
+    uid = str(user.pk)
+
+    first = service.setup_totp(user_id=uid, account_name="totp_user@example.com")
+    second = service.setup_totp(user_id=uid, account_name="totp_user@example.com")
+
+    assert second.secret != first.secret
+    # The abandoned enrollment's backup codes are invalidated and a fresh set is
+    # issued — the row is deleted and repopulated, not merged.
+    assert set(second.backup_codes) != set(first.backup_codes)
+    assert service.get_backup_codes_remaining(uid) == service.config.backup_codes_count
+    assert service.get_status(uid) == TOTPStatus.PENDING_CONFIRMATION.value
+
+    # The persisted secret is the new one, so confirmation must use it.
+    code = TOTPService.generate_totp(second.secret)[0]
+    assert service.confirm_setup(uid, code) is True
+    assert service.get_status(uid) == TOTPStatus.ENABLED.value
+
+
+@pytest.mark.django_db
+def test_setup_totp_still_blocks_enabled_device():
+    """Once confirmed/enabled, setup_totp() raises — the 409 path is preserved."""
+    service = _service()
+    user = _make_user()
+    uid = str(user.pk)
+
+    result = service.setup_totp(user_id=uid, account_name="totp_user@example.com")
+    service.confirm_setup(uid, TOTPService.generate_totp(result.secret)[0])
+
+    with pytest.raises(TOTPAlreadyEnabledError):
+        service.setup_totp(user_id=uid, account_name="totp_user@example.com")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "blockauth"
-version = "0.16.8"
+version = "0.16.9"
 description = "Comprehensive Python authentication package bridging Web2 and Web3"
 authors = [{name = "BloclabsHQ", email = "eng@bloclabs.com"}]
 license = {text = "MIT"}

--- a/uv.lock
+++ b/uv.lock
@@ -312,7 +312,7 @@ wheels = [
 
 [[package]]
 name = "blockauth"
-version = "0.16.7"
+version = "0.16.9"
 source = { editable = "." }
 dependencies = [
     { name = "argon2-cffi" },


### PR DESCRIPTION
## Summary

- `DjangoTOTP2FAStore.create()` rejected any existing row that wasn't `DISABLED`, so an enrollment left in `PENDING_CONFIRMATION` (setup started, never confirmed) made every later `setup_totp()` raise `TOTPAlreadyEnabledError` (HTTP 409) — a dead-end with no library-level recovery.
- Now the conflict is reserved for genuinely `ENABLED` devices; a disabled or unconfirmed row is replaced so setup regenerates a fresh secret and backup codes. The existing row is locked with `select_for_update()` inside the current transaction so a concurrent confirm can't wipe a just-enabled device.
- Adds DB-backed coverage for `DjangoTOTP2FAStore` (previously untested) in `blockauth/totp/tests/test_django_storage.py`: ENABLED still 409s, DISABLED/PENDING are replaced, and the end-to-end `setup_totp()` resume + still-blocks-enabled paths.
- Releases **0.16.9** and restores `blockauth.__version__` to match `pyproject.toml` (it had lagged at 0.16.7 through the 0.16.8 release, which failed publish tag-validation).

## Breaking Changes

- [ ] This PR contains breaking changes

## Test plan

- [x] `uv run pytest` passes (800 passed)
- [x] `uv run black --check blockauth` clean on changed files; `isort --check-only` clean
- [x] Version bumped in `pyproject.toml` + `blockauth/__init__.py` (0.16.9)
- [x] `CHANGELOG.md` updated