### PR TITLE
Collapse TOTP throttling to one layer and unify the 429 envelope

### DIFF
--- a/blockauth/conf.py
+++ b/blockauth/conf.py
@@ -24,6 +24,10 @@ DEFAULTS = {
         3,
         30,
     ),  # (number of request, duration in second) rate limits based on per (email, subject, and IP address)
+    # Number of trusted reverse proxies in front of the app. Controls how the
+    # client IP is read from X-Forwarded-For (counted from the right). Set to 0
+    # when the app is directly internet-facing, or to the trusted hop count.
+    "TRUSTED_PROXY_DEPTH": 1,
     # Email verification settings
     "EMAIL_VERIFICATION_REQUIRED": False,  # Whether users must verify email before accessing non-auth endpoints
     # Feature flags - Enable/disable specific authentication features

--- a/blockauth/totp/docs/totp_docs.py
+++ b/blockauth/totp/docs/totp_docs.py
@@ -167,7 +167,7 @@ totp_setup_docs = {
                 OpenApiExample(
                     "Rate Limited",
                     value={
-                        "error": "rate_limit_exceeded",
+                        "error": "throttled",
                         "message": "Too many setup attempts. Please try again later.",
                     },
                     status_codes=[429],
@@ -276,7 +276,7 @@ totp_confirm_docs = {
                 OpenApiExample(
                     "Rate Limited",
                     value={
-                        "error": "rate_limit_exceeded",
+                        "error": "throttled",
                         "message": "Too many confirmation attempts. Please try again later.",
                     },
                     status_codes=[429],
@@ -466,7 +466,7 @@ totp_verify_docs = {
                 OpenApiExample(
                     "Rate Limited",
                     value={
-                        "error": "rate_limit_exceeded",
+                        "error": "throttled",
                         "message": "Too many verification attempts. Please try again later.",
                     },
                     status_codes=[429],
@@ -582,7 +582,7 @@ totp_status_docs = {
             examples=[
                 OpenApiExample(
                     "Rate Limited",
-                    value={"error": "rate_limit_exceeded", "message": "Too many requests. Please try again later."},
+                    value={"error": "throttled", "message": "Too many requests. Please try again later."},
                     status_codes=[429],
                 )
             ],
@@ -687,7 +687,7 @@ totp_disable_docs = {
                 OpenApiExample(
                     "Rate Limited",
                     value={
-                        "error": "rate_limit_exceeded",
+                        "error": "throttled",
                         "message": "Too many disable attempts. Please try again later.",
                     },
                     status_codes=[429],
@@ -820,7 +820,7 @@ totp_regenerate_backup_codes_docs = {
                 OpenApiExample(
                     "Rate Limited",
                     value={
-                        "error": "rate_limit_exceeded",
+                        "error": "throttled",
                         "message": "Too many regeneration attempts. Please try again later.",
                     },
                     status_codes=[429],

--- a/blockauth/totp/tests/test_security.py
+++ b/blockauth/totp/tests/test_security.py
@@ -110,11 +110,12 @@ class TestGetClientIP(unittest.TestCase):
         result = get_client_ip(request)
         self.assertEqual(result, "203.0.113.1")
 
-    def test_handles_multiple_forwarded_ips(self):
-        """Should extract first IP from X-Forwarded-For chain."""
+    def test_counts_forwarded_ips_from_the_right(self):
+        """Should count from the right (trusted-proxy depth), not trust the
+        client-supplied leftmost value. Default depth=1 -> rightmost entry."""
         request = self._make_request(x_forwarded_for="203.0.113.1, 198.51.100.1, 192.0.2.1")
         result = get_client_ip(request)
-        self.assertEqual(result, "203.0.113.1")
+        self.assertEqual(result, "192.0.2.1")
 
     def test_validates_forwarded_ip(self):
         """Should validate X-Forwarded-For IP."""
@@ -135,6 +136,34 @@ class TestGetClientIP(unittest.TestCase):
         # Should not raise, should return a valid IP or empty
         result = get_client_ip(request)
         self.assertIsInstance(result, str)
+
+    def test_spoofed_leftmost_is_ignored(self):
+        """A client prepending a forged IP cannot control the result; the
+        rightmost (trusted-proxy-appended) entry wins at default depth=1."""
+        request = self._make_request(remote_addr="10.0.0.1", x_forwarded_for="6.6.6.6, 192.0.2.10")
+        result = get_client_ip(request)
+        self.assertEqual(result, "192.0.2.10")
+
+    @patch("blockauth.utils.rate_limiter._get_trusted_proxy_depth", return_value=0)
+    def test_depth_zero_ignores_forwarded_header(self, _mock_depth):
+        """With no trusted proxies, X-Forwarded-For is ignored entirely."""
+        request = self._make_request(remote_addr="10.0.0.1", x_forwarded_for="6.6.6.6")
+        result = get_client_ip(request)
+        self.assertEqual(result, "10.0.0.1")
+
+    @patch("blockauth.utils.rate_limiter._get_trusted_proxy_depth", return_value=2)
+    def test_depth_two_counts_two_from_the_right(self, _mock_depth):
+        """With two trusted proxies, the client is the entry two in from the right."""
+        request = self._make_request(x_forwarded_for="203.0.113.5, 198.51.100.2, 192.0.2.20")
+        result = get_client_ip(request)
+        self.assertEqual(result, "198.51.100.2")
+
+    @patch("blockauth.utils.rate_limiter._get_trusted_proxy_depth", return_value=2)
+    def test_chain_shorter_than_depth_falls_back_to_remote_addr(self, _mock_depth):
+        """A chain shorter than the trusted depth is not trusted."""
+        request = self._make_request(remote_addr="10.0.0.9", x_forwarded_for="192.0.2.30")
+        result = get_client_ip(request)
+        self.assertEqual(result, "10.0.0.9")
 
 
 # =============================================================================

--- a/blockauth/totp/tests/test_views.py
+++ b/blockauth/totp/tests/test_views.py
@@ -56,40 +56,46 @@ class TestTOTPThrottles(unittest.TestCase):
     """Test rate limiting configurations."""
 
     def test_setup_throttle_configuration(self):
-        """Setup should have 3/hour rate limit."""
+        """Setup should have 10/hour rate limit (relaxed: minting is low-risk)."""
         throttle = TOTPThrottles.SETUP
-        self.assertEqual(throttle.num_requests, 3)
+        self.assertEqual(throttle.num_requests, 10)
         self.assertEqual(throttle.duration, 3600)  # 1 hour
+        self.assertEqual(throttle.daily_limit, 30)
 
     def test_verify_throttle_configuration(self):
-        """Verify should have 5/minute rate limit."""
+        """Verify should have 5/minute rate limit and fail closed."""
         throttle = TOTPThrottles.VERIFY
         self.assertEqual(throttle.num_requests, 5)
         self.assertEqual(throttle.duration, 60)
+        self.assertTrue(throttle.fail_closed)
 
     def test_confirm_throttle_configuration(self):
-        """Confirm should have 5/minute rate limit."""
+        """Confirm should have 5/minute rate limit and fail closed."""
         throttle = TOTPThrottles.CONFIRM
         self.assertEqual(throttle.num_requests, 5)
         self.assertEqual(throttle.duration, 60)
+        self.assertTrue(throttle.fail_closed)
 
     def test_disable_throttle_configuration(self):
-        """Disable should have 3/hour rate limit."""
+        """Disable should have 3/hour rate limit and fail closed."""
         throttle = TOTPThrottles.DISABLE
         self.assertEqual(throttle.num_requests, 3)
         self.assertEqual(throttle.duration, 3600)
+        self.assertTrue(throttle.fail_closed)
 
     def test_regenerate_backup_throttle_configuration(self):
-        """Regenerate backup codes should have 3/hour rate limit."""
+        """Regenerate backup codes should have 3/hour rate limit and fail closed."""
         throttle = TOTPThrottles.REGENERATE_BACKUP
         self.assertEqual(throttle.num_requests, 3)
         self.assertEqual(throttle.duration, 3600)
+        self.assertTrue(throttle.fail_closed)
 
     def test_status_throttle_configuration(self):
-        """Status should have 30/minute rate limit."""
+        """Status should have 30/minute rate limit and fail open (read-only)."""
         throttle = TOTPThrottles.STATUS
         self.assertEqual(throttle.num_requests, 30)
         self.assertEqual(throttle.duration, 60)
+        self.assertFalse(throttle.fail_closed)
 
 
 class TestRateLimitingBehavior(unittest.TestCase):
@@ -146,7 +152,24 @@ class TestRateLimitingBehavior(unittest.TestCase):
         response = view(request)
 
         self.assertIn("error", response.data)
-        self.assertEqual(response.data["error"], "rate_limit_exceeded")
+        self.assertEqual(response.data["error"], "throttled")
+
+    @patch("blockauth.totp.views.TOTPThrottles")
+    def test_verify_throttle_uses_unified_envelope(self, mock_throttles):
+        """The in-method throttle path must emit the same {error: throttled}/429
+        envelope as every other throttled path."""
+        mock_throttle = MagicMock()
+        mock_throttle.allow_request.return_value = False
+        mock_throttles.VERIFY = mock_throttle
+
+        request = self.factory.post("/totp/verify/", {"code": "123456"})
+        force_authenticate(request, user=self.user)
+        request.META["REMOTE_ADDR"] = "127.0.0.1"
+
+        response = TOTPVerifyView.as_view()(request)
+
+        self.assertEqual(response.status_code, status.HTTP_429_TOO_MANY_REQUESTS)
+        self.assertEqual(response.data["error"], "throttled")
 
 
 class TestViewAuthentication(unittest.TestCase):

--- a/blockauth/totp/views.py
+++ b/blockauth/totp/views.py
@@ -3,16 +3,14 @@ TOTP 2FA API Views
 
 DRF views for TOTP 2FA operations.
 
-Security: All endpoints implement rate limiting per the public security standards
-- Django @ratelimit decorators for primary rate limiting
-- EnhancedThrottle for additional controls (daily limits, failure tracking, cooldowns)
+Security: All endpoints are throttled by a single in-method EnhancedThrottle
+layer (per-minute rate, daily caps, failure cooldowns). Every throttled path
+returns the unified envelope {"error": "throttled"} with HTTP 429.
 """
 
 import logging
 from typing import Any, Optional
 
-from django.utils.decorators import method_decorator
-from django_ratelimit.decorators import ratelimit
 from drf_spectacular.utils import extend_schema
 from rest_framework import status
 from rest_framework.permissions import IsAuthenticated
@@ -82,25 +80,33 @@ class TOTPThrottles:
     """
     Centralized TOTP throttle configurations.
 
-    Security Standards Compliance:
-    - Setup: 3/hour (sensitive operation, creates secrets)
-    - Confirm: 5/minute (verification during setup)
-    - Verify: 5/minute (login verification - critical security)
-    - Disable: 3/hour (sensitive security operation)
-    - Regenerate backup: 3/hour (sensitive operation)
-    - Status: 30/minute (read-only, less restrictive)
+    Throttle policy:
+    - Setup: 10/hour. Minting a TOTP secret for one's own authenticated
+      account is low-risk; the brute-force surface is confirm, not setup.
+      A failure cooldown is kept as a safety net.
+    - Confirm: 5/minute, 5 failures -> 15-min cooldown (verification surface).
+    - Verify: 5/minute, 5 failures -> 15-min cooldown (login 2FA - critical).
+    - Disable: 3/hour (sensitive security operation).
+    - Regenerate backup: 3/hour (sensitive operation).
+    - Status: 30/minute (read-only, less restrictive).
+
+    fail_closed=True on the brute-force-critical subjects (confirm, verify,
+    disable, regenerate) so a degraded cache backend denies rather than
+    silently allowing every request.
     """
 
-    # Setup: 3/hour, max 5 failures triggers 30-min cooldown
-    SETUP = EnhancedThrottle(rate=(3, 3600), daily_limit=10, max_failures=5, cooldown_minutes=30)
+    # Setup: 10/hour, max 5 failures triggers 30-min cooldown
+    SETUP = EnhancedThrottle(rate=(10, 3600), daily_limit=30, max_failures=5, cooldown_minutes=30)
     # Confirm: 5/minute during setup flow
-    CONFIRM = EnhancedThrottle(rate=(5, 60), max_failures=5, cooldown_minutes=15)
+    CONFIRM = EnhancedThrottle(rate=(5, 60), max_failures=5, cooldown_minutes=15, fail_closed=True)
     # Verify: 5/minute - CRITICAL for login security
-    VERIFY = EnhancedThrottle(rate=(5, 60), max_failures=5, cooldown_minutes=15)
+    VERIFY = EnhancedThrottle(rate=(5, 60), max_failures=5, cooldown_minutes=15, fail_closed=True)
     # Disable: 3/hour (sensitive operation)
-    DISABLE = EnhancedThrottle(rate=(3, 3600), max_failures=3, cooldown_minutes=30)
+    DISABLE = EnhancedThrottle(rate=(3, 3600), max_failures=3, cooldown_minutes=30, fail_closed=True)
     # Regenerate backup codes: 3/hour
-    REGENERATE_BACKUP = EnhancedThrottle(rate=(3, 3600), daily_limit=5, max_failures=3, cooldown_minutes=30)
+    REGENERATE_BACKUP = EnhancedThrottle(
+        rate=(3, 3600), daily_limit=5, max_failures=3, cooldown_minutes=30, fail_closed=True
+    )
     # Status: 30/minute (read-only)
     STATUS = EnhancedThrottle(rate=(30, 60))
 
@@ -135,7 +141,6 @@ def get_totp_service(encryption_service: Optional[Any] = None) -> TOTPService:
     return TOTPService(store=store, config=config, encryption_service=encryption_service)
 
 
-@method_decorator(ratelimit(key="user", rate="3/h", method="POST", block=True), name="post")
 class TOTPSetupView(APIView):
     """
     Set up TOTP 2FA for the current user.
@@ -149,7 +154,8 @@ class TOTPSetupView(APIView):
 
     User must confirm setup with a valid TOTP code.
 
-    Rate Limit: 3/hour (sensitive operation - per the public security standards mfa_setup)
+    Rate Limit: 10/hour (low-risk self-service operation; the brute-force
+    surface is confirm, not setup)
     """
 
     permission_classes = [IsAuthenticated]
@@ -164,7 +170,7 @@ class TOTPSetupView(APIView):
                 "TOTP setup rate limit exceeded for user %s", request.user.id, extra={"user_id": str(request.user.id)}
             )
             return Response(
-                {"error": "rate_limit_exceeded", "message": "Too many setup attempts. Please try again later."},
+                {"error": "throttled", "message": "Too many setup attempts. Please try again later."},
                 status=status.HTTP_429_TOO_MANY_REQUESTS,
             )
 
@@ -205,7 +211,6 @@ class TOTPSetupView(APIView):
             return Response(TOTPErrorSerializer(e.to_dict()).data, status=status.HTTP_400_BAD_REQUEST)
 
 
-@method_decorator(ratelimit(key="user", rate="5/m", method="POST", block=True), name="post")
 class TOTPConfirmView(APIView):
     """
     Confirm TOTP setup with a valid code.
@@ -231,7 +236,7 @@ class TOTPConfirmView(APIView):
                 "TOTP confirm rate limit exceeded for user %s", request.user.id, extra={"user_id": str(request.user.id)}
             )
             return Response(
-                {"error": "rate_limit_exceeded", "message": "Too many confirmation attempts. Please try again later."},
+                {"error": "throttled", "message": "Too many confirmation attempts. Please try again later."},
                 status=status.HTTP_429_TOO_MANY_REQUESTS,
             )
 
@@ -261,7 +266,6 @@ class TOTPConfirmView(APIView):
             return Response(TOTPErrorSerializer(e.to_dict()).data, status=status.HTTP_400_BAD_REQUEST)
 
 
-@method_decorator(ratelimit(key="user", rate="5/m", method="POST", block=True), name="post")
 class TOTPVerifyView(APIView):
     """
     Verify a TOTP code or backup code.
@@ -291,7 +295,7 @@ class TOTPVerifyView(APIView):
                 extra={"user_id": str(request.user.id), "ip": get_client_ip(request)},
             )
             return Response(
-                {"error": "rate_limit_exceeded", "message": "Too many verification attempts. Please try again later."},
+                {"error": "throttled", "message": "Too many verification attempts. Please try again later."},
                 status=status.HTTP_429_TOO_MANY_REQUESTS,
             )
 
@@ -339,7 +343,6 @@ class TOTPVerifyView(APIView):
             return Response(TOTPErrorSerializer(e.to_dict()).data, status=status.HTTP_400_BAD_REQUEST)
 
 
-@method_decorator(ratelimit(key="user", rate="30/m", method="GET", block=True), name="get")
 class TOTPStatusView(APIView):
     """
     Get TOTP status for the current user.
@@ -363,7 +366,7 @@ class TOTPStatusView(APIView):
         throttle = TOTPThrottles.STATUS
         if not throttle.allow_request(request, TOTPSubject.STATUS):
             return Response(
-                {"error": "rate_limit_exceeded", "message": "Too many requests. Please try again later."},
+                {"error": "throttled", "message": "Too many requests. Please try again later."},
                 status=status.HTTP_429_TOO_MANY_REQUESTS,
             )
 
@@ -396,7 +399,6 @@ class TOTPStatusView(APIView):
         )
 
 
-@method_decorator(ratelimit(key="user", rate="3/h", method="POST", block=True), name="post")
 class TOTPDisableView(APIView):
     """
     Disable TOTP 2FA for the current user.
@@ -422,7 +424,7 @@ class TOTPDisableView(APIView):
                 "TOTP disable rate limit exceeded for user %s", request.user.id, extra={"user_id": str(request.user.id)}
             )
             return Response(
-                {"error": "rate_limit_exceeded", "message": "Too many disable attempts. Please try again later."},
+                {"error": "throttled", "message": "Too many disable attempts. Please try again later."},
                 status=status.HTTP_429_TOO_MANY_REQUESTS,
             )
 
@@ -466,7 +468,6 @@ class TOTPDisableView(APIView):
         return Response({"message": "TOTP 2FA disabled successfully"})
 
 
-@method_decorator(ratelimit(key="user", rate="3/h", method="POST", block=True), name="post")
 class TOTPRegenerateBackupCodesView(APIView):
     """
     Regenerate backup codes.
@@ -495,7 +496,7 @@ class TOTPRegenerateBackupCodesView(APIView):
                 extra={"user_id": str(request.user.id)},
             )
             return Response(
-                {"error": "rate_limit_exceeded", "message": "Too many regeneration attempts. Please try again later."},
+                {"error": "throttled", "message": "Too many regeneration attempts. Please try again later."},
                 status=status.HTTP_429_TOO_MANY_REQUESTS,
             )
 

--- a/blockauth/utils/rate_limiter.py
+++ b/blockauth/utils/rate_limiter.py
@@ -1,5 +1,7 @@
 import ipaddress
+import os
 import time
+import uuid
 from typing import Optional
 
 from django.core.cache import cache as default_cache
@@ -11,6 +13,11 @@ from blockauth.utils.logger import blockauth_logger
 
 # Maximum length for IP-related header values (security limit)
 MAX_IP_HEADER_LENGTH = 500
+
+# Per-process token used by the cache-liveness probe. A fixed token per process
+# means concurrent probes within the same worker write the same value, so a
+# successful read-back is never a false negative under load.
+_HEALTHCHECK_TOKEN = uuid.uuid4().hex
 
 
 def validate_ip_address(ip_string: str) -> Optional[str]:
@@ -57,12 +64,30 @@ def validate_ip_address(ip_string: str) -> Optional[str]:
         return None
 
 
+def _get_trusted_proxy_depth() -> int:
+    """Number of trusted reverse proxies in front of the application.
+
+    Drives how X-Forwarded-For is interpreted in get_client_ip(). Defaults to
+    1 (one trusted edge proxy). Set TRUSTED_PROXY_DEPTH to 0 for deployments
+    where the application is directly internet-facing (no proxy), or to the
+    number of trusted hops for multi-proxy topologies.
+    """
+    try:
+        return max(0, int(get_config("TRUSTED_PROXY_DEPTH")))
+    except (AttributeError, TypeError, ValueError):
+        return 1
+
+
 def get_client_ip(request) -> str:
     """
-    Extract and validate client IP from request, handling proxies.
+    Extract and validate the client IP from the request.
 
-    Security: Validates IP address format to prevent header injection attacks.
-    Falls back to REMOTE_ADDR if X-Forwarded-For is invalid or missing.
+    Security: X-Forwarded-For is appended to by each proxy, so the rightmost
+    entries are written by infrastructure we control and the leftmost entries
+    are client-supplied and forgeable. We therefore count from the RIGHT using
+    the configured trusted-proxy depth instead of trusting the leftmost value.
+    The IP format is validated to prevent header injection. Falls back to
+    REMOTE_ADDR (the immediate peer) when X-Forwarded-For cannot be trusted.
 
     Args:
         request: Django/DRF request object
@@ -70,32 +95,45 @@ def get_client_ip(request) -> str:
     Returns:
         Validated IP address string, or empty string if none found
     """
-    # Try X-Forwarded-For first (for proxied requests)
-    x_forwarded_for = request.META.get("HTTP_X_FORWARDED_FOR", "")
+    depth = _get_trusted_proxy_depth()
+    remote_addr = request.META.get("REMOTE_ADDR", "")
 
-    if x_forwarded_for:
-        # Security: Limit header length to prevent DoS
-        if len(x_forwarded_for) > MAX_IP_HEADER_LENGTH:
-            blockauth_logger.warning(
-                "X-Forwarded-For header exceeds maximum length", sanitize_log_context({"length": len(x_forwarded_for)})
-            )
-            x_forwarded_for = x_forwarded_for[:MAX_IP_HEADER_LENGTH]
+    if depth > 0:
+        x_forwarded_for = request.META.get("HTTP_X_FORWARDED_FOR", "")
 
-        # X-Forwarded-For format: "client, proxy1, proxy2, ..."
-        # The first IP is the original client
-        first_ip = x_forwarded_for.split(",")[0].strip()
-        validated_ip = validate_ip_address(first_ip)
+        if x_forwarded_for:
+            # Security: Limit header length to prevent DoS
+            if len(x_forwarded_for) > MAX_IP_HEADER_LENGTH:
+                blockauth_logger.warning(
+                    "X-Forwarded-For header exceeds maximum length",
+                    sanitize_log_context({"length": len(x_forwarded_for)}),
+                )
+                x_forwarded_for = x_forwarded_for[:MAX_IP_HEADER_LENGTH]
 
-        if validated_ip:
-            return validated_ip
+            # "client, proxy1, proxy2" — trust the rightmost `depth` hops and
+            # treat the next value in from the right as the real client.
+            parts = [p.strip() for p in x_forwarded_for.split(",") if p.strip()]
 
-        # Log invalid X-Forwarded-For for security monitoring
-        blockauth_logger.warning(
-            "Invalid IP in X-Forwarded-For header", sanitize_log_context({"raw_value": first_ip[:50]})
-        )
+            if len(parts) >= depth:
+                candidate = parts[-depth]
+                validated_ip = validate_ip_address(candidate)
+                if validated_ip:
+                    return validated_ip
+
+                blockauth_logger.warning(
+                    "Invalid IP at trusted X-Forwarded-For position",
+                    sanitize_log_context({"raw_value": candidate[:50]}),
+                )
+            else:
+                # Fewer forwarded hops than trusted depth — the chain is shorter
+                # than expected (possible spoof or misconfiguration). Do not
+                # trust it; fall back to the immediate peer.
+                blockauth_logger.warning(
+                    "X-Forwarded-For shorter than trusted proxy depth",
+                    sanitize_log_context({"entries": len(parts), "trusted_depth": depth}),
+                )
 
     # Fall back to REMOTE_ADDR
-    remote_addr = request.META.get("REMOTE_ADDR", "")
     validated_remote = validate_ip_address(remote_addr)
 
     if validated_remote:
@@ -219,10 +257,16 @@ class EnhancedThrottle(BaseThrottle):
     Enhanced throttle with daily limits, cooldowns, and failure tracking.
 
     Features:
-    - Per-minute rate limiting (IP + user/identifier)
+    - Per-minute rate limiting
     - Daily limits
     - Cooldown after repeated failures
-    - Separate IP and user tracking
+    - Fail-closed on cache unavailability for brute-force-critical subjects
+
+    Bucket keying: all counters (rate, failures, cooldown, daily) are keyed on
+    the authenticated principal when one is present, falling back to the client
+    IP only for unauthenticated flows. A client-controlled IP / X-Forwarded-For
+    therefore cannot be varied to mint a fresh bucket and reset the lockout for
+    an authenticated user.
     """
 
     cache = default_cache
@@ -234,6 +278,7 @@ class EnhancedThrottle(BaseThrottle):
         daily_limit: int = None,
         max_failures: int = 5,
         cooldown_minutes: int = 15,
+        fail_closed: bool = False,
     ):
         """
         Args:
@@ -241,6 +286,9 @@ class EnhancedThrottle(BaseThrottle):
             daily_limit: Max requests per day (None = no daily limit)
             max_failures: Failures before cooldown triggers
             cooldown_minutes: Cooldown duration after max failures
+            fail_closed: When True, deny the request if the cache backend is
+                unavailable/degraded instead of failing open. Set for
+                brute-force-critical subjects (verify, confirm, disable).
         """
         if rate is None:
             rate = get_config("REQUEST_LIMIT")
@@ -248,6 +296,7 @@ class EnhancedThrottle(BaseThrottle):
         self.daily_limit = daily_limit
         self.max_failures = max_failures
         self.cooldown_minutes = cooldown_minutes
+        self.fail_closed = fail_closed
         self._block_reason = None
 
     def _get_identifier(self, request):
@@ -257,11 +306,46 @@ class EnhancedThrottle(BaseThrottle):
             identifier = str(request.user.id)
         return identifier
 
+    @staticmethod
+    def _axis(ip, identifier) -> str:
+        """Throttle bucket axis.
+
+        Prefer the authenticated principal so the bucket cannot be reset by
+        varying a client-controlled IP / X-Forwarded-For. Fall back to the IP
+        for unauthenticated flows where it is the only available signal.
+        """
+        return identifier or ip or "anon"
+
+    def _cache_alive(self) -> bool:
+        """Active liveness probe for the cache backend.
+
+        A backend configured to swallow errors (e.g. django-redis
+        IGNORE_EXCEPTIONS=True) makes every cache.get() return its empty
+        default and cache.set() a silent no-op — which would make every
+        throttle read appear unthrottled. A raising backend is caught here too.
+        Writes a per-process sentinel and reads it back to confirm the cache is
+        actually serving reads/writes.
+        """
+        key = f"throttle_healthcheck_{os.getpid()}"
+        try:
+            self.cache.set(key, _HEALTHCHECK_TOKEN, 30)
+            return self.cache.get(key) == _HEALTHCHECK_TOKEN
+        except Exception:
+            return False
+
     def allow_request(self, request, subject) -> bool:
         """Check all rate limits."""
         ip = get_client_ip(request)
         identifier = self._get_identifier(request)
         now = self.timer()
+
+        # Fail closed for brute-force-critical subjects when the cache backend
+        # is unavailable/degraded — otherwise every counter reads empty and the
+        # throttle silently allows all requests.
+        if self.fail_closed and not self._cache_alive():
+            self._block_reason = "cache_unavailable"
+            self._log_blocked(request, subject, "cache_unavailable")
+            return False
 
         # Check cooldown first
         if not self._check_cooldown(ip, identifier, subject):
@@ -285,7 +369,7 @@ class EnhancedThrottle(BaseThrottle):
 
     def _check_rate(self, ip, identifier, subject, now) -> bool:
         """Check per-minute rate limit."""
-        key = f"throttle_rate_{subject}_{ip}_{identifier or 'anon'}"
+        key = f"throttle_rate_{subject}_{self._axis(ip, identifier)}"
         history = self.cache.get(key, [])
         history = [t for t in history if now - t < self.duration]
 
@@ -298,7 +382,7 @@ class EnhancedThrottle(BaseThrottle):
 
     def _check_daily(self, ip, identifier, subject, now) -> bool:
         """Check daily limit."""
-        day_key = f"throttle_daily_{subject}_{identifier or ip}_{int(now // 86400)}"
+        day_key = f"throttle_daily_{subject}_{self._axis(ip, identifier)}_{int(now // 86400)}"
         count = self.cache.get(day_key, 0)
 
         if count >= self.daily_limit:
@@ -309,20 +393,20 @@ class EnhancedThrottle(BaseThrottle):
 
     def _check_cooldown(self, ip, identifier, subject) -> bool:
         """Check if in cooldown period."""
-        key = f"throttle_cooldown_{subject}_{ip}_{identifier or 'anon'}"
+        key = f"throttle_cooldown_{subject}_{self._axis(ip, identifier)}"
         return not self.cache.get(key, False)
 
     def record_failure(self, request, subject):
         """Record a failed attempt. Call when operation fails."""
         ip = get_client_ip(request)
         identifier = self._get_identifier(request)
-        key = f"throttle_failures_{subject}_{ip}_{identifier or 'anon'}"
+        key = f"throttle_failures_{subject}_{self._axis(ip, identifier)}"
 
         count = self.cache.get(key, 0) + 1
         self.cache.set(key, count, 3600)  # Track for 1 hour
 
         if count >= self.max_failures:
-            cooldown_key = f"throttle_cooldown_{subject}_{ip}_{identifier or 'anon'}"
+            cooldown_key = f"throttle_cooldown_{subject}_{self._axis(ip, identifier)}"
             self.cache.set(cooldown_key, True, self.cooldown_minutes * 60)
             blockauth_logger.warning(
                 f"Cooldown triggered for {subject}",
@@ -342,11 +426,11 @@ class EnhancedThrottle(BaseThrottle):
         identifier = self._get_identifier(request)
 
         # Clear failures
-        key = f"throttle_failures_{subject}_{ip}_{identifier or 'anon'}"
+        key = f"throttle_failures_{subject}_{self._axis(ip, identifier)}"
         self.cache.delete(key)
 
         # Clear cooldown
-        cooldown_key = f"throttle_cooldown_{subject}_{ip}_{identifier or 'anon'}"
+        cooldown_key = f"throttle_cooldown_{subject}_{self._axis(ip, identifier)}"
         self.cache.delete(cooldown_key)
 
     def _log_blocked(self, request, subject, reason):

--- a/blockauth/utils/tests/test_enhanced_throttle.py
+++ b/blockauth/utils/tests/test_enhanced_throttle.py
@@ -133,3 +133,109 @@ class TestDifferentIdentifiersIsolated:
         assert throttle.allow_request(req_a, subject) is False
         # user_b still free
         assert throttle.allow_request(req_b, subject) is True
+
+
+class AuthenticatedRequest:
+    """Authenticated request: identifier derives from the user, not request body."""
+
+    def __init__(self, user_id="user-123", ip="192.168.1.1"):
+        self.data = {}
+        self.META = {"REMOTE_ADDR": ip, "HTTP_X_FORWARDED_FOR": ip}
+        self.user = type("User", (), {"is_authenticated": True, "id": user_id})()
+
+
+class TestPrincipalKeyingPreventsIPReset:
+    """A client-controlled IP must not be able to reset an authenticated
+    principal's lockout (security advisory GHSA-6r23-jfg2-98q6)."""
+
+    def test_cooldown_persists_across_ips_for_same_identifier(self):
+        throttle = EnhancedThrottle(rate=(100, 60), max_failures=3, cooldown_minutes=15)
+        subject = "totp_verify"
+
+        # Three failures from one IP trips the cooldown for this identifier.
+        for ip in ("1.1.1.1", "1.1.1.1", "1.1.1.1"):
+            throttle.record_failure(FakeRequest(identifier="victim@test.com", ip=ip), subject)
+
+        # A request from a *different* IP for the same identifier stays blocked —
+        # rotating the IP does not mint a fresh bucket.
+        rotated = FakeRequest(identifier="victim@test.com", ip="9.9.9.9")
+        assert throttle.allow_request(rotated, subject) is False
+        assert throttle.get_block_reason() == "cooldown"
+
+    def test_authenticated_user_lockout_persists_across_ips(self):
+        throttle = EnhancedThrottle(rate=(100, 60), max_failures=3, cooldown_minutes=15)
+        subject = "totp_verify"
+
+        for ip in ("10.0.0.1", "10.0.0.2", "10.0.0.3"):
+            throttle.record_failure(AuthenticatedRequest(user_id="u-1", ip=ip), subject)
+
+        assert throttle.allow_request(AuthenticatedRequest(user_id="u-1", ip="203.0.113.7"), subject) is False
+
+    def test_anonymous_flow_still_keyed_on_ip(self):
+        """With no identifier, the IP remains the discriminating axis."""
+        throttle = EnhancedThrottle(rate=(100, 60), max_failures=2, cooldown_minutes=15)
+        subject = "test_anon"
+
+        anon_a = FakeRequest(identifier=None, ip="1.1.1.1")
+        anon_b = FakeRequest(identifier=None, ip="2.2.2.2")
+        throttle.record_failure(anon_a, subject)
+        throttle.record_failure(anon_a, subject)
+
+        assert throttle.allow_request(anon_a, subject) is False
+        assert throttle.allow_request(anon_b, subject) is True
+
+
+class SilentlyDegradedCache:
+    """Mimics django-redis with IGNORE_EXCEPTIONS=True: reads return the
+    default, writes are silent no-ops, nothing raises."""
+
+    def get(self, key, default=None):
+        return default
+
+    def set(self, key, value, timeout=None):
+        pass
+
+    def delete(self, key):
+        pass
+
+
+class RaisingCache:
+    """Mimics a cache backend that raises on every operation."""
+
+    def get(self, *args, **kwargs):
+        raise RuntimeError("cache down")
+
+    def set(self, *args, **kwargs):
+        raise RuntimeError("cache down")
+
+    def delete(self, *args, **kwargs):
+        raise RuntimeError("cache down")
+
+
+class TestFailClosedOnCacheOutage:
+    def test_fail_closed_denies_on_silently_degraded_cache(self):
+        throttle = EnhancedThrottle(rate=(5, 60), fail_closed=True)
+        throttle.cache = SilentlyDegradedCache()
+
+        assert throttle.allow_request(FakeRequest(), "totp_verify") is False
+        assert throttle.get_block_reason() == "cache_unavailable"
+
+    def test_fail_closed_denies_on_raising_cache(self):
+        throttle = EnhancedThrottle(rate=(5, 60), fail_closed=True)
+        throttle.cache = RaisingCache()
+
+        assert throttle.allow_request(FakeRequest(), "totp_verify") is False
+        assert throttle.get_block_reason() == "cache_unavailable"
+
+    def test_fail_open_allows_on_degraded_cache_for_non_critical(self):
+        """Non-critical subjects (fail_closed=False) keep failing open so a
+        cache blip does not break read-only endpoints."""
+        throttle = EnhancedThrottle(rate=(5, 60), fail_closed=False)
+        throttle.cache = SilentlyDegradedCache()
+
+        assert throttle.allow_request(FakeRequest(), "totp_status") is True
+
+    def test_healthy_cache_passes_probe(self):
+        throttle = EnhancedThrottle(rate=(5, 60), fail_closed=True)
+        # Uses the real LocMemCache from settings — probe should succeed.
+        assert throttle.allow_request(FakeRequest(), "totp_verify") is True

--- a/docs/security/security-standards.md
+++ b/docs/security/security-standards.md
@@ -51,6 +51,33 @@ This page summarizes the mandatory security standards for BlockAuth.
 | Password reset | 3/hour |
 | Token refresh | 10/minute |
 | KDF derivation | 10/hour |
+| TOTP setup | 10/hour |
+| TOTP confirm / verify | 5/minute, 5 failures → cooldown |
+
+### Throttle wire contract
+
+When a request is throttled, the API returns HTTP `429` with a single,
+stable body:
+
+```json
+{ "error": "throttled", "message": "..." }
+```
+
+This `error` code is a public contract — consumers should match `throttled`,
+not the response message. Note that a `429` may also be returned by the TOTP
+service-layer account lockout after repeated failed verification attempts; that
+case carries the TOTP error envelope (e.g. `{"error": "totp_too_many_attempts"}`)
+rather than the throttle envelope. Both use status `429`.
+
+### Throttle bucket keying
+
+Throttle counters (rate, failures, cooldown, daily) are keyed on the
+authenticated principal when present, falling back to the client IP only for
+unauthenticated flows. The client IP is read from `X-Forwarded-For` counted
+from the right using `TRUSTED_PROXY_DEPTH` (default `1`); set it to `0` when the
+app is directly internet-facing, or to the number of trusted proxy hops. For
+brute-force-critical subjects the throttle fails **closed** if the cache backend
+is unavailable.
 
 ## Input Validation
 


### PR DESCRIPTION
## What

Collapses TOTP throttling to a single in-method layer, unifies the 429 response envelope, realigns the setup vs confirm policy, and hardens throttle keying and cache behavior.

Refs #176.

## Changes

- **Collapse the dual throttle layers.** Remove the redundant `@ratelimit` decorators from all six TOTP views and rely on the in-method `EnhancedThrottle`, which already runs first in every handler (before any serializer/service work). The decorators duplicated the in-method rate and were the only path requiring each consumer to install its own `Ratelimited` exception handler.
- **Unify the envelope.** Every throttled path now returns `{"error": "throttled"}` with HTTP `429`. The in-method path previously returned `rate_limit_exceeded`. OpenAPI examples and the security-standards doc are updated; the service-layer lockout 429 (`totp_too_many_attempts`) is documented as a distinct, also-429 case.
- **Realign policy.** Setup raised `3/h → 10/h` (daily `10 → 30`). Minting a TOTP secret for one's own authenticated account is low-risk; the brute-force surface is confirm, which keeps `5/min` + a failure cooldown.
- **Harden keying (defense-in-depth).** Rate/failure/cooldown buckets are keyed on the authenticated principal, falling back to the client IP only for unauthenticated flows, so a client-controlled `X-Forwarded-For` cannot mint a fresh bucket for an authenticated user. The client IP is read from `X-Forwarded-For` counted from the **right** via a new `TRUSTED_PROXY_DEPTH` setting (default `1`) instead of the forgeable leftmost value.
- **Fail closed on cache outage.** For brute-force-critical subjects (confirm, verify, disable, regenerate) the throttle denies when the cache backend is unavailable/degraded, detected via an active liveness probe (covers the silent `IGNORE_EXCEPTIONS=True` case, not just raising backends). Read-only/benign subjects (setup, status) still fail open.

## Breaking change

Throttle responses now use error code `throttled` instead of `rate_limit_exceeded`. Consumers matching the old code must update. Will be called out in the release notes for the next tag.

## Validation

Full local suite: **812 passed** (sqlite + locmem, no dev-stack needed). New coverage:
- setup 10/h config + 429 envelope; verify path returns the unified `throttled` envelope
- principal-keyed lockout persists across rotated IPs (authenticated + identifier flows); anonymous flow still keyed on IP
- fail-closed denies on silently-degraded and raising caches; fails open for non-critical subjects; healthy cache passes the probe
- `get_client_ip` counts from the right, ignores spoofed leftmost, honors depth 0/2, falls back when the chain is shorter than the trusted depth

Note: this repo has no pull-request test workflow (`docs.yml` runs on push-to-main, `publish.yml` on tags), so the local run above is the validation of record.
