### PR TITLE
chore(release): v0.17.0

### DIFF
--- a/blockauth/__init__.py
+++ b/blockauth/__init__.py
@@ -28,7 +28,7 @@ Static utilities (no storage needed):
     backup_codes = TOTPService.generate_backup_codes()
 """
 
-__version__ = "0.16.10"
+__version__ = "0.17.0"
 
 # =============================================================================
 # Direct imports (Django-independent, no AppRegistryNotReady errors)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "blockauth"
-version = "0.16.10"
+version = "0.17.0"
 description = "Comprehensive Python authentication package bridging Web2 and Web3"
 authors = [{name = "BloclabsHQ", email = "eng@bloclabs.com"}]
 license = {text = "MIT"}


### PR DESCRIPTION
Version bump for release. Tag `v0.17.0` will be pushed after merge (publish.yml validates tag == pyproject == __version__).

Includes:
- #179 — redact passwords in change/reset success logs + redact sensitive keys passed via `additional_context`
- #181 — raise password minimum length 8 → 12 (consistency with the shell form; stricter policy)

Downstream: fabric-auth pin bumps from `v0.16.10` → `v0.17.0` after the tag is published.