### PR TITLE
chore(release): v0.18.0

### DIFF
--- a/blockauth/__init__.py
+++ b/blockauth/__init__.py
@@ -28,7 +28,7 @@ Static utilities (no storage needed):
     backup_codes = TOTPService.generate_backup_codes()
 """
 
-__version__ = "0.17.0"
+__version__ = "0.18.0"
 
 # =============================================================================
 # Direct imports (Django-independent, no AppRegistryNotReady errors)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "blockauth"
-version = "0.17.0"
+version = "0.18.0"
 description = "Comprehensive Python authentication package bridging Web2 and Web3"
 authors = [{name = "BloclabsHQ", email = "eng@bloclabs.com"}]
 license = {text = "MIT"}

--- a/uv.lock
+++ b/uv.lock
@@ -312,7 +312,7 @@ wheels = [
 
 [[package]]
 name = "blockauth"
-version = "0.16.10"
+version = "0.18.0"
 source = { editable = "." }
 dependencies = [
     { name = "argon2-cffi" },


### PR DESCRIPTION
Release cut to carry the log-redaction hardening into the published library.

- **#184** — recursive log-context redaction (sensitive keys redacted at every nesting level; depth-bounded; wires up SENSITIVE_PATTERNS; unified redaction marker).
- **#185** — NON_SENSITIVE_KEYS allowlist so broad patterns stop over-redacting non-secret fields (credential_id, authentication_type); SENSITIVE_FIELDS checked first so exact-secret redaction stays authoritative.

Bumps `pyproject` + `__version__` + lock self-version 0.17.0 → 0.18.0. On merge I'll tag `v0.18.0` off dev → publish.yml validates tag==pyproject==__init__ and cuts the release; then bump fabric-auth's pin to @v0.18.0.