### PR TITLE
feat(logging): recursive log-context redaction + unified marker

### DIFF
--- a/blockauth/totp/tests/test_security.py
+++ b/blockauth/totp/tests/test_security.py
@@ -11,6 +11,7 @@ Tests specifically for security features:
 import unittest
 from unittest.mock import MagicMock, patch
 
+from blockauth.constants import REDACTION_STRING
 from blockauth.utils.audit import _is_sensitive, _sanitize_value, audit_trail
 from blockauth.utils.rate_limiter import get_client_ip, validate_ip_address
 
@@ -258,9 +259,9 @@ class TestAuditTrailDecorator(unittest.TestCase):
 
         if "arguments" in logged_data:
             args = logged_data["arguments"]
-            self.assertEqual(args.get("password"), "[REDACTED]")
-            self.assertEqual(args.get("secret"), "[REDACTED]")
-            self.assertNotEqual(args.get("user_id"), "[REDACTED]")
+            self.assertEqual(args.get("password"), REDACTION_STRING)
+            self.assertEqual(args.get("secret"), REDACTION_STRING)
+            self.assertNotEqual(args.get("user_id"), REDACTION_STRING)
 
     def test_decorator_preserves_function_metadata(self):
         """Decorator should preserve function name and docstring."""

--- a/blockauth/utils/audit.py
+++ b/blockauth/utils/audit.py
@@ -8,6 +8,8 @@ from datetime import datetime
 from functools import wraps
 from typing import Any, Callable, Dict, Optional
 
+from blockauth.constants import REDACTION_STRING
+
 from .generics import sanitize_log_context
 from .logger import blockauth_logger
 
@@ -129,13 +131,13 @@ def audit_trail(
                         continue
                     if i < len(args):
                         if _is_sensitive(name):
-                            safe_args[name] = "[REDACTED]"
+                            safe_args[name] = REDACTION_STRING
                         else:
                             safe_args[name] = _sanitize_value(args[i])
 
                 for key, value in kwargs.items():
                     if _is_sensitive(key):
-                        safe_args[key] = "[REDACTED]"
+                        safe_args[key] = REDACTION_STRING
                     else:
                         safe_args[key] = _sanitize_value(value)
 
@@ -159,7 +161,7 @@ def audit_trail(
                     if isinstance(result, dict):
                         # Sanitize dict result
                         success_data["result"] = {
-                            k: "[REDACTED]" if _is_sensitive(k) else _sanitize_value(v) for k, v in result.items()
+                            k: REDACTION_STRING if _is_sensitive(k) else _sanitize_value(v) for k, v in result.items()
                         }
                     else:
                         success_data["result"] = _sanitize_value(result)

--- a/blockauth/utils/generics.py
+++ b/blockauth/utils/generics.py
@@ -1,3 +1,4 @@
+import re
 from datetime import date, datetime
 from importlib import import_module
 from typing import Any, Dict, List
@@ -7,6 +8,12 @@ from django.db import models
 
 # Import from enums module (Django-independent, no AppRegistryNotReady errors)
 from blockauth.enums import AuthenticationType
+
+# Hard ceiling on how deep the sanitizer will walk a nested structure. Logging
+# context is JSON-shaped (no cycles in practice), but a bound is cheap insurance
+# against a pathological or cyclic payload spinning forever. Anything beyond the
+# limit is redacted wholesale — fail safe, never leak.
+_MAX_REDACTION_DEPTH = 6
 
 
 def model_to_json(instance: models.Model, remove_fields: tuple = None) -> Dict[str, Any]:
@@ -35,9 +42,67 @@ def model_to_json(instance: models.Model, remove_fields: tuple = None) -> Dict[s
     return data
 
 
+def _is_sensitive_key(key: Any) -> bool:
+    """
+    Decide whether a mapping key names a sensitive value.
+
+    Two layers, both case-insensitive:
+      1. Exact membership in ``SENSITIVE_FIELDS`` — the known request-body and
+         token field names.
+      2. Regex match against ``SENSITIVE_PATTERNS`` — a defence-in-depth net for
+         keys we don't enumerate (``user_password``, ``x_api_token``, a decoded
+         JWT's ``signature``...), which matter most inside nested, unknown
+         structures. Over-redaction is the safe failure mode for a log sink.
+    """
+    from blockauth.constants import SENSITIVE_FIELDS, SENSITIVE_PATTERNS
+
+    lowered = str(key).lower()
+    if lowered in SENSITIVE_FIELDS:
+        return True
+    return any(re.fullmatch(pattern, lowered) for pattern in SENSITIVE_PATTERNS)
+
+
+def _redact(value: Any, depth: int) -> Any:
+    """
+    Recursively redact sensitive keys inside a nested structure.
+
+    A sensitive *key* redacts its entire value (subtree included) — we never
+    walk into something already known to be secret. A non-sensitive key whose
+    value is a ``dict``/``list`` is walked so secrets nested under innocuous keys
+    (e.g. ``{"profile": {"password": "..."}}``) don't slip through. Scalars pass
+    through untouched.
+    """
+    from blockauth.constants import REDACTION_STRING
+
+    if depth > _MAX_REDACTION_DEPTH:
+        # Too deep to reason about safely — redact wholesale rather than risk a leak.
+        return REDACTION_STRING
+
+    if isinstance(value, dict):
+        result = {}
+        for key, val in value.items():
+            if _is_sensitive_key(key):
+                result[key] = REDACTION_STRING
+            else:
+                result[key] = _redact(val, depth + 1)
+        return result
+
+    if isinstance(value, (list, tuple)):
+        redacted = [_redact(item, depth + 1) for item in value]
+        return type(value)(redacted) if isinstance(value, tuple) else redacted
+
+    return value
+
+
 def sanitize_log_context(data: Dict[str, Any], additional_context: Dict[str, Any] = None) -> Dict[str, Any]:
     """
     Sanitize sensitive data from logging context.
+
+    Redaction is recursive: sensitive keys are redacted at every level of a
+    nested ``dict``/``list``, not just the top, so a secret tucked under an
+    innocuous key (a decoded JWT ``payload``, a serializer error ``detail``)
+    cannot reach a log sink. A sensitive key redacts its whole value; the walker
+    descends only through non-sensitive keys.
 
     Args:
         data: Original data dictionary
@@ -46,21 +111,12 @@ def sanitize_log_context(data: Dict[str, Any], additional_context: Dict[str, Any
     Returns:
         Sanitized dictionary safe for logging
     """
-    from blockauth.constants import REDACTION_STRING, SENSITIVE_FIELDS
-
     # Merge first, then redact: additional_context can itself carry sensitive
     # keys (e.g. a decoded JWT under "payload"), so sanitizing only `data` and
     # updating afterwards would leak those values straight through.
     merged = {**data, **(additional_context or {})}
 
-    sanitized = {}
-    for key, value in merged.items():
-        if key.lower() in SENSITIVE_FIELDS:
-            sanitized[key] = REDACTION_STRING
-        else:
-            sanitized[key] = value
-
-    return sanitized
+    return _redact(merged, depth=0)
 
 
 def get_authentication_types_display(authentication_types: List[str]) -> List[str]:

--- a/blockauth/utils/tests/test_sanitize_log_context.py
+++ b/blockauth/utils/tests/test_sanitize_log_context.py
@@ -83,3 +83,91 @@ def test_additional_context_still_overrides_data_keys():
     sanitized = sanitize_log_context({"user": "from-data"}, {"user": "from-context"})
 
     assert sanitized["user"] == "from-context"
+
+
+# ---------------------------------------------------------------------------
+# Recursive redaction — secrets nested under non-sensitive keys must not leak.
+# ---------------------------------------------------------------------------
+
+
+def _flatten_values(obj):
+    """Yield every scalar value in a nested dict/list for leak assertions."""
+    out = []
+    if isinstance(obj, dict):
+        for v in obj.values():
+            out.extend(_flatten_values(v))
+    elif isinstance(obj, (list, tuple)):
+        for v in obj:
+            out.extend(_flatten_values(v))
+    else:
+        out.append(obj)
+    return out
+
+
+def test_nested_sensitive_key_under_innocuous_key_is_redacted():
+    # Regression: a sensitive key one level down (here under "profile") used to
+    # survive because redaction only looked at top-level keys.
+    sanitized = sanitize_log_context({"profile": {"email": "creator@example.test", "password": "topSecret123!"}})
+
+    assert sanitized["profile"]["email"] == "creator@example.test"
+    assert sanitized["profile"]["password"] == REDACTION_STRING
+    assert "topSecret123!" not in _flatten_values(sanitized)
+
+
+def test_deeply_nested_sensitive_value_is_redacted():
+    sanitized = sanitize_log_context({"a": {"b": {"c": {"new_password": "deepSecret!"}}}})
+
+    assert sanitized["a"]["b"]["c"]["new_password"] == REDACTION_STRING
+    assert "deepSecret!" not in _flatten_values(sanitized)
+
+
+def test_sensitive_key_redacts_whole_subtree_not_just_leaves():
+    # A sensitive key blanks its entire value — we never expose the structure or
+    # length of a secret payload by walking into it.
+    sanitized = sanitize_log_context({"payload": {"sub": "user-1", "scope": "admin"}})
+
+    assert sanitized["payload"] == REDACTION_STRING
+
+
+def test_secrets_inside_lists_of_dicts_are_redacted():
+    sanitized = sanitize_log_context({"sessions": [{"id": 1, "token": "raw-a"}, {"id": 2, "token": "raw-b"}]})
+
+    assert sanitized["sessions"][0]["id"] == 1
+    assert sanitized["sessions"][0]["token"] == REDACTION_STRING
+    assert sanitized["sessions"][1]["token"] == REDACTION_STRING
+    assert "raw-a" not in _flatten_values(sanitized)
+    assert "raw-b" not in _flatten_values(sanitized)
+
+
+def test_pattern_matched_keys_are_redacted():
+    # Keys not enumerated in SENSITIVE_FIELDS but caught by SENSITIVE_PATTERNS
+    # (defence-in-depth for unknown nested data).
+    sanitized = sanitize_log_context({"user_password": "p1", "x_api_token": "t1", "wallet_secret": "s1"})
+
+    assert sanitized["user_password"] == REDACTION_STRING
+    assert sanitized["x_api_token"] == REDACTION_STRING
+    assert sanitized["wallet_secret"] == REDACTION_STRING
+    for raw in ("p1", "t1", "s1"):
+        assert raw not in _flatten_values(sanitized)
+
+
+def test_runaway_depth_fails_safe_to_redaction():
+    # Build a structure deeper than the recursion ceiling; the over-deep tail
+    # must collapse to the redaction string rather than recurse unbounded.
+    root = inner = {}
+    for _ in range(20):
+        child = {}
+        inner["next"] = child
+        inner = child
+    inner["leaf"] = "buried"
+
+    sanitized = sanitize_log_context(root)
+
+    assert "buried" not in _flatten_values(sanitized)
+
+
+def test_scalars_and_clean_nesting_pass_through():
+    sanitized = sanitize_log_context({"count": 3, "meta": {"ok": True, "items": ["a", "b"]}})
+
+    assert sanitized["count"] == 3
+    assert sanitized["meta"] == {"ok": True, "items": ["a", "b"]}


### PR DESCRIPTION
Closes the deferred **item 5** from #179: `sanitize_log_context` only redacted top-level keys, so a secret nested under an innocuous key reached the log sink.

## What changed
- **Recursive redaction.** Walks nested `dict`/`list` structures and redacts sensitive keys at every level. A secret under `{"profile": {"password": ...}}`, inside a list of session dicts, or in a decoded-JWT error `detail` no longer leaks.
- **Sensitive key → whole subtree redacted.** The walker descends only through *non-sensitive* keys; a sensitive key blanks its entire value (preserves the existing `payload` regression test — we never expose a secret's structure or length).
- **Depth-bounded (6).** Anything deeper fails safe to `REDACTION_STRING` rather than recursing unbounded on a pathological/cyclic payload.
- **Wires up `SENSITIVE_PATTERNS`.** Previously defined but dead. Now used as defence-in-depth for keys we don't enumerate (`user_password`, `x_api_token`, …) — over-redaction is the safe failure mode for a log sink.
- **Unified the redaction marker.** `audit.py` used its own `[REDACTED]` literal while the rest of the lib uses `REDACTION_STRING` (`***REDACTED***`). The recursive sanitizer now re-redacts audit args, so the two layers had to agree — pointed `audit.py` at `REDACTION_STRING` and updated its tests.

## Tests
`blockauth/utils/tests/test_sanitize_log_context.py` grows from 6 → 13 cases (nested, deep, list-of-dicts, pattern-matched, depth-guard, clean pass-through). Full suite: **825 passed** locally. black/flake8 clean.

## Heads-up — pattern over-redaction
Enabling `SENSITIVE_PATTERNS` means broad regexes (`.*key.*`, `.*credential.*`, `.*auth.*`) now match. Side effect: log fields like `credential_id` (passkey views) and `authentication_type` get redacted even though they aren't secrets. That's an observability trade-off, not a leak — flagging it in case you'd rather scope the patterns down. Easy to tighten if so.

## Not in this PR
No version bump. This reaches the fabric-auth runtime only via a blockauth release (v0.18.0) + pin bump, which is a separate product-push step.